### PR TITLE
Feat:외부 이미지 저장소(dist/upload) 정적 리소스 서빙 설정

### DIFF
--- a/backend/src/main/java/com/venueon/common/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/WebMvcConfig.java
@@ -1,0 +1,36 @@
+package com.venueon.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * /upload/** 요청을 file.upload-dir 디렉토리의 정적 파일로 매핑합니다.
+ * 예) GET /upload/test.png → {upload-dir}/test.png
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+
+        // ~ (틸다)를 실제 홈 디렉토리로 치환
+        String resolved = uploadDir.startsWith("~")
+                ? System.getProperty("user.home") + uploadDir.substring(1)
+                : uploadDir;
+
+        // 절대 경로로 정규화 + 끝에 / 보장
+        Path absolutePath = Paths.get(resolved).toAbsolutePath().normalize();
+        String location = "file:" + absolutePath + "/";
+
+        registry.addResourceHandler("/upload/**")
+                .addResourceLocations(location);
+    }
+}


### PR DESCRIPTION
🛠️ 주요 변경 사항
WebMvcConfig.java 신규 생성
/upload/** 패턴의 URL 요청을 실제 물리적 디렉토리 경로와 매핑했습니다.
경로 유연성 확보 (Path Resolution)
로컬 환경에서 주로 사용하는 틸다(~) 기호를 Java 시스템 프로퍼티(user.home)를 이용해 실제 절대 경로로 치환되도록 로직을 구현했습니다.

배포 환경(Docker)과 로컬 환경(Windows/Linux) 모두에서 문제없이 경로를 인식합니다.

✅ 테스트 결과
환경: 로컬 개발 환경 (WSL2/Linux)
파일 위치: ~/dist/upload/artspace-seoul.png
테스트 URL: http://localhost:8080/upload/artspace-seoul.png
검증 내용:
HTTP Status: 200 OK 확인
Content-Type: image/png 확인
이미지 바이너리 데이터가 정상적으로 브라우저 및 API 도구(curl)에서 수신됨을 확인

🚀 비고
현재 별도의 CRUD(업로드 기능)는 구현되지 않은 상태이며, 기존에 dist/upload에 존재하는 이미지를 URL로 불러오는 기능이 우선적으로 연결되었음을 확인했습니다.
배포 서버의 경우 ~/dist/upload 폴더에 대한 쓰기 권한 설정을 완료하여 이미지 파일이 정상적으로 서빙될 준비가 되었습니다.