### PR TITLE
feat: User API 회원가입/로그인 JWT 발급 (#36)

### DIFF
--- a/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
@@ -1,13 +1,16 @@
 package com.venueon.common.config;
 
+import com.venueon.user.adapter.in.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -19,13 +22,30 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .cors(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
             .authorizeHttpRequests(auth -> auth
+                // 인증 불필요 경로
+                .requestMatchers("/auth/signup", "/auth/login").permitAll()
+                // Swagger UI
+                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
+                // Actuator
+                .requestMatchers("/actuator/**").permitAll()
+                // 정적 리소스
+                .requestMatchers("/images/**", "/css/**", "/js/**", "/favicon.ico").permitAll()
+                // /auth/me — 인증 필요
+                .requestMatchers("/auth/me").authenticated()
+                // 그 외 기존 경로는 일단 허용 (점진적으로 보호 추가 예정)
                 .anyRequest().permitAll()
-            );
+            )
+            // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/venueon/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/venueon/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
 

--- a/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.venueon.common.exception;
 import com.venueon.common.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,6 +17,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("입력값이 올바르지 않습니다.");
+        log.warn("Validation Error: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(message));
     }
 
     @ExceptionHandler(org.springframework.web.servlet.resource.NoResourceFoundException.class)
@@ -32,3 +45,4 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 }
+

--- a/backend/src/main/java/com/venueon/user/adapter/in/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/security/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.venueon.user.adapter.in.security;
+
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * UserDetailsService 구현 — DB에서 사용자 조회
+ * Spring Security 인증에 사용
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        UserJpaEntity user = userJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/in/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/security/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.venueon.user.adapter.in.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 매 요청마다 JWT 추출 → 인증 설정 (OncePerRequestFilter)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getEmailFromToken(token);
+
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("JWT 인증 성공: email={}", email);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/in/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/security/JwtTokenProvider.java
@@ -1,0 +1,95 @@
+package com.venueon.user.adapter.in.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성/검증/파싱
+ * - HS256 서명
+ * - Subject = email
+ * - Claim: role
+ */
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expirationMs;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * JWT 토큰 생성
+     */
+    public String generateToken(String email, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(email)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * 토큰에서 이메일 추출
+     */
+    public String getEmailFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    /**
+     * 토큰에서 role 추출
+     */
+    public String getRoleFromToken(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    /**
+     * 토큰 유효성 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT 토큰 만료: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 토큰: {}", e.getMessage());
+        } catch (SecurityException e) {
+            log.warn("JWT 서명 검증 실패: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어 있음: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -1,0 +1,92 @@
+package com.venueon.user.adapter.in.web;
+
+import com.venueon.common.dto.ApiResponse;
+import com.venueon.user.adapter.in.web.dto.*;
+import com.venueon.user.application.port.in.GetUserInfoUseCase;
+import com.venueon.user.application.port.in.LoginUseCase;
+import com.venueon.user.application.port.in.SignUpUseCase;
+import com.venueon.user.domain.model.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * /auth/signup, /auth/login, /auth/me 엔드포인트
+ */
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final SignUpUseCase signUpUseCase;
+    private final LoginUseCase loginUseCase;
+    private final GetUserInfoUseCase getUserInfoUseCase;
+
+    /**
+     * POST /auth/signup — 회원가입
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
+        log.debug("회원가입 요청: email={}", request.email());
+
+        User user = signUpUseCase.signUp(
+                request.email(),
+                request.password(),
+                request.nickname(),
+                request.role()
+        );
+
+        UserInfoResponse response = new UserInfoResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole().name()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * POST /auth/login — 로그인 (JWT 발급)
+     */
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        log.debug("로그인 요청: email={}", request.email());
+
+        LoginUseCase.LoginResult result = loginUseCase.login(request.email(), request.password());
+
+        LoginResponse response = new LoginResponse(
+                result.token(),
+                result.email(),
+                result.nickname(),
+                result.role()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * GET /auth/me — 사용자 정보 조회 (JWT 필요)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponse> me(Authentication authentication) {
+        String email = authentication.getName();
+        log.debug("/auth/me 요청: email={}", email);
+
+        User user = getUserInfoUseCase.getUserByEmail(email);
+
+        UserInfoResponse response = new UserInfoResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole().name()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.venueon.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 로그인 요청 DTO
+ */
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginResponse.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.venueon.user.adapter.in.web.dto;
+
+/**
+ * 로그인 응답 DTO (token, email, nickname, role)
+ */
+public record LoginResponse(
+        String token,
+        String email,
+        String nickname,
+        String role
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/SignUpRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/SignUpRequest.java
@@ -1,0 +1,24 @@
+package com.venueon.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 회원가입 요청 DTO
+ */
+public record SignUpRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname,
+
+        @NotBlank(message = "역할은 필수입니다.")
+        String role
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
@@ -1,0 +1,11 @@
+package com.venueon.user.adapter.in.web.dto;
+
+/**
+ * 사용자 정보 응답 DTO
+ */
+public record UserInfoResponse(
+        Long id,
+        String email,
+        String nickname,
+        String role
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
@@ -1,0 +1,50 @@
+package com.venueon.user.adapter.out.persistence;
+
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.domain.model.User;
+import org.springframework.stereotype.Component;
+
+/**
+ * UserJpaEntity ↔ User 도메인 모델 변환
+ */
+@Component
+public class UserMapper {
+
+    /**
+     * 도메인 모델 → JPA Entity
+     */
+    public UserJpaEntity toEntity(User user) {
+        return UserJpaEntity.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .profileImg(user.getProfileImg())
+                .phone(user.getPhone())
+                .orgName(user.getOrgName())
+                .orgNumber(user.getOrgNumber())
+                .orgDescription(user.getOrgDescription())
+                .build();
+    }
+
+    /**
+     * JPA Entity → 도메인 모델
+     */
+    public User toDomain(UserJpaEntity entity) {
+        return new User(
+                entity.getId(),
+                entity.getEmail(),
+                entity.getPassword(),
+                entity.getNickname(),
+                entity.getRole(),
+                entity.getProfileImg(),
+                entity.getPhone(),
+                entity.getOrgName(),
+                entity.getOrgNumber(),
+                entity.getOrgDescription(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,39 @@
+package com.venueon.user.adapter.out.persistence;
+
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * UserRepositoryPort 구현체 — JPA 연동
+ */
+@Component
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements UserRepositoryPort {
+
+    private final UserJpaRepository userJpaRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    public User save(User user) {
+        UserJpaEntity entity = userMapper.toEntity(user);
+        UserJpaEntity saved = userJpaRepository.save(entity);
+        return userMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email)
+                .map(userMapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/GetUserInfoUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/GetUserInfoUseCase.java
@@ -1,0 +1,11 @@
+package com.venueon.user.application.port.in;
+
+import com.venueon.user.domain.model.User;
+
+/**
+ * 사용자 정보 조회 유스케이스 (Port-In)
+ */
+public interface GetUserInfoUseCase {
+
+    User getUserByEmail(String email);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/LoginUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/LoginUseCase.java
@@ -1,0 +1,14 @@
+package com.venueon.user.application.port.in;
+
+/**
+ * 로그인 유스케이스 (Port-In)
+ */
+public interface LoginUseCase {
+
+    /**
+     * 로그인 결과 DTO (Service → Controller 전달용)
+     */
+    record LoginResult(String token, String email, String nickname, String role) {}
+
+    LoginResult login(String email, String password);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/SignUpUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/SignUpUseCase.java
@@ -1,0 +1,11 @@
+package com.venueon.user.application.port.in;
+
+import com.venueon.user.domain.model.User;
+
+/**
+ * 회원가입 유스케이스 (Port-In)
+ */
+public interface SignUpUseCase {
+
+    User signUp(String email, String password, String nickname, String role);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/user/application/port/out/UserRepositoryPort.java
@@ -1,0 +1,18 @@
+package com.venueon.user.application.port.out;
+
+import com.venueon.user.domain.model.User;
+
+import java.util.Optional;
+
+/**
+ * 사용자 저장/조회 인터페이스 (Port-Out)
+ * Service는 이 포트만 의존 — JPA 직접 참조 금지
+ */
+public interface UserRepositoryPort {
+
+    User save(User user);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/venueon/user/application/service/AuthService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/AuthService.java
@@ -1,0 +1,86 @@
+package com.venueon.user.application.service;
+
+import com.venueon.common.annotation.UseCase;
+import com.venueon.common.exception.BusinessException;
+import com.venueon.common.exception.ErrorCode;
+import com.venueon.user.adapter.in.security.JwtTokenProvider;
+import com.venueon.user.application.port.in.GetUserInfoUseCase;
+import com.venueon.user.application.port.in.LoginUseCase;
+import com.venueon.user.application.port.in.SignUpUseCase;
+import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.User;
+import com.venueon.user.domain.model.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 회원가입/로그인 비즈니스 로직
+ * - BCrypt 비밀번호 암호화
+ * - 이메일 중복 체크
+ * - JWT 발급 위임
+ */
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class AuthService implements SignUpUseCase, LoginUseCase, GetUserInfoUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public User signUp(String email, String password, String nickname, String role) {
+        log.debug("회원가입 시도: email={}", email);
+
+        // 이메일 중복 체크
+        if (userRepositoryPort.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL, "이미 사용 중인 이메일입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // 역할 변환
+        UserRole userRole;
+        try {
+            userRole = UserRole.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "유효하지 않은 역할입니다: " + role);
+        }
+
+        // 도메인 모델 생성 및 저장
+        User user = new User(null, email, encodedPassword, nickname, userRole,
+                null, null, null, null, null, null, null);
+        User savedUser = userRepositoryPort.save(user);
+
+        log.info("회원가입 완료: email={}, role={}", email, userRole);
+        return savedUser;
+    }
+
+    @Override
+    public LoginResult login(String email, String password) {
+        log.debug("로그인 시도: email={}", email);
+
+        // 사용자 조회
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        // JWT 토큰 생성
+        String token = jwtTokenProvider.generateToken(user.getEmail(), user.getRole().name());
+
+        log.info("로그인 성공: email={}", email);
+        return new LoginResult(token, user.getEmail(), user.getNickname(), user.getRole().name());
+    }
+
+    @Override
+    public User getUserByEmail(String email) {
+        return userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+    }
+}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,10 +1,9 @@
 # ===== Dev Profile (Docker PostgreSQL) =====
-# Docker 환경 구성 후 아래 설정 활성화
-# spring.datasource.url=jdbc:postgresql://localhost:5432/venueon_dev
-# spring.datasource.driver-class-name=org.postgresql.Driver
-# spring.datasource.username=venueon
-# spring.datasource.password=venueon1234
-# spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.url=jdbc:postgresql://localhost:5432/venueon_dev
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=venueon
+spring.datasource.password=venueon1234
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # JPA
 spring.jpa.hibernate.ddl-auto=create-drop

--- a/docs/jwt-auth-flow.md
+++ b/docs/jwt-auth-flow.md
@@ -1,0 +1,210 @@
+# JWT 인증 흐름 완전 분석
+
+> NCafe 프로젝트의 BFF(Backend For Frontend) 패턴 기반 JWT 인증 구조를 코드 레벨에서 설명합니다.
+
+---
+
+## 🔑 로그인 흐름 (단계별 코드 추적)
+
+### 1단계 — 사용자가 로그인 폼 제출
+
+**파일:** `frontend/components/auth/LoginForm.tsx`
+
+```
+사용자가 아이디/비밀번호 입력 후 [로그인] 클릭
+```
+
+```typescript
+// LoginForm.tsx
+await authAPI.login(username, password);
+//    ↓ 이 호출은 아래로 이어집니다
+```
+
+---
+
+### 2단계 — BFF 로그인 API 호출
+
+**파일:** `frontend/app/lib/api.ts` → `frontend/app/api/auth/login/route.ts`
+
+```typescript
+// app/lib/api.ts
+login: (username, password) =>
+  fetchAPI('/auth/login', {      // → 실제 요청: POST /api/auth/login
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  })
+```
+
+이 요청은 **브라우저 → Next.js 서버**로 갑니다 (Spring Boot로 직접 가지 않습니다!).
+
+---
+
+### 3단계 — Next.js 서버가 Spring Boot에 대신 로그인 요청
+
+**파일:** `frontend/app/api/auth/login/route.ts`
+
+```
+브라우저가 POST /api/auth/login 호출
+    ↓
+[Next.js 서버] app/api/auth/login/route.ts 실행
+    ↓
+① Spring Boot POST http://localhost:8031/auth/login 호출 (서버→서버)
+    ↓
+② Spring Boot가 JWT 토큰({ token: "eyJ..." }) 반환
+    ↓
+③ Next.js가 다시 GET http://localhost:8031/auth/me 호출 (JWT를 헤더에 넣어서)
+    ↓
+④ Spring Boot가 사용자 정보({ nickname, role, ... }) 반환
+    ↓
+⑤ iron-session이 JWT + user 정보를 암호화해서 httpOnly 쿠키에 저장
+    ↓
+⑥ 브라우저에겐 { user: { nickname, role } } 만 반환 (JWT는 절대 클라이언트로 나가지 않음!)
+```
+
+> **브라우저 입장**: JWT가 뭔지 모릅니다. 그냥 `app_session`이라는 암호화된 쿠키만 받습니다.
+
+---
+
+### 4단계 — Spring Boot가 JWT를 발급하는 과정
+
+**파일:** `backend/.../AuthController.java` → `LoginService.java` → `JwtTokenProvider.java`
+
+```
+POST /auth/login { username, password }
+    ↓
+AuthController.login()
+    ↓
+LoginService.login()
+    ↓
+AuthenticationManager.authenticate()  ← 비밀번호 검증
+    ↓
+JdbcUserDetailsManager → DB SELECT: SELECT nickname, password, role FROM users WHERE nickname = ?
+    ↓
+BCrypt 비밀번호 검증 통과
+    ↓
+JwtTokenProvider.generateToken()  ← JWT 발급 (HS256, 24시간)
+    ↓
+{ token: "eyJhbGciOiJIUzI1NiJ9...", username: "admin", role: "ROLE_ADMIN" } 반환
+```
+
+---
+
+## 🔒 로그인 이후 — API 요청마다 JWT가 자동 주입되는 흐름
+
+### 예시: 어드민이 메뉴 목록을 불러올 때
+
+**파일:** `frontend/app/api/[...path]/route.ts` (Catch-all 프록시)
+
+```
+브라우저: fetch('/api/admin/menus')
+    ↓
+쿠키 자동 전송: app_session=암호화덩어리 (브라우저가 자동으로 붙임)
+    ↓
+[Next.js 서버] app/api/[...path]/route.ts 실행
+    ↓
+① getSession() → app_session 쿠키 복호화 → JWT 꺼냄
+② path = "/api/admin/menus" → backendPath = "/admin/menus"
+③ headers['Authorization'] = `Bearer eyJhbGci...`  ← JWT 주입!
+    ↓
+fetch("http://localhost:8031/admin/menus", { Authorization: Bearer JWT })
+    ↓
+[Spring Boot] JwtAuthenticationFilter 실행
+    ↓
+① Authorization 헤더에서 JWT 추출
+② JwtTokenProvider.validateToken(jwt) → 유효성 검증
+③ JwtTokenProvider.getUsernameFromToken(jwt) → "admin"
+④ JdbcUserDetailsManager.loadUserByUsername("admin") → DB 조회
+⑤ SecurityContext에 인증 정보 등록
+    ↓
+SecurityConfig: .requestMatchers("/admin/**").hasRole("ADMIN")
+→ ROLE_ADMIN이면 통과, 아니면 403
+    ↓
+AdminMenuController.getMenuList() 실행
+    ↓
+{ menus: [...] } 반환
+    ↓
+[Next.js 서버] 응답 그대로 브라우저에 전달
+    ↓
+브라우저: 메뉴 목록 화면에 표시
+```
+
+---
+
+## 🚪 페이지 접근 보호 — Middleware
+
+**파일:** `frontend/middleware.ts`
+
+```
+브라우저가 /admin/menus 페이지 접근 시도
+    ↓
+middleware.ts 실행 (모든 요청에 대해 먼저 실행됨)
+    ↓
+PROTECTED_PATHS = ['/admin'] → 보호 경로 해당
+    ↓
+쿠키에 'app_session'이 있는지 확인
+    ↓
+없으면 → /login?redirect=/admin/menus 로 리다이렉트
+있으면 → 통과 (쿠키 내용 복호화는 안 함, 존재 여부만 확인)
+```
+
+> **주의**: Middleware는 쿠키가 "존재"하는지만 확인합니다. 실제 JWT 유효성은 Spring Boot가 API 요청마다 검증합니다.
+
+---
+
+## 📊 전체 흐름 한눈에 보기
+
+```
+[브라우저]                [Next.js 서버]                 [Spring Boot]     [DB]
+    │                          │                               │              │
+    │─── POST /api/auth/login ─▶                               │              │
+    │    {username, password}  │── POST /auth/login ──────────▶│              │
+    │                          │   {username, password}        │── SELECT ───▶│
+    │                          │                               │◀─ user,pwd ──│
+    │                          │◀── {token:"eyJ..."} ──────────│              │
+    │                          │── GET /auth/me ───────────────▶│              │
+    │                          │   Authorization: Bearer JWT    │              │
+    │                          │◀── {nickname, role} ───────────│              │
+    │                          │                               │              │
+    │                          │  JWT → iron-session 암호화    │              │
+    │                          │  → app_session 쿠키 저장      │              │
+    │◀── Set-Cookie:app_session│                               │              │
+    │    {user:{nickname,role}}│                               │              │
+    │                          │                               │              │
+    │─── GET /api/admin/menus ─▶                               │              │
+    │    Cookie: app_session   │  쿠키 복호화 → JWT 추출       │              │
+    │                          │── GET /admin/menus ───────────▶│              │
+    │                          │   Authorization: Bearer JWT    │── 인증/인가 ─▶│
+    │◀── {menus:[...]} ────────│◀── {menus:[...]} ─────────────│              │
+```
+
+---
+
+## 핵심 파일 역할 정리
+
+| 역할 | 파일 경로 |
+|------|----------|
+| **로그인 폼 (UI)** | `frontend/components/auth/LoginForm.tsx` |
+| **API 유틸리티** | `frontend/app/lib/api.ts` |
+| **세션 설정 (iron-session)** | `frontend/app/lib/session.ts` |
+| **로그인 처리 Route** | `frontend/app/api/auth/login/route.ts` |
+| **로그아웃 처리 Route** | `frontend/app/api/auth/logout/route.ts` |
+| **세션 조회 Route** | `frontend/app/api/auth/session/route.ts` |
+| **JWT 자동 주입 (Catch-all 프록시)** | `frontend/app/api/[...path]/route.ts` |
+| **페이지 접근 보호** | `frontend/middleware.ts` |
+| **JWT 발급** | `backend/.../security/JwtTokenProvider.java` |
+| **JWT 요청 검증** | `backend/.../security/JwtAuthenticationFilter.java` |
+| **권한 제어** | `backend/.../config/SecurityConfig.java` |
+| **유저 DB 조회** | `backend/.../security/SecurityBeanConfig.java` |
+
+---
+
+## 보안 포인트 요약
+
+| 항목 | 내용 |
+|------|------|
+| **JWT 저장 위치** | Next.js 서버의 iron-session (httpOnly 쿠키) |
+| **브라우저의 JWT 접근** | ❌ 불가 (httpOnly 쿠키이므로 JavaScript 접근 차단) |
+| **XSS 공격에 대한 안전성** | ✅ httpOnly 쿠키는 스크립트로 탈취 불가 |
+| **CSRF 방어** | ✅ sameSite: 'lax' 설정 |
+| **JWT 만료 처리** | Spring Boot 401 응답 시 Catch-all 프록시가 세션 자동 삭제 |
+| **Secret Key 관리** | 환경변수 `JWT_SECRET`으로 관리 (application.properties에서 주입) |

--- a/docs/phase1-user-api-backend.md
+++ b/docs/phase1-user-api-backend.md
@@ -1,0 +1,270 @@
+# 🔐 Phase 1 — User API (BE): 회원가입/로그인 JWT 발급
+
+> **브랜치:** `feature/{이슈번호}-user-auth-api`  
+> **담당:** Backend  
+> **목표:** 회원가입 / 로그인 API 구현 + JWT 토큰 발급 + `/auth/me` 사용자 정보 조회
+
+---
+
+## 📋 참고 문서
+
+- [jwt-auth-flow.md](./jwt-auth-flow.md) — JWT 인증 흐름 분석
+- [GIT_WORKFLOW.md](./GIT_WORKFLOW.md) — Git 브랜치/커밋 규칙
+
+---
+
+## 🏗️ 구현 파일 목록 (헥사고날 아키텍처)
+
+### 1. Security 인프라 (JWT 관련)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 1 | `common/config/SecurityConfig.java` | 기존 파일 수정 — JWT 필터 등록, 경로별 권한 설정 |
+| 2 | `user/adapter/in/security/JwtTokenProvider.java` | JWT 토큰 생성/검증/파싱 (HS256, jjwt 라이브러리) |
+| 3 | `user/adapter/in/security/JwtAuthenticationFilter.java` | 매 요청마다 JWT 추출 → 인증 설정 (OncePerRequestFilter) |
+| 4 | `user/adapter/in/security/CustomUserDetailsService.java` | UserDetailsService 구현 — DB에서 사용자 조회 |
+
+### 2. Application Port (비즈니스 인터페이스)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 5 | `user/application/port/in/SignUpUseCase.java` | 회원가입 유스케이스 (Port-In) |
+| 6 | `user/application/port/in/LoginUseCase.java` | 로그인 유스케이스 (Port-In) |
+| 7 | `user/application/port/in/GetUserInfoUseCase.java` | 사용자 정보 조회 유스케이스 (Port-In) |
+| 8 | `user/application/port/out/UserRepositoryPort.java` | 사용자 저장/조회 인터페이스 (Port-Out) |
+
+### 3. Application Service (비즈니스 로직)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 9 | `user/application/service/AuthService.java` | 회원가입/로그인 비즈니스 로직 (@UseCase) |
+
+### 4. Adapter Out — Persistence
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 10 | `user/adapter/out/persistence/UserPersistenceAdapter.java` | UserRepositoryPort 구현체 — JPA 연동 |
+| 11 | `user/adapter/out/persistence/UserMapper.java` | UserJpaEntity ↔ User 도메인 모델 변환 |
+
+### 5. Adapter In — Presentation (Controller + DTO)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 12 | `user/adapter/in/web/dto/SignUpRequest.java` | 회원가입 요청 DTO |
+| 13 | `user/adapter/in/web/dto/LoginRequest.java` | 로그인 요청 DTO |
+| 14 | `user/adapter/in/web/dto/LoginResponse.java` | 로그인 응답 DTO (token, username, role) |
+| 15 | `user/adapter/in/web/dto/UserInfoResponse.java` | 사용자 정보 응답 DTO |
+| 16 | `user/adapter/in/web/AuthController.java` | `/auth/signup`, `/auth/login`, `/auth/me` 엔드포인트 |
+
+---
+
+## 📐 API 스펙
+
+### POST `/auth/signup` — 회원가입
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "password": "password123",
+  "nickname": "사용자",
+  "role": "USER"         // "USER" | "HOST"
+}
+
+// Response (201 Created)
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "email": "user@example.com",
+    "nickname": "사용자",
+    "role": "USER"
+  }
+}
+```
+
+### POST `/auth/login` — 로그인 (JWT 발급)
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "password": "password123"
+}
+
+// Response (200 OK)
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "email": "user@example.com",
+  "nickname": "사용자",
+  "role": "USER"
+}
+```
+
+### GET `/auth/me` — 사용자 정보 조회 (JWT 필요)
+
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9...
+```
+```json
+// Response (200 OK)
+{
+  "id": 1,
+  "email": "user@example.com",
+  "nickname": "사용자",
+  "role": "USER"
+}
+```
+
+---
+
+## 🔧 구현 순서 (커밋 단위 권장)
+
+### Step 1 — JWT 인프라 구성
+```
+커밋: feat: JWT 토큰 발급/검증 클래스 구현 (#이슈번호)
+```
+- `JwtTokenProvider.java` — `generateToken()`, `validateToken()`, `getEmailFromToken()` 구현
+- `application-dev.properties`의 `jwt.secret`, `jwt.expiration` 확인
+
+### Step 2 — Port/Service 레이어 구현
+```
+커밋: feat: User Auth Port/Service 구현 (#이슈번호)
+```
+- Port-In: `SignUpUseCase`, `LoginUseCase`, `GetUserInfoUseCase`
+- Port-Out: `UserRepositoryPort`
+- Service: `AuthService` — BCrypt 비밀번호 암호화, 이메일 중복 체크, JWT 발급 위임
+
+### Step 3 — Persistence Adapter 구현
+```
+커밋: feat: User Persistence Adapter 구현 (#이슈번호)
+```
+- `UserPersistenceAdapter` — `save()`, `findByEmail()`, `existsByEmail()` 구현
+- `UserMapper` — Entity ↔ Domain 변환
+
+### Step 4 — Controller/DTO + Security 필터 통합
+```
+커밋: feat: Auth Controller + JWT 필터 통합 (#이슈번호)
+```
+- DTO 클래스 생성
+- `AuthController` — 3개 엔드포인트
+- `JwtAuthenticationFilter` — `OncePerRequestFilter` 상속
+- `CustomUserDetailsService` — `loadUserByUsername()` 구현
+- `SecurityConfig` 수정 — JWT 필터 등록, 경로별 인가 규칙 추가
+
+---
+
+## ✅ 푸시 전 검증 체크리스트
+
+### 1단계: 컴파일 확인
+
+```bash
+cd backend
+./gradlew compileJava
+```
+- [ ] 컴파일 에러 없이 BUILD SUCCESSFUL
+
+### 2단계: 애플리케이션 기동 확인
+
+```bash
+# DB 없이 테스트할 경우 H2 임시 사용 또는 Docker DB 실행
+docker compose -f docker-compose.local.yml up db -d
+
+cd backend
+./gradlew bootRun
+```
+- [ ] 서버 정상 기동 (port 8080)
+- [ ] 콘솔에 에러 로그 없음
+
+### 3단계: Swagger UI 확인
+
+```
+http://localhost:8080/swagger-ui.html
+```
+- [ ] `/auth/signup`, `/auth/login`, `/auth/me` 엔드포인트가 표시됨
+
+### 4단계: curl/Postman으로 API 테스트
+
+```bash
+# ① 회원가입
+curl -X POST http://localhost:8080/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"test1234","nickname":"테스터","role":"USER"}'
+
+# 기대: 201 Created + 사용자 정보 반환
+
+# ② 이메일 중복 가입 시도
+curl -X POST http://localhost:8080/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"test1234","nickname":"테스터2","role":"USER"}'
+
+# 기대: 409 Conflict 또는 400 Bad Request (이메일 중복 에러)
+
+# ③ 로그인
+curl -X POST http://localhost:8080/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"test1234"}'
+
+# 기대: 200 OK + JWT 토큰 반환
+# 반환된 token 값을 복사
+
+# ④ JWT로 사용자 정보 조회
+curl -X GET http://localhost:8080/auth/me \
+  -H "Authorization: Bearer {위에서_받은_JWT_토큰}"
+
+# 기대: 200 OK + 사용자 정보(email, nickname, role) 반환
+
+# ⑤ 잘못된 JWT로 요청
+curl -X GET http://localhost:8080/auth/me \
+  -H "Authorization: Bearer invalid.jwt.token"
+
+# 기대: 401 Unauthorized
+
+# ⑥ JWT 없이 보호된 경로 요청
+curl -X GET http://localhost:8080/auth/me
+
+# 기대: 401 Unauthorized
+```
+
+### 5단계: 아키텍처 준수 확인
+
+- [ ] Domain 모델(`User.java`)에 JPA 어노테이션 없음 (기존 유지)
+- [ ] Service에서 JpaRepository 직접 참조 없음 → Port-Out만 의존
+- [ ] Controller에 비즈니스 로직 없음 → UseCase 호출만
+- [ ] `SecurityConfig`에서 `/auth/signup`, `/auth/login` → `permitAll()`
+- [ ] `SecurityConfig`에서 `/auth/me` → `authenticated()`
+
+### 6단계: 최종 확인
+
+- [ ] `./gradlew clean build` — 전체 빌드 성공
+- [ ] 불필요한 `System.out.println` 제거
+- [ ] `@Slf4j` 로거로 디버그 로그 작성
+
+---
+
+## 🔀 브랜치 작업 흐름
+
+```bash
+# 1. master에서 브랜치 생성
+git switch master
+git pull origin master
+git switch -c feature/{이슈번호}-user-auth-api
+
+# 2. 위 Step 1~4 순서로 개발 + 커밋
+
+# 3. 전체 검증 통과 후 푸시
+git push origin feature/{이슈번호}-user-auth-api
+
+# 4. GitHub에서 PR 생성
+#    제목: feat: User API 회원가입/로그인 JWT 발급 (#이슈번호)
+#    본문에 closes #이슈번호 포함
+```
+
+---
+
+## ⚠️ 주의사항
+
+- `jwt.secret`은 **최소 32자 이상** (HS256 요구사항)
+- `application-dev.properties`에 이미 `${JWT_SECRET:...}` 환경변수 설정이 있으므로 그대로 사용
+- 비밀번호는 반드시 **BCryptPasswordEncoder**로 암호화 후 저장
+- Spring Boot 4.x에서 `SecurityFilterChain` 설정 방식 확인 (DSL 기반)

--- a/docs/phase2-auth-frontend.md
+++ b/docs/phase2-auth-frontend.md
@@ -1,0 +1,338 @@
+# 🖥️ Phase 2 — 로그인/가입 페이지 (FE): UI + API 연동
+
+> **브랜치:** `feature/{이슈번호}-auth-frontend`  
+> **담당:** Frontend  
+> **선행 조건:** Phase 1 (`feature/{이슈번호}-user-auth-api`) 머지 완료  
+> **목표:** 로그인/회원가입 UI 구현 + BFF Route를 통한 백엔드 JWT 인증 연동
+
+---
+
+## 📋 참고 문서
+
+- [jwt-auth-flow.md](./jwt-auth-flow.md) — JWT 인증 흐름 (BFF 패턴)
+- [phase1-user-api-backend.md](./phase1-user-api-backend.md) — 백엔드 API 스펙
+- [GIT_WORKFLOW.md](./GIT_WORKFLOW.md) — Git 브랜치/커밋 규칙
+
+---
+
+## 🔑 핵심 아키텍처: BFF(Backend For Frontend) 인증 패턴
+
+> **브라우저는 JWT를 절대 알지 못합니다.**
+
+```
+[브라우저]  →  [Next.js BFF 서버]  →  [Spring Boot]
+           POST /api/auth/login    POST /auth/login
+           ← { user 정보 }         ← { token: JWT }
+           (JWT는 iron‑session     (JWT를 BFF에게만 줌)
+            쿠키에 암호화 저장)
+```
+
+- 프론트엔드 클라이언트 코드에서 `api.post('/auth/login', ...)` 호출
+- Next.js `/api/auth/login/route.ts` (BFF Route)가 Spring Boot로 대신 요청
+- Spring Boot가 JWT 반환 → BFF가 iron-session 쿠키에 암호화 저장
+- 브라우저에겐 사용자 정보만 반환 (JWT 노출 안 됨✅)
+
+---
+
+## 🏗️ 구현 파일 목록
+
+### 1. BFF API Route (Next.js 서버사이드)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 1 | `src/app/api/auth/signup/route.ts` | 회원가입 BFF Route — Spring Boot 대신 호출 |
+| 2 | `src/app/api/auth/login/route.ts` | 로그인 BFF Route — JWT 수신 → iron-session 저장 |
+| 3 | `src/app/api/auth/logout/route.ts` | 로그아웃 BFF Route — 세션 파기 |
+| 4 | `src/app/api/auth/session/route.ts` | 세션 조회 Route — 현재 로그인 상태 확인 |
+
+### 2. 클라이언트 컴포넌트 (UI)
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 5 | `src/app/(auth)/login/page.tsx` | 로그인 페이지 (기존 파일 수정) |
+| 6 | `src/app/(auth)/signup/page.tsx` | 회원가입 페이지 (기존 파일 수정) |
+| 7 | `src/app/(auth)/auth.module.css` | 로그인/회원가입 공용 스타일 |
+
+### 3. 인증 상태 관리
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 8 | `src/lib/auth-api.ts` | 인증 관련 API 호출 함수 (클라이언트용) |
+| 9 | `src/lib/useAuth.ts` | Zustand 인증 상태 스토어 (로그인 상태, 사용자 정보) |
+
+### 4. 미들웨어 수정
+
+| 순서 | 파일 경로 | 역할 |
+|------|-----------|------|
+| 10 | `src/middleware.ts` | 기존 파일 확인 — 보호 경로 설정 유지 |
+
+---
+
+## 📐 BFF Route 상세 스펙
+
+### POST `/api/auth/signup` — 회원가입 BFF
+
+```typescript
+// route.ts 내부 동작:
+// 1. 브라우저로부터 { email, password, nickname, role } 수신
+// 2. Spring Boot POST /auth/signup 으로 대신 요청
+// 3. 성공 시 → Spring Boot 응답을 브라우저에 그대로 전달
+// 4. 실패 시 → 에러 메시지 전달
+```
+
+### POST `/api/auth/login` — 로그인 BFF (핵심!)
+
+```typescript
+// route.ts 내부 동작:
+// 1. 브라우저로부터 { email, password } 수신
+// 2. Spring Boot POST /auth/login 으로 대신 요청
+// 3. Spring Boot가 { token, email, nickname, role } 반환
+// 4. GET /auth/me 호출 (JWT 헤더 포함) → 사용자 상세 정보 획득
+// 5. iron-session에 JWT + 사용자 정보 암호화 저장
+// 6. 브라우저에겐 { user: { nickname, email, role } } 만 반환
+
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const API_BASE = process.env.API_BASE_URL || "http://backend:8080";
+
+  // ① Spring Boot에 로그인 요청
+  const loginRes = await fetch(`${API_BASE}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!loginRes.ok) {
+    const error = await loginRes.json().catch(() => ({}));
+    return Response.json(error, { status: loginRes.status });
+  }
+
+  const loginData = await loginRes.json();
+  // loginData = { token: "eyJ...", email: "...", nickname: "...", role: "..." }
+
+  // ② JWT로 사용자 정보 조회
+  const meRes = await fetch(`${API_BASE}/auth/me`, {
+    headers: { Authorization: `Bearer ${loginData.token}` },
+  });
+  const userData = meRes.ok ? await meRes.json() : loginData;
+
+  // ③ iron-session에 JWT + 사용자 정보 저장
+  const cookieStore = await cookies();
+  const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+  session.jwt = loginData.token;
+  session.email = userData.email;
+  session.nickname = userData.nickname;
+  session.role = userData.role;
+  session.userId = userData.id;
+  session.isLoggedIn = true;
+  await session.save();
+
+  // ④ 브라우저에겐 JWT 없이 사용자 정보만 반환
+  return Response.json({
+    user: {
+      email: userData.email,
+      nickname: userData.nickname,
+      role: userData.role,
+    },
+  });
+}
+```
+
+### POST `/api/auth/logout` — 로그아웃 BFF
+
+```typescript
+// route.ts 내부 동작:
+// 1. iron-session 세션 파기 (session.destroy())
+// 2. { success: true } 반환
+```
+
+### GET `/api/auth/session` — 세션 조회
+
+```typescript
+// route.ts 내부 동작:
+// 1. iron-session 복호화해서 사용자 정보 확인
+// 2. 로그인 상태면 { isLoggedIn: true, user: { ... } } 반환
+// 3. 비로그인이면 { isLoggedIn: false } 반환
+```
+
+---
+
+## 🔧 구현 순서 (커밋 단위 권장)
+
+### Step 1 — BFF API Route 구현
+```
+커밋: feat: Auth BFF Route 구현 (login/signup/logout/session) (#이슈번호)
+```
+- `/api/auth/signup/route.ts`
+- `/api/auth/login/route.ts` — JWT → iron-session 저장 (위 코드 참고)
+- `/api/auth/logout/route.ts` — 세션 파기
+- `/api/auth/session/route.ts` — 세션 조회
+
+### Step 2 — 인증 API 유틸 + Zustand 스토어
+```
+커밋: feat: 인증 API 유틸 및 상태 관리 구현 (#이슈번호)
+```
+- `src/lib/auth-api.ts` — 클라이언트에서 BFF Route를 호출하는 함수
+  ```typescript
+  export const authAPI = {
+    signup: (data) => fetch('/api/auth/signup', { method: 'POST', body: JSON.stringify(data) }),
+    login: (email, password) => fetch('/api/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
+    logout: () => fetch('/api/auth/logout', { method: 'POST' }),
+    getSession: () => fetch('/api/auth/session').then(r => r.json()),
+  };
+  ```
+- `src/lib/useAuth.ts` — Zustand 스토어
+  ```typescript
+  // 상태: user, isLoggedIn, isLoading
+  // 액션: login(), logout(), checkSession()
+  ```
+
+### Step 3 — 로그인/회원가입 UI 구현
+```
+커밋: feat: 로그인/회원가입 페이지 UI 구현 (#이슈번호)
+```
+- `src/app/(auth)/login/page.tsx` — 폼 UI + authAPI.login() 연동
+- `src/app/(auth)/signup/page.tsx` — 폼 UI + authAPI.signup() 연동 + 역할 선택(USER/HOST)
+- `src/app/(auth)/auth.module.css` — 공용 스타일
+
+### Step 4 — 네비게이션 연동
+```
+커밋: feat: 로그인 상태 기반 네비게이션 표시 (#이슈번호)
+```
+- Header/Navigation에 로그인 상태 반영
+- 로그인 시: 닉네임 표시 + 로그아웃 버튼
+- 비로그인 시: 로그인/회원가입 링크 표시
+
+---
+
+## ✅ 푸시 전 검증 체크리스트
+
+### 사전 준비
+
+```bash
+# Phase 1 머지된 master 반영
+git switch master
+git pull origin master
+git switch feature/{이슈번호}-auth-frontend
+git merge master
+
+# 백엔드 실행 (Phase 1 API 필요)
+cd backend
+./gradlew bootRun &
+
+# 프론트엔드 실행
+cd frontend
+npm install
+npm run dev
+```
+
+### 1단계: 빌드 확인
+
+```bash
+cd frontend
+npm run build
+```
+- [ ] 빌드 에러 없음
+- [ ] TypeScript 타입 에러 없음
+
+### 2단계: 페이지 접근 확인
+
+```
+http://localhost:3000/login    → 로그인 페이지 렌더링
+http://localhost:3000/signup   → 회원가입 페이지 렌더링
+```
+- [ ] 로그인 페이지가 정상 표시됨
+- [ ] 회원가입 페이지가 정상 표시됨
+- [ ] 스타일이 올바르게 적용됨
+
+### 3단계: 회원가입 테스트
+
+1. `/signup` 페이지 접속
+2. 이메일, 비밀번호, 닉네임 입력 + 역할 선택(USER)
+3. 가입 버튼 클릭
+- [ ] 성공 시 로그인 페이지로 이동 (또는 성공 메시지 표시)
+- [ ] 실패 시 에러 메시지 표시 (이메일 중복 등)
+- [ ] 빈 필드 제출 시 유효성 검증 동작
+
+### 4단계: 로그인 테스트
+
+1. `/login` 페이지 접속
+2. 가입한 이메일/비밀번호 입력
+3. 로그인 버튼 클릭
+- [ ] 성공 시 메인 페이지(`/`)로 이동
+- [ ] 브라우저 DevTools → Application → Cookies에서 `venueon_session` 쿠키 확인
+- [ ] 쿠키가 httpOnly로 설정됨 (JavaScript에서 접근 불가)
+- [ ] 네비게이션에 로그인한 사용자 정보 표시
+- [ ] 잘못된 비밀번호 입력 시 에러 메시지 표시
+
+### 5단계: 세션 유지 확인
+
+1. 로그인 상태에서 페이지 새로고침 (F5)
+- [ ] 로그인 상태 유지됨 (세션 쿠키 기반)
+2. 보호된 경로 접근 테스트
+- [ ] 로그인 상태: `/mypage` 접근 가능
+- [ ] 비로그인 상태: `/mypage` → `/login?redirect=/mypage` 리다이렉트
+
+### 6단계: 로그아웃 테스트
+
+1. 로그아웃 버튼 클릭
+- [ ] `venueon_session` 쿠키 삭제됨
+- [ ] 네비게이션이 비로그인 상태로 변경
+- [ ] 보호된 경로 접근 시 로그인 페이지로 리다이렉트
+
+### 7단계: BFF 보안 검증
+
+```bash
+# 브라우저 콘솔 (F12)에서 직접 확인:
+document.cookie
+# → venueon_session이 보이지 않아야 함 (httpOnly)
+```
+- [ ] JWT가 브라우저 JavaScript에서 접근 불가
+- [ ] 브라우저 Network 탭에서 `/api/auth/login` 응답에 JWT 토큰이 없음
+- [ ] 브라우저 Network 탭에서 API 요청 시 Authorization 헤더가 노출되지 않음
+
+### 8단계: Catch-all 프록시 JWT 주입 확인
+
+```bash
+# 로그인 상태에서 보호된 API 호출 테스트
+# 브라우저 Network 탭에서 확인:
+# /api/events (또는 다른 API) 요청 →
+#   → Next.js 서버가 자동으로 Authorization: Bearer JWT 주입
+#   → 백엔드가 정상 응답
+```
+- [ ] 기존 catch-all 프록시(`/api/[...path]/route.ts`)가 정상 동작
+- [ ] JWT가 자동으로 백엔드 요청에 주입됨
+
+---
+
+## 🔀 브랜치 작업 흐름
+
+```bash
+# 1. Phase 1 머지 후 master 최신화
+git switch master
+git pull origin master
+git switch -c feature/{이슈번호}-auth-frontend
+
+# 2. 위 Step 1~4 순서로 개발 + 커밋
+
+# 3. 전체 검증 통과 후 푸시
+git push origin feature/{이슈번호}-auth-frontend
+
+# 4. GitHub에서 PR 생성
+#    제목: feat: 로그인/가입 페이지 UI + BFF 인증 연동 (#이슈번호)
+#    본문에 closes #이슈번호 포함
+```
+
+---
+
+## ⚠️ 주의사항
+
+- `/api/auth/*` Route는 **catch-all 프록시(`/api/[...path]/route.ts`)보다 우선** 적용됨 (Next.js 라우팅 규칙)
+- `iron-session` v8 사용 중 — `cookies()` 함수에 `await` 필요 (Next.js 16 App Router)
+- `SESSION_SECRET`은 `.env`에 이미 설정됨 (`session.ts`에서 참조)
+- Zustand 스토어는 **클라이언트 컴포넌트**에서만 사용 (`"use client"` 필수)
+- 회원가입 폼에서 비밀번호 **최소 길이 검증** 추가 권장 (프론트 + 백엔드 둘 다)

--- a/docs/phase3-auth-e2e-verify.md
+++ b/docs/phase3-auth-e2e-verify.md
@@ -1,0 +1,487 @@
+# 🧪 Phase 3 — 인증 연동 검증: 가입→로그인→JWT E2E 테스트
+
+> **브랜치:** `feature/{이슈번호}-auth-e2e-verify`  
+> **선행 조건:** Phase 1, Phase 2 모두 머지 완료  
+> **목표:** 전체 인증 흐름이 정상 동작하는지 End-to-End 검증 + 엣지 케이스 테스트
+
+---
+
+## 📋 참고 문서
+
+- [jwt-auth-flow.md](./jwt-auth-flow.md) — JWT 인증 흐름 전체
+- [phase1-user-api-backend.md](./phase1-user-api-backend.md) — 백엔드 API 스펙
+- [phase2-auth-frontend.md](./phase2-auth-frontend.md) — 프론트엔드 UI + BFF Route
+- [GIT_WORKFLOW.md](./GIT_WORKFLOW.md) — Git 브랜치/커밋 규칙
+
+---
+
+## 🎯 E2E 검증이란?
+
+**End-to-End (E2E) 검증**은 사용자 관점에서 전체 시스템이 올바르게 동작하는지 확인합니다.
+
+```
+[사용자 브라우저] → [Next.js BFF] → [Spring Boot] → [PostgreSQL DB]
+      UI            Route/Proxy       Controller         데이터
+      ↕                ↕                 ↕                 ↕
+ 폼 입력/제출     JWT 세션 관리      인증/인가 처리     사용자 저장/조회
+```
+
+Phase 1과 Phase 2를 각각 테스트했다면, Phase 3에서는 **전체 연결**이 끊김 없이 동작하는지 확인합니다.
+
+---
+
+## 🔧 테스트 환경 준비
+
+### 전체 시스템 기동
+
+```bash
+# 1. master 최신화 (Phase 1, 2가 모두 머지된 상태)
+git switch master
+git pull origin master
+git switch -c feature/{이슈번호}-auth-e2e-verify
+
+# 2. DB 기동
+docker compose -f docker-compose.local.yml up db -d
+
+# 3. 백엔드 기동
+cd backend
+./gradlew bootRun &
+# 확인: http://localhost:8080/swagger-ui.html 접근 가능
+
+# 4. 프론트엔드 기동
+cd frontend
+npm install
+npm run dev
+# 확인: http://localhost:3000 접근 가능
+```
+
+- [ ] DB 정상 기동 (`docker ps`로 확인)
+- [ ] 백엔드 정상 기동 (8080 포트)
+- [ ] 프론트엔드 정상 기동 (3000 포트)
+
+---
+
+## ✅ E2E 테스트 시나리오
+
+### 시나리오 1: 정상 회원가입 → 로그인 → 인증된 API 사용
+
+```
+1. 브라우저에서 http://localhost:3000/signup 접속
+2. 아래 정보로 회원가입:
+   - 이메일: e2e-user@test.com
+   - 비밀번호: test1234
+   - 닉네임: E2E테스터
+   - 역할: USER
+3. 가입 성공 확인 → 로그인 페이지 이동
+4. http://localhost:3000/login 에서 로그인
+   - 이메일: e2e-user@test.com
+   - 비밀번호: test1234
+5. 로그인 성공 → 메인 페이지 이동
+6. 네비게이션에 "E2E테스터" 닉네임 표시 확인
+7. http://localhost:3000/mypage 접근 → 정상 표시 (로그인 상태)
+8. 페이지 새로고침 → 로그인 상태 유지 확인
+```
+
+**검증 포인트:**
+- [ ] 회원가입 성공
+- [ ] 로그인 성공 + 자동 리다이렉트
+- [ ] 사용자 정보 정상 표시 (닉네임)
+- [ ] 보호된 페이지 접근 가능
+- [ ] 새로고침 후 세션 유지
+
+---
+
+### 시나리오 2: HOST 역할 회원가입 → 로그인
+
+```
+1. http://localhost:3000/signup 에서 HOST로 가입
+   - 이메일: host@test.com
+   - 비밀번호: host1234
+   - 닉네임: 기획자
+   - 역할: HOST
+2. 로그인 후 사용자 정보의 role이 "HOST"인지 확인
+```
+
+**검증 포인트:**
+- [ ] HOST 역할로 가입 성공
+- [ ] 로그인 시 role = "HOST" 반환
+
+---
+
+### 시나리오 3: 로그아웃 → 보호 경로 차단
+
+```
+1. 로그인 상태에서 로그아웃 클릭
+2. 네비게이션이 비로그인 상태로 변경 확인
+3. http://localhost:3000/mypage 접근 시도
+4. → /login?redirect=/mypage 로 리다이렉트 확인
+5. 다시 로그인 → /mypage로 자동 이동 (redirect 파라미터 반영)
+```
+
+**검증 포인트:**
+- [ ] 로그아웃 시 세션 파기
+- [ ] 보호 경로 접근 차단 → 로그인 리다이렉트
+- [ ] redirect 파라미터가 정상 동작
+
+---
+
+### 시나리오 4: 에러 케이스 — 잘못된 비밀번호
+
+```
+1. http://localhost:3000/login 접속
+2. 존재하는 이메일 + 잘못된 비밀번호 입력
+3. 로그인 버튼 클릭
+4. → 에러 메시지 표시 (e.g., "이메일 또는 비밀번호가 올바르지 않습니다")
+```
+
+**검증 포인트:**
+- [ ] 적절한 에러 메시지 표시
+- [ ] 로그인 상태가 변경되지 않음
+- [ ] 세션 쿠키가 생성되지 않음
+
+---
+
+### 시나리오 5: 에러 케이스 — 이메일 중복 가입
+
+```
+1. http://localhost:3000/signup 접속
+2. 이미 가입된 이메일로 다시 가입 시도
+3. → 에러 메시지 표시 (e.g., "이미 등록된 이메일입니다")
+```
+
+**검증 포인트:**
+- [ ] 중복 이메일 에러 처리
+- [ ] 적절한 에러 메시지 표시
+
+---
+
+### 시나리오 6: 에러 케이스 — 존재하지 않는 이메일 로그인
+
+```
+1. http://localhost:3000/login 접속
+2. 가입하지 않은 이메일로 로그인 시도
+3. → 에러 메시지 표시
+```
+
+**검증 포인트:**
+- [ ] 미존재 계정 에러 처리
+- [ ] 보안을 위해 "이메일이 틀렸다"가 아닌 일반적인 에러 메시지 권장
+
+---
+
+### 시나리오 7: JWT 만료 처리
+
+```
+1. 로그인 성공 (정상 세션 획득)
+2. 백엔드를 재시작 (또는 JWT secret을 변경)
+3. 보호된 API 호출 시도
+4. → 백엔드가 401 응답
+5. → catch-all 프록시가 세션 자동 파기 (session.destroy())
+6. → 다음 페이지 이동 시 로그인 페이지로 리다이렉트
+```
+
+**검증 포인트:**
+- [ ] 401 응답 시 세션 자동 파기
+- [ ] 사용자가 자연스럽게 재로그인 유도됨
+
+---
+
+### 시나리오 8: 동시 탭 세션 동기화
+
+```
+1. 탭 A에서 로그인
+2. 탭 B를 새로 열기 → 로그인 상태 확인
+3. 탭 A에서 로그아웃
+4. 탭 B를 새로고침 → 로그아웃 상태 확인
+```
+
+**검증 포인트:**
+- [ ] 쿠키 기반이므로 탭 간 세션 공유
+- [ ] 로그아웃 시 모든 탭에 반영 (새로고침 후)
+
+---
+
+## 🔍 보안 검증 체크리스트
+
+### BFF 보안 (프론트엔드)
+
+```bash
+# 브라우저 DevTools (F12) 확인
+```
+
+| 항목 | 확인 방법 | 기대 결과 |
+|------|-----------|-----------|
+| **JWT 클라이언트 노출** | Network 탭 → `/api/auth/login` 응답 Body | JWT 토큰이 **없어야** 함 |
+| **httpOnly 쿠키** | Console → `document.cookie` | `venueon_session`이 **보이지 않아야** 함 |
+| **쿠키 속성** | Application → Cookies | httpOnly: ✅, sameSite: lax |
+| **Authorization 헤더** | Network 탭 → 일반 페이지 요청 | Authorization 헤더 **없어야** 함 |
+
+### 백엔드 보안
+
+```bash
+# curl로 직접 검증
+```
+
+| 항목 | 테스트 커맨드 | 기대 결과 |
+|------|--------------|-----------|
+| **JWT 없이 /auth/me 접근** | `curl http://localhost:8080/auth/me` | 401 Unauthorized |
+| **잘못된 JWT** | `curl -H "Authorization: Bearer fake" http://localhost:8080/auth/me` | 401 Unauthorized |
+| **만료된 JWT** | (1초 만료 토큰 생성 후 대기) | 401 Unauthorized |
+| **회원가입 허용경로** | `curl -X POST http://localhost:8080/auth/signup ...` | JWT 없이도 200/201 |
+| **비밀번호 암호화** | DB 직접 조회: `SELECT password FROM users` | BCrypt 해시 (`$2a$...`) |
+
+### DB 직접 확인
+
+```bash
+# Docker 컨테이너 내 psql 접속
+docker exec -it venueon-db psql -U venueon -d venueon_prod
+
+# 또는 docker-compose.local.yml의 DB 설정에 맞게
+```
+
+```sql
+-- 가입한 유저 확인
+SELECT id, email, nickname, role, created_at FROM users;
+
+-- 비밀번호가 BCrypt 해시인지 확인
+SELECT email, password FROM users;
+-- password 값이 $2a$10$... 형태여야 함 (평문❌)
+```
+
+- [ ] 사용자 데이터가 정상 저장됨
+- [ ] 비밀번호가 BCrypt로 암호화됨
+- [ ] role이 올바르게 저장됨
+
+---
+
+## 📊 전체 흐름 체크 — curl 순차 테스트 스크립트
+
+> 아래 스크립트를 터미널에서 순서대로 실행하여 전체 흐름을 자동 검증할 수 있습니다.
+
+```bash
+#!/bin/bash
+# E2E 인증 흐름 검증 스크립트
+# 사용법: bash docs/e2e-auth-test.sh
+
+BACKEND="http://localhost:8080"
+FRONTEND="http://localhost:3000"
+EMAIL="e2e-$(date +%s)@test.com"
+PASSWORD="testpass1234"
+NICKNAME="E2E테스터"
+
+echo "=========================================="
+echo "🧪 VenueOn 인증 E2E 테스트 시작"
+echo "=========================================="
+echo "테스트 이메일: $EMAIL"
+echo ""
+
+# ① 회원가입 (백엔드 직접)
+echo "--- ① 회원가입 ---"
+SIGNUP_RES=$(curl -s -w "\n%{http_code}" -X POST "$BACKEND/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"nickname\":\"$NICKNAME\",\"role\":\"USER\"}")
+
+SIGNUP_STATUS=$(echo "$SIGNUP_RES" | tail -1)
+SIGNUP_BODY=$(echo "$SIGNUP_RES" | head -n -1)
+echo "Status: $SIGNUP_STATUS"
+echo "Body: $SIGNUP_BODY"
+
+if [ "$SIGNUP_STATUS" = "201" ] || [ "$SIGNUP_STATUS" = "200" ]; then
+  echo "✅ 회원가입 성공"
+else
+  echo "❌ 회원가입 실패"
+  exit 1
+fi
+echo ""
+
+# ② 이메일 중복 가입 시도
+echo "--- ② 이메일 중복 가입 ---"
+DUP_RES=$(curl -s -w "\n%{http_code}" -X POST "$BACKEND/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"nickname\":\"중복\",\"role\":\"USER\"}")
+
+DUP_STATUS=$(echo "$DUP_RES" | tail -1)
+echo "Status: $DUP_STATUS"
+
+if [ "$DUP_STATUS" != "200" ] && [ "$DUP_STATUS" != "201" ]; then
+  echo "✅ 중복 가입 차단됨"
+else
+  echo "❌ 중복 가입이 허용됨 — 에러!"
+fi
+echo ""
+
+# ③ 로그인
+echo "--- ③ 로그인 ---"
+LOGIN_RES=$(curl -s -w "\n%{http_code}" -X POST "$BACKEND/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+
+LOGIN_STATUS=$(echo "$LOGIN_RES" | tail -1)
+LOGIN_BODY=$(echo "$LOGIN_RES" | head -n -1)
+echo "Status: $LOGIN_STATUS"
+
+if [ "$LOGIN_STATUS" = "200" ]; then
+  echo "✅ 로그인 성공"
+  # JWT 토큰 추출 (jq 사용 가능 시)
+  TOKEN=$(echo "$LOGIN_BODY" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+  echo "JWT Token: ${TOKEN:0:50}..."
+else
+  echo "❌ 로그인 실패"
+  exit 1
+fi
+echo ""
+
+# ④ JWT로 /auth/me 호출
+echo "--- ④ JWT로 사용자 정보 조회 ---"
+ME_RES=$(curl -s -w "\n%{http_code}" -X GET "$BACKEND/auth/me" \
+  -H "Authorization: Bearer $TOKEN")
+
+ME_STATUS=$(echo "$ME_RES" | tail -1)
+ME_BODY=$(echo "$ME_RES" | head -n -1)
+echo "Status: $ME_STATUS"
+echo "Body: $ME_BODY"
+
+if [ "$ME_STATUS" = "200" ]; then
+  echo "✅ JWT 인증 성공"
+else
+  echo "❌ JWT 인증 실패"
+fi
+echo ""
+
+# ⑤ 잘못된 JWT
+echo "--- ⑤ 잘못된 JWT ---"
+INVALID_RES=$(curl -s -o /dev/null -w "%{http_code}" -X GET "$BACKEND/auth/me" \
+  -H "Authorization: Bearer invalid.jwt.token")
+
+echo "Status: $INVALID_RES"
+if [ "$INVALID_RES" = "401" ]; then
+  echo "✅ 잘못된 JWT 거부됨"
+else
+  echo "❌ 잘못된 JWT가 허용됨 — 보안 문제!"
+fi
+echo ""
+
+# ⑥ JWT 없이 접근
+echo "--- ⑥ JWT 없이 보호 경로 접근 ---"
+NO_JWT_RES=$(curl -s -o /dev/null -w "%{http_code}" -X GET "$BACKEND/auth/me")
+
+echo "Status: $NO_JWT_RES"
+if [ "$NO_JWT_RES" = "401" ]; then
+  echo "✅ 인증 없는 접근 차단됨"
+else
+  echo "❌ 인증 없이 접근 가능 — 보안 문제!"
+fi
+echo ""
+
+# ⑦ 잘못된 비밀번호 로그인
+echo "--- ⑦ 잘못된 비밀번호 ---"
+WRONG_PW_RES=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BACKEND/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"wrong_password\"}")
+
+echo "Status: $WRONG_PW_RES"
+if [ "$WRONG_PW_RES" = "401" ]; then
+  echo "✅ 잘못된 비밀번호 거부됨"
+else
+  echo "❌ 잘못된 비밀번호로 로그인 성공 — 보안 문제!"
+fi
+echo ""
+
+echo "=========================================="
+echo "🧪 E2E 테스트 완료"
+echo "=========================================="
+```
+
+---
+
+## 🔧 구현 작업 (이 브랜치에서 할 일)
+
+Phase 3 브랜치에서는 주로 **테스트/수정/문서화**를 진행합니다.
+
+### Step 1 — E2E 테스트 스크립트 추가
+```
+커밋: test: 인증 E2E 테스트 스크립트 추가 (#이슈번호)
+```
+- `docs/e2e-auth-test.sh` — 위 curl 테스트 스크립트 파일화
+
+### Step 2 — 발견된 버그 수정
+```
+커밋: fix: E2E 테스트에서 발견된 인증 버그 수정 (#이슈번호)
+```
+- Phase 1, 2에서 놓친 에지 케이스 수정
+- 에러 메시지 통일
+- 리다이렉트 로직 보완
+
+### Step 3 — 인증 연동 문서 최종 업데이트
+```
+커밋: docs: 인증 연동 완료 — jwt-auth-flow.md 현행화 (#이슈번호)
+```
+- `jwt-auth-flow.md`에 VenueOn 프로젝트 기준으로 파일 경로 반영
+- 실제 테스트 결과 기반으로 문서 보완
+
+---
+
+## ✅ 푸시 전 최종 검증 체크리스트
+
+### 전체 시스템 동작
+
+- [ ] `docker compose -f docker-compose.local.yml up db -d` — DB 기동
+- [ ] `./gradlew bootRun` — 백엔드 정상 기동
+- [ ] `npm run dev` — 프론트엔드 정상 기동
+
+### E2E 시나리오 통과
+
+- [ ] 시나리오 1: 정상 회원가입 → 로그인 → 인증 API
+- [ ] 시나리오 2: HOST 역할 가입/로그인
+- [ ] 시나리오 3: 로그아웃 → 보호 경로 차단
+- [ ] 시나리오 4: 잘못된 비밀번호 에러 처리
+- [ ] 시나리오 5: 이메일 중복 가입 에러 처리
+- [ ] 시나리오 6: 미존재 이메일 로그인 에러 처리
+- [ ] 시나리오 7: JWT 만료/무효화 처리
+- [ ] 시나리오 8: 다중 탭 세션 동기화
+
+### 보안 통과
+
+- [ ] JWT가 브라우저에 노출되지 않음
+- [ ] httpOnly 쿠키 정상 설정
+- [ ] 비밀번호 BCrypt 해시 저장
+- [ ] 인증 없는 보호 API 접근 차단 (401)
+
+### 코드 품질
+
+- [ ] `./gradlew clean build` — 백엔드 빌드 성공
+- [ ] `npm run build` — 프론트엔드 빌드 성공
+- [ ] 불필요한 console.log / System.out.println 제거
+- [ ] E2E 테스트 스크립트 정상 동작
+
+---
+
+## 🔀 브랜치 작업 흐름
+
+```bash
+# 1. Phase 1, 2 머지 후 master 최신화
+git switch master
+git pull origin master
+git switch -c feature/{이슈번호}-auth-e2e-verify
+
+# 2. E2E 테스트 실행 + 버그 수정 + 문서 업데이트
+
+# 3. 전체 검증 통과 후 푸시
+git push origin feature/{이슈번호}-auth-e2e-verify
+
+# 4. GitHub에서 PR 생성
+#    제목: test: 인증 E2E 검증 완료 (#이슈번호)
+#    본문에 closes #이슈번호 포함
+```
+
+---
+
+## 📌 Phase 1~3 전체 요약
+
+| Phase | 브랜치 | 핵심 산출물 | 검증 포인트 |
+|-------|--------|------------|------------|
+| **1. BE API** | `feature/{N}-user-auth-api` | JWT 발급 + Auth API | curl로 API 단위 테스트 |
+| **2. FE UI** | `feature/{N}-auth-frontend` | 로그인/가입 UI + BFF Route | 브라우저 + DevTools 확인 |
+| **3. E2E** | `feature/{N}-auth-e2e-verify` | 통합 테스트 + 보안 검증 | 전체 시나리오 + 자동 테스트 |
+
+> 각 Phase는 **이전 Phase가 master에 머지된 후** 진행합니다.


### PR DESCRIPTION
## 📌 개요
회원가입/로그인 API 구현 및 JWT 토큰 발급 기능을 추가합니다.

closes #36

---

## 🔐 구현 내용

### Security 인프라 (JWT)
- `JwtTokenProvider` — JWT 토큰 생성/검증/파싱 (HS256)
- `JwtAuthenticationFilter` — 매 요청마다 JWT 추출 → 인증 설정 (OncePerRequestFilter)
- `CustomUserDetailsService` — DB에서 사용자 조회
- `SecurityConfig` 수정 — JWT 필터 등록, 경로별 인가 규칙 추가

### Application Layer (Port + Service)
- Port-In: `SignUpUseCase`, `LoginUseCase`, `GetUserInfoUseCase`
- Port-Out: `UserRepositoryPort`
- Service: `AuthService` — BCrypt 비밀번호 암호화, 이메일 중복 체크, JWT 발급

### Persistence Adapter
- `UserPersistenceAdapter` — save, findByEmail, existsByEmail
- `UserMapper` — Entity ↔ Domain 변환

### Presentation Layer (Controller + DTO)
- `AuthController` — `/auth/signup`, `/auth/login`, `/auth/me` 엔드포인트
- DTO: `SignUpRequest`, `LoginRequest`, `LoginResponse`, `UserInfoResponse`

### 문서
- `docs/jwt-auth-flow.md` — JWT 인증 흐름 분석
- `docs/phase1-user-api-backend.md` — Phase 1 백엔드 구현 가이드
- `docs/phase2-auth-frontend.md` — Phase 2 프론트엔드 가이드
- `docs/phase3-auth-e2e-verify.md` — Phase 3 E2E 검증 가이드

---

## 🧪 API 스펙

| Method | Endpoint | 설명 | 인증 |
|--------|----------|------|------|
| POST | `/auth/signup` | 회원가입 | ❌ |
| POST | `/auth/login` | 로그인 (JWT 발급) | ❌ |
| GET | `/auth/me` | 사용자 정보 조회 | ✅ Bearer Token |

---

## ✅ 체크리스트
- [x] 헥사고날 아키텍처 준수 (Port-In/Out, Adapter 분리)
- [x] BCrypt 비밀번호 암호화
- [x] JWT 토큰 생성/검증
- [x] SecurityConfig 경로별 인가 설정
- [x] 컴파일 확인 (`./gradlew compileJava`)
