### PR TITLE
feat(#99): Entity 스키마 v4 업데이트 및 초기 데이터 추가

### DIFF
--- a/backend/src/main/java/com/venueon/comment/adapter/out/persistence/entity/CommentJpaEntity.java
+++ b/backend/src/main/java/com/venueon/comment/adapter/out/persistence/entity/CommentJpaEntity.java
@@ -35,6 +35,10 @@ public class CommentJpaEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "is_hidden", nullable = false)
+    @Builder.Default
+    private boolean isHidden = false;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/venueon/common/config/DataInitializer.java
+++ b/backend/src/main/java/com/venueon/common/config/DataInitializer.java
@@ -6,6 +6,17 @@ import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
 import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
+import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
+import com.venueon.order.domain.model.OrderStatus;
+import com.venueon.report.adapter.out.persistence.entity.RefundJpaEntity;
+import com.venueon.report.adapter.out.persistence.entity.ReportJpaEntity;
+import com.venueon.report.adapter.out.persistence.repository.RefundJpaRepository;
+import com.venueon.report.adapter.out.persistence.repository.ReportJpaRepository;
+import com.venueon.report.domain.model.AdminAction;
+import com.venueon.report.domain.model.RefundStatus;
+import com.venueon.report.domain.model.ReportStatus;
+import com.venueon.report.domain.model.ReportTargetType;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
 import com.venueon.user.domain.model.UserRole;
@@ -30,6 +41,9 @@ public class DataInitializer implements ApplicationRunner {
     private final UserJpaRepository userRepository;
     private final CategoryJpaRepository categoryRepository;
     private final EventJpaRepository eventRepository;
+    private final OrderJpaRepository orderRepository;
+    private final ReportJpaRepository reportRepository;
+    private final RefundJpaRepository refundRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -47,10 +61,14 @@ public class DataInitializer implements ApplicationRunner {
         List<UserJpaEntity> hosts = createHosts();
         List<CategoryJpaEntity> categories = createCategories();
         List<EventJpaEntity> events = createEvents(hosts, categories);
+        List<OrderJpaEntity> orders = createOrders(users, events);
+        List<ReportJpaEntity> reports = createReports(users, events);
+        List<RefundJpaEntity> refunds = createRefunds(users, orders);
 
         log.info("=== 개발용 초기 데이터 생성 완료 ===");
         log.info("Admin: 1명, User: {}명, Host: {}명", users.size(), hosts.size());
         log.info("Category: {}개, Event: {}개", categories.size(), events.size());
+        log.info("Order: {}개, Report: {}개, Refund: {}개", orders.size(), reports.size(), refunds.size());
     }
 
     private UserJpaEntity createAdmin() {
@@ -368,6 +386,131 @@ public class DataInitializer implements ApplicationRunner {
                         .thumbnailUrl("lecture-thumbnail/SSF_thumbnail.jpg")
                         .startDate(LocalDateTime.of(2026, 6, 28, 9, 0))
                         .endDate(LocalDateTime.of(2026, 6, 29, 18, 0))
+                        .build()
+        ));
+    }
+
+    private List<OrderJpaEntity> createOrders(List<UserJpaEntity> users, List<EventJpaEntity> events) {
+        return orderRepository.saveAll(List.of(
+                // user1(김참여) — AI & Cloud Bootcamp 수강 (유료, PAID)
+                OrderJpaEntity.builder()
+                        .user(users.get(0))
+                        .event(events.get(0))
+                        .status(OrderStatus.PAID)
+                        .quantity(1)
+                        .amount(150000)
+                        .paymentMethod("CARD")
+                        .build(),
+                // user1(김참여) — 마음챙김 요가 클래스 수강 (유료, PAID)
+                OrderJpaEntity.builder()
+                        .user(users.get(0))
+                        .event(events.get(3))
+                        .status(OrderStatus.PAID)
+                        .quantity(2)
+                        .amount(60000)
+                        .paymentMethod("KAKAO_PAY")
+                        .build(),
+                // user2(이탐색) — UX Design Workshop 수강 (유료, PAID)
+                OrderJpaEntity.builder()
+                        .user(users.get(1))
+                        .event(events.get(1))
+                        .status(OrderStatus.PAID)
+                        .quantity(1)
+                        .amount(80000)
+                        .paymentMethod("NAVER_PAY")
+                        .build(),
+                // user2(이탐색) — Startup Demo Day 참가 (무료, REGISTERED)
+                OrderJpaEntity.builder()
+                        .user(users.get(1))
+                        .event(events.get(2))
+                        .status(OrderStatus.REGISTERED)
+                        .quantity(1)
+                        .amount(0)
+                        .build(),
+                // user3(박이벤트) — Business Growth Summit 수강 (유료, CANCELLED → 환불 대상)
+                OrderJpaEntity.builder()
+                        .user(users.get(2))
+                        .event(events.get(5))
+                        .status(OrderStatus.CANCELLED)
+                        .quantity(1)
+                        .amount(50000)
+                        .paymentMethod("CARD")
+                        .build(),
+                // user3(박이벤트) — 한식 마스터클래스 수강 (유료, PAID)
+                OrderJpaEntity.builder()
+                        .user(users.get(2))
+                        .event(events.get(6))
+                        .status(OrderStatus.PAID)
+                        .quantity(1)
+                        .amount(65000)
+                        .paymentMethod("BANK_TRANSFER")
+                        .build()
+        ));
+    }
+
+    private List<ReportJpaEntity> createReports(List<UserJpaEntity> users, List<EventJpaEntity> events) {
+        return reportRepository.saveAll(List.of(
+                // 신고 1: user1이 이벤트(AI & Cloud Bootcamp)를 허위 정보로 신고 — 대기중
+                ReportJpaEntity.builder()
+                        .reporter(users.get(0))
+                        .targetType(ReportTargetType.EVENT)
+                        .targetId(events.get(0).getId())
+                        .reason("허위 정보")
+                        .detail("강의 내용과 실제 진행 내용이 전혀 다릅니다. 설명에는 AWS, GCP 실습이라고 되어 있지만 실제로는 이론 수업만 진행됩니다.")
+                        .status(ReportStatus.PENDING)
+                        .build(),
+                // 신고 2: user2가 user3을 스팸/광고로 신고 — 대기중
+                ReportJpaEntity.builder()
+                        .reporter(users.get(1))
+                        .targetType(ReportTargetType.USER)
+                        .targetId(users.get(2).getId())
+                        .reason("스팸/광고")
+                        .detail("커뮤니티에서 반복적으로 외부 사이트 링크를 게시하고 있습니다. 광고성 글을 지속적으로 작성합니다.")
+                        .status(ReportStatus.PENDING)
+                        .build(),
+                // 신고 3: user3이 이벤트(현대미술 워크숍)를 부적절한 콘텐츠로 신고 — 처리 완료
+                ReportJpaEntity.builder()
+                        .reporter(users.get(2))
+                        .targetType(ReportTargetType.EVENT)
+                        .targetId(events.get(4).getId())
+                        .reason("부적절한 콘텐츠")
+                        .detail("이벤트 설명에 부적절한 이미지가 포함되어 있습니다.")
+                        .status(ReportStatus.RESOLVED)
+                        .adminAction(AdminAction.WARN)
+                        .resolvedAt(LocalDateTime.now().minusDays(2))
+                        .build(),
+                // 신고 4: user1이 이벤트(Business Growth Summit)를 저작권 침해로 신고 — 반려
+                ReportJpaEntity.builder()
+                        .reporter(users.get(0))
+                        .targetType(ReportTargetType.EVENT)
+                        .targetId(events.get(5).getId())
+                        .reason("저작권 침해")
+                        .detail("이벤트 썸네일 이미지가 타사의 저작물을 무단으로 사용한 것 같습니다.")
+                        .status(ReportStatus.REJECTED)
+                        .adminAction(AdminAction.DISMISS)
+                        .resolvedAt(LocalDateTime.now().minusDays(1))
+                        .build()
+        ));
+    }
+
+    private List<RefundJpaEntity> createRefunds(List<UserJpaEntity> users, List<OrderJpaEntity> orders) {
+        return refundRepository.saveAll(List.of(
+                // 환불 1: user3(박이벤트)의 Business Growth Summit 취소 → 환불 요청 (대기중)
+                RefundJpaEntity.builder()
+                        .order(orders.get(4))  // CANCELLED 상태인 주문
+                        .user(users.get(2))
+                        .amount(50000)
+                        .status(RefundStatus.PENDING)
+                        .reason("일정이 변경되어 참석이 어렵습니다.")
+                        .build(),
+                // 환불 2: user1(김참여)의 마음챙김 요가 클래스 환불 (승인 완료)
+                RefundJpaEntity.builder()
+                        .order(orders.get(1))  // 요가 클래스 주문
+                        .user(users.get(0))
+                        .amount(60000)
+                        .status(RefundStatus.APPROVED)
+                        .reason("개인 사정으로 참석이 어렵습니다.")
+                        .processedAt(LocalDateTime.now().minusDays(3))
                         .build()
         ));
     }

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventJpaEntity.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventJpaEntity.java
@@ -61,6 +61,10 @@ public class EventJpaEntity {
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
+    @Column(name = "is_hidden", nullable = false)
+    @Builder.Default
+    private boolean isHidden = false;
+
     @Column(name = "start_date")
     private LocalDateTime startDate;
 

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
@@ -34,8 +34,15 @@ public class OrderJpaEntity {
     @Builder.Default
     private OrderStatus status = OrderStatus.PENDING;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int quantity = 1;
+
     @Builder.Default
     private int amount = 0;
+
+    @Column(name = "payment_method")
+    private String paymentMethod;
 
     @CreationTimestamp
     @Column(name = "ordered_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostJpaEntity.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostJpaEntity.java
@@ -49,6 +49,10 @@ public class PostJpaEntity {
     @Builder.Default
     private int commentCount = 0;
 
+    @Column(name = "is_hidden", nullable = false)
+    @Builder.Default
+    private boolean isHidden = false;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/venueon/report/adapter/out/persistence/entity/RefundJpaEntity.java
+++ b/backend/src/main/java/com/venueon/report/adapter/out/persistence/entity/RefundJpaEntity.java
@@ -1,0 +1,48 @@
+package com.venueon.report.adapter.out.persistence.entity;
+
+import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
+import com.venueon.report.domain.model.RefundStatus;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refunds")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefundJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private OrderJpaEntity order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
+
+    @Column(nullable = false)
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private RefundStatus status = RefundStatus.PENDING;
+
+    private String reason;
+
+    @CreationTimestamp
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+}

--- a/backend/src/main/java/com/venueon/report/adapter/out/persistence/entity/ReportJpaEntity.java
+++ b/backend/src/main/java/com/venueon/report/adapter/out/persistence/entity/ReportJpaEntity.java
@@ -1,0 +1,57 @@
+package com.venueon.report.adapter.out.persistence.entity;
+
+import com.venueon.report.domain.model.AdminAction;
+import com.venueon.report.domain.model.ReportStatus;
+import com.venueon.report.domain.model.ReportTargetType;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reports")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReportJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private UserJpaEntity reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private ReportTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @Column(columnDefinition = "TEXT", length = 300)
+    private String detail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ReportStatus status = ReportStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "admin_action")
+    private AdminAction adminAction;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+}

--- a/backend/src/main/java/com/venueon/report/adapter/out/persistence/repository/RefundJpaRepository.java
+++ b/backend/src/main/java/com/venueon/report/adapter/out/persistence/repository/RefundJpaRepository.java
@@ -1,0 +1,20 @@
+package com.venueon.report.adapter.out.persistence.repository;
+
+import com.venueon.report.adapter.out.persistence.entity.RefundJpaEntity;
+import com.venueon.report.domain.model.RefundStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefundJpaRepository extends JpaRepository<RefundJpaEntity, Long> {
+
+    Page<RefundJpaEntity> findByStatus(RefundStatus status, Pageable pageable);
+
+    Page<RefundJpaEntity> findAllByOrderByRequestedAtDesc(Pageable pageable);
+
+    Optional<RefundJpaEntity> findByOrderId(Long orderId);
+
+    long countByStatus(RefundStatus status);
+}

--- a/backend/src/main/java/com/venueon/report/adapter/out/persistence/repository/ReportJpaRepository.java
+++ b/backend/src/main/java/com/venueon/report/adapter/out/persistence/repository/ReportJpaRepository.java
@@ -1,0 +1,21 @@
+package com.venueon.report.adapter.out.persistence.repository;
+
+import com.venueon.report.adapter.out.persistence.entity.ReportJpaEntity;
+import com.venueon.report.domain.model.ReportStatus;
+import com.venueon.report.domain.model.ReportTargetType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportJpaRepository extends JpaRepository<ReportJpaEntity, Long> {
+
+    Page<ReportJpaEntity> findByReporterId(Long reporterId, Pageable pageable);
+
+    Page<ReportJpaEntity> findByStatus(ReportStatus status, Pageable pageable);
+
+    Page<ReportJpaEntity> findByTargetTypeAndStatus(ReportTargetType targetType, ReportStatus status, Pageable pageable);
+
+    Page<ReportJpaEntity> findByTargetType(ReportTargetType targetType, Pageable pageable);
+
+    long countByStatus(ReportStatus status);
+}

--- a/backend/src/main/java/com/venueon/report/domain/model/AdminAction.java
+++ b/backend/src/main/java/com/venueon/report/domain/model/AdminAction.java
@@ -1,0 +1,8 @@
+package com.venueon.report.domain.model;
+
+/**
+ * 관리자 신고 처리 액션 enum
+ */
+public enum AdminAction {
+    DELETE, HIDE, WARN, DISMISS
+}

--- a/backend/src/main/java/com/venueon/report/domain/model/RefundStatus.java
+++ b/backend/src/main/java/com/venueon/report/domain/model/RefundStatus.java
@@ -1,0 +1,8 @@
+package com.venueon.report.domain.model;
+
+/**
+ * 환불 처리 상태 enum
+ */
+public enum RefundStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/backend/src/main/java/com/venueon/report/domain/model/ReportStatus.java
+++ b/backend/src/main/java/com/venueon/report/domain/model/ReportStatus.java
@@ -1,0 +1,8 @@
+package com.venueon.report.domain.model;
+
+/**
+ * 신고 처리 상태 enum
+ */
+public enum ReportStatus {
+    PENDING, RESOLVED, REJECTED
+}

--- a/backend/src/main/java/com/venueon/report/domain/model/ReportTargetType.java
+++ b/backend/src/main/java/com/venueon/report/domain/model/ReportTargetType.java
@@ -1,0 +1,8 @@
+package com.venueon.report.domain.model;
+
+/**
+ * 신고 대상 유형 enum
+ */
+public enum ReportTargetType {
+    EVENT, POST, COMMENT, USER
+}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
@@ -47,6 +47,10 @@ public class UserJpaEntity {
     @Column(name = "org_description", length = 1000)
     private String orgDescription;
 
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private boolean isActive = true;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;


### PR DESCRIPTION
Resolves #99

## 수정 내용
- ReportJpaEntity (신고), RefundJpaEntity (환불) 엔티티 추가
- ReportTargetType, ReportStatus, AdminAction, RefundStatus Enum 추가
- EventJpaEntity, PostJpaEntity, CommentJpaEntity에 `is_hidden` 필드 추가
- OrderJpaEntity에 `quantity`, `payment_method` 추가
- UserJpaEntity에 `is_active` 추가
- DataInitializer에 주문(6건), 신고(4건), 환불(2건) 더미 데이터 추가