### PR TITLE
feat: 로그인/가입 페이지 UI + BFF 인증 연동 및 Zustand 설정 (#37)

### DIFF
--- a/frontend/src/app/(auth)/auth.module.css
+++ b/frontend/src/app/(auth)/auth.module.css
@@ -1,0 +1,106 @@
+.container {
+  padding: var(--space-8);
+  max-width: 480px;
+  margin: 0 auto;
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  margin-top: var(--space-8);
+}
+
+.title {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  margin-bottom: var(--space-2);
+  text-align: center;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  text-align: center;
+  margin-bottom: var(--space-6);
+  font-size: var(--font-size-sm);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.input {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--font-size-base);
+  transition: border-color var(--transition);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.button {
+  padding: var(--space-3);
+  background-color: var(--color-primary);
+  color: white;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  margin-top: var(--space-2);
+  transition: background-color var(--transition);
+}
+
+.button:hover:not(:disabled) {
+  background-color: var(--color-primary-hover);
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  margin-top: -var(--space-2);
+}
+
+.link {
+  color: var(--color-primary);
+  text-decoration: underline;
+  margin-left: var(--space-1);
+}
+
+.footer {
+  text-align: center;
+  margin-top: var(--space-6);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.radioGroup {
+  display: flex;
+  gap: var(--space-4);
+}
+
+.radioLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,11 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { authAPI } from "@/lib/auth-api";
+import { useAuth } from "@/store/useAuthStore";
+import { useUIStore } from "@/store/useUIStore";
+import styles from "../auth.module.css";
+import React from "react";
+
+function LoginContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { checkSession } = useAuth();
+  const { showToast } = useUIStore();
+  
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      await authAPI.login(email, password);
+      await checkSession();
+      showToast("로그인 성공!", "success");
+      const redirectTo = searchParams.get("redirect") || "/";
+      router.push(redirectTo);
+      router.refresh(); // 리프레시를 통해 헤더 등 업데이트
+    } catch (err: any) {
+      const msg = err.message || "로그인에 실패했습니다.";
+      setError(msg);
+      showToast(msg, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>로그인</h1>
+      <p className={styles.subtitle}>이메일과 비밀번호를 입력해주세요.</p>
+
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="email">이메일</label>
+          <input
+            id="email"
+            type="email"
+            required
+            className={styles.input}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="password">비밀번호</label>
+          <input
+            id="password"
+            type="password"
+            required
+            className={styles.input}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호를 입력하세요"
+          />
+        </div>
+
+        {error && <div className={styles.error}>{error}</div>}
+
+        <button type="submit" className={styles.button} disabled={loading}>
+          {loading ? "로그인 중..." : "로그인"}
+        </button>
+      </form>
+
+      <div className={styles.footer}>
+        계정이 없으신가요? 
+        <Link href="/signup" className={styles.link}>
+          회원가입하기
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 export default function LoginPage() {
   return (
-    <div style={{ padding: "var(--space-8)", maxWidth: 480, margin: "0 auto" }}>
-      <h1>로그인</h1>
-      <p style={{ color: "var(--color-text-muted)" }}>
-        이메일과 비밀번호를 입력해주세요.
-      </p>
-      {/* TODO: LoginForm 컴포넌트 구현 */}
-    </div>
+    <React.Suspense fallback={<div>Loading...</div>}>
+      <LoginContent />
+    </React.Suspense>
   );
 }

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -1,11 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { authAPI } from "@/lib/auth-api";
+import { useUIStore } from "@/store/useUIStore";
+import styles from "../auth.module.css";
+
 export default function SignupPage() {
+  const router = useRouter();
+  const { showToast } = useUIStore();
+  
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [role, setRole] = useState("USER"); // "USER" | "HOST"
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      if (password.length < 8) {
+        throw new Error("비밀번호는 8자 이상이어야 합니다.");
+      }
+      
+      await authAPI.signup({ email, password, nickname, role });
+      showToast("회원가입이 완료되었습니다. 로그인해주세요.", "success");
+      router.push("/login");
+    } catch (err: any) {
+      const msg = err.message || "회원가입에 실패했습니다.";
+      setError(msg);
+      showToast(msg, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div style={{ padding: "var(--space-8)", maxWidth: 480, margin: "0 auto" }}>
-      <h1>회원가입</h1>
-      <p style={{ color: "var(--color-text-muted)" }}>
-        기획자(HOST) 또는 일반 사용자(USER)로 가입할 수 있습니다.
-      </p>
-      {/* TODO: SignupForm 컴포넌트 구현 (역할 선택 포함) */}
+    <div className={styles.container}>
+      <h1 className={styles.title}>회원가입</h1>
+      <p className={styles.subtitle}>기획자(HOST) 또는 일반 사용자(USER)로 가입할 수 있습니다.</p>
+
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="email">이메일</label>
+          <input
+            id="email"
+            type="email"
+            required
+            className={styles.input}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="password">비밀번호</label>
+          <input
+            id="password"
+            type="password"
+            required
+            minLength={8}
+            className={styles.input}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호(8자 이상)"
+          />
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="nickname">닉네임</label>
+          <input
+            id="nickname"
+            type="text"
+            required
+            className={styles.input}
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder="닉네임을 입력하세요"
+          />
+        </div>
+
+        <div className={styles.formGroup}>
+          <span className={styles.label}>회원 유형</span>
+          <div className={styles.radioGroup}>
+            <label className={styles.radioLabel}>
+              <input
+                type="radio"
+                name="role"
+                value="USER"
+                checked={role === "USER"}
+                onChange={(e) => setRole(e.target.value)}
+              />
+              일반 사용자
+            </label>
+            <label className={styles.radioLabel}>
+              <input
+                type="radio"
+                name="role"
+                value="HOST"
+                checked={role === "HOST"}
+                onChange={(e) => setRole(e.target.value)}
+              />
+              기획자 (HOST)
+            </label>
+          </div>
+        </div>
+
+        {error && <div className={styles.error}>{error}</div>}
+
+        <button type="submit" className={styles.button} disabled={loading}>
+          {loading ? "처리 중..." : "가입하기"}
+        </button>
+      </form>
+
+      <div className={styles.footer}>
+        이미 계정이 있으신가요? 
+        <Link href="/login" className={styles.link}>
+          로그인하기
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { SessionData, sessionOptions } from "@/lib/session";
 
 // ✅ 환경 변수: 런타임 변수(API_BASE_URL)를 우선 참조합니다.
-const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://backend:8080";
+const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 async function proxyRequest(req: NextRequest) {
   // 요청 경로 및 쿼리 파라미터 추출

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,57 @@
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+    // 1. Spring Boot에 로그인 요청
+    const loginRes = await fetch(`${API_BASE}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!loginRes.ok) {
+      const error = await loginRes.json().catch(() => ({}));
+      return NextResponse.json(error, { status: loginRes.status });
+    }
+
+    const loginData = await loginRes.json();
+    
+    // 2. JWT로 사용자 정보 조회
+    const meRes = await fetch(`${API_BASE}/auth/me`, {
+      headers: { Authorization: `Bearer ${loginData.token}` },
+    });
+    
+    const userData = meRes.ok ? await meRes.json() : loginData;
+
+    // 3. iron-session에 JWT + 사용자 정보 저장
+    const cookieStore = await cookies();
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+    session.jwt = loginData.token;
+    session.email = userData.email;
+    session.nickname = userData.nickname;
+    session.role = userData.role;
+    session.userId = userData.id;
+    session.isLoggedIn = true;
+    await session.save();
+
+    // 4. 브라우저에겐 JWT 없이 사용자 정보만 반환
+    return NextResponse.json({
+      user: {
+        id: userData.id,
+        email: userData.email,
+        nickname: userData.nickname,
+        role: userData.role,
+      },
+      success: true
+    });
+  } catch (error) {
+    console.error("Login API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,13 @@
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+  
+  session.destroy();
+  
+  return NextResponse.json({ success: true });
+}

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -1,0 +1,23 @@
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+
+  if (session.isLoggedIn) {
+    return NextResponse.json({
+      isLoggedIn: true,
+      user: {
+        id: session.userId,
+        email: session.email,
+        nickname: session.nickname,
+        role: session.role,
+      },
+    });
+  } else {
+    return NextResponse.json({ isLoggedIn: false });
+  }
+}

--- a/frontend/src/app/api/auth/signup/route.ts
+++ b/frontend/src/app/api/auth/signup/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+    const res = await fetch(`${API_BASE}/auth/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json().catch(() => ({}));
+
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error("Signup API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "@/styles/globals.css";
+import Header from "@/components/layout/Header";
+import Toast from "@/components/ui/Toast";
 
 export const metadata: Metadata = {
   title: "VenueOn — 이벤트 중계 플랫폼",
@@ -18,34 +20,9 @@ export default function RootLayout({
         <Header />
         <main>{children}</main>
         <Footer />
+        <Toast />
       </body>
     </html>
-  );
-}
-
-// ── 임시 Header / Footer (추후 components/ 분리) ──
-function Header() {
-  return (
-    <header
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        padding: "var(--space-4) var(--space-8)",
-        borderBottom: "1px solid var(--color-border)",
-        background: "var(--color-surface)",
-      }}
-    >
-      <a href="/" style={{ fontSize: "var(--font-size-xl)", fontWeight: 700 }}>
-        VenueOn
-      </a>
-      <nav style={{ display: "flex", gap: "var(--space-4)" }}>
-        <a href="/events">이벤트</a>
-        <a href="/community">커뮤니티</a>
-        <a href="/mypage">마이페이지</a>
-        <a href="/auth/login">로그인</a>
-      </nav>
-    </header>
   );
 }
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/store/useAuthStore";
+
+export default function Header() {
+  const { user, isLoggedIn, isLoading, checkSession, logout } = useAuth();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    checkSession();
+  }, [checkSession]);
+
+  return (
+    <header
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "var(--space-4) var(--space-8)",
+        borderBottom: "1px solid var(--color-border)",
+        background: "var(--color-surface)",
+      }}
+    >
+      <Link href="/" style={{ fontSize: "var(--font-size-xl)", fontWeight: 700, color: "var(--color-primary)" }}>
+        VenueOn
+      </Link>
+      <nav style={{ display: "flex", gap: "var(--space-4)", alignItems: "center" }}>
+        <Link href="/events" style={{ color: "var(--color-text)" }}>이벤트</Link>
+        <Link href="/community" style={{ color: "var(--color-text)" }}>커뮤니티</Link>
+        
+        {mounted && isLoading ? (
+          <span style={{ color: "var(--color-text-muted)" }}>...</span>
+        ) : mounted && isLoggedIn ? (
+          <>
+            <Link href="/mypage" style={{ color: "var(--color-text)" }}>마이페이지</Link>
+            <span style={{ color: "var(--color-success)", fontWeight: "bold" }}>{user?.nickname}님</span>
+            <button 
+              onClick={() => logout()}
+              style={{ padding: "4px 8px", background: "var(--color-border)", borderRadius: "4px", color: "var(--color-text)", fontWeight: "bold" }}
+            >
+              로그아웃
+            </button>
+          </>
+        ) : mounted ? (
+          <Link href="/login" style={{ color: "var(--color-text)" }}>로그인</Link>
+        ) : (
+          <span style={{ color: "var(--color-text-muted)" }}>...</span>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useUIStore } from "@/store/useUIStore";
+import { useEffect, useState } from "react";
+
+export default function Toast() {
+  const { isToastOpen, toastMessage, toastType, hideToast } = useUIStore();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !isToastOpen) return null;
+
+  // 타입별 배경색 지정
+  const bgColors = {
+    info: "var(--color-surface)",
+    success: "var(--color-success)",
+    warning: "var(--color-secondary)",
+    error: "var(--color-error)",
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: "2rem",
+        left: "50%",
+        transform: "translateX(-50%)",
+        backgroundColor: bgColors[toastType] || bgColors.info,
+        color: "white",
+        padding: "12px 24px",
+        borderRadius: "8px",
+        boxShadow: "0 4px 6px rgba(0,0,0,0.3)",
+        zIndex: 9999,
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        animation: "fadeInUp 0.3s ease",
+        fontWeight: "bold",
+      }}
+    >
+      <span>{toastMessage}</span>
+      <button 
+        onClick={hideToast}
+        style={{
+          color: "white",
+          opacity: 0.8,
+          fontSize: "1.2rem",
+          padding: "0 4px"
+        }}
+      >
+        ×
+      </button>
+
+      <style>{`
+        @keyframes fadeInUp {
+          from {
+            opacity: 0;
+            transform: translate(-50%, 1rem);
+          }
+          to {
+            opacity: 1;
+            transform: translate(-50%, 0);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,0 +1,30 @@
+export const authAPI = {
+  signup: async (data: any) => {
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '회원가입 실패');
+    return result;
+  },
+  login: async (email: string, password: string) => {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '로그인 실패');
+    return result;
+  },
+  logout: async () => {
+    const res = await fetch('/api/auth/logout', { method: 'POST' });
+    return res.json().catch(() => ({}));
+  },
+  getSession: async () => {
+    const res = await fetch('/api/auth/session');
+    return res.json().catch(() => ({ isLoggedIn: false }));
+  },
+};

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import { authAPI } from '@/lib/auth-api';
+
+interface User {
+  id?: number;
+  email?: string;
+  nickname?: string;
+  role?: "ADMIN" | "HOST" | "USER";
+}
+
+interface AuthState {
+  user: User | null;
+  isLoggedIn: boolean;
+  isLoading: boolean;
+  checkSession: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  user: null,
+  isLoggedIn: false,
+  isLoading: true,
+  checkSession: async () => {
+    set({ isLoading: true });
+    try {
+      const data = await authAPI.getSession();
+      if (data.isLoggedIn) {
+        set({ user: data.user, isLoggedIn: true, isLoading: false });
+      } else {
+        set({ user: null, isLoggedIn: false, isLoading: false });
+      }
+    } catch (e) {
+      set({ user: null, isLoggedIn: false, isLoading: false });
+    }
+  },
+  logout: async () => {
+    try {
+      await authAPI.logout();
+      set({ user: null, isLoggedIn: false });
+      window.location.href = '/login';
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}));

--- a/frontend/src/store/useUIStore.ts
+++ b/frontend/src/store/useUIStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+export type ToastType = 'info' | 'success' | 'warning' | 'error';
+
+interface ToastState {
+  isToastOpen: boolean;
+  toastMessage: string;
+  toastType: ToastType;
+}
+
+interface UIStore extends ToastState {
+  showToast: (message: string, type?: ToastType) => void;
+  hideToast: () => void;
+}
+
+export const useUIStore = create<UIStore>((set) => ({
+  isToastOpen: false,
+  toastMessage: '',
+  toastType: 'info',
+  showToast: (message, type = 'info') => {
+    set({
+      isToastOpen: true,
+      toastMessage: message,
+      toastType: type,
+    });
+
+    // 3초 뒤 자동 닫힘 처리
+    setTimeout(() => {
+      set({ isToastOpen: false });
+    }, 3000);
+  },
+  hideToast: () => set({ isToastOpen: false }),
+}));


### PR DESCRIPTION
Closes #37, Closes #87

## 📌 개요
로그인/회원가입 페이지 구현 및 프론트엔드 BFF 인증 우회처리, 그리고 Zustand와 전역 Toast 알림을 구축했습니다.
해당 작업에서 Zustand 스토어 설정 내용이 포함되어 이슈 #87 내용도 함께 반영하여 Close 합니다.

### �� 구현 내용
- BFF Route (`/api/auth/signup`, `/api/auth/login`, `/api/auth/logout`, `/api/auth/session`) 구축
- JWT `iron-session` 암호화 저장 및 Proxy `Authorization` 주입
- Frontend UI 폴더 구성 (`/login`, `/signup`) 처리

### 🧩 Zustand 상태 관리 (이슈 #87)
- `src/store/useAuthStore.ts`: 유저 상태(로그인 여부, 유저 프로필) 관리 및 Next.js Session 유지 연동
- `src/store/useUIStore.ts`: 전역 Toast 알림 UI 구현 (에러, 성공 메세지용)
- `src/components/ui/Toast.tsx`: Layout 단계의 공용 팝업 컴포넌트 추가
