### PR TITLE
test: 백엔드 api요청 방법 재설계 close #70

### DIFF
--- a/backend/src/main/java/com/venueon/event/presentation/EventController.java
+++ b/backend/src/main/java/com/venueon/event/presentation/EventController.java
@@ -1,11 +1,13 @@
 package com.venueon.event.presentation;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/events")
+@RequestMapping("/events")
+@RequiredArgsConstructor
 public class EventController {
 
     @GetMapping

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/v1/:path*",
-        destination: `${backendUrl}/v1/:path*`,
+        destination: `${backendUrl}/:path*`, // ⭐ 백엔드에는 /v1 접두사가 없으므로 /:path* 로 전달
       },
       {
         source: "/images/:path*",


### PR DESCRIPTION
롬복 임포트 통해 api/ 삭제했으며
경로설정 재작성 통해 프론트~백엔드 cors 재설정 및 연결 확인 했습니다. 
"프론트주소/v1/:path"는 "백엔드주소/:path"로 전달됩니다.

<EventController.java>
import lombok.RequiredArgsConstructor;

<next.config.ts>
source: "/v1/:path*",
destination: `${backendUrl}/:path*`, // ⭐ 백엔드에는 /v1 접두사가 없으므로 /:path* 로 전달