### PR TITLE
[VO-602] A-011: 호스트 전용 회원가입 FE/BE 구현 및 HostProfile 도메인 분리

### DIFF
--- a/backend/src/main/java/com/venueon/common/config/DataInitializer.java
+++ b/backend/src/main/java/com/venueon/common/config/DataInitializer.java
@@ -17,7 +17,9 @@ import com.venueon.report.domain.model.AdminAction;
 import com.venueon.report.domain.model.RefundStatus;
 import com.venueon.report.domain.model.ReportStatus;
 import com.venueon.report.domain.model.ReportTargetType;
+import com.venueon.user.adapter.out.persistence.entity.HostProfileJpaEntity;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.HostProfileJpaRepository;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
 import com.venueon.user.domain.model.UserRole;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ import java.util.List;
 public class DataInitializer implements ApplicationRunner {
 
     private final UserJpaRepository userRepository;
+    private final HostProfileJpaRepository hostProfileRepository;
     private final CategoryJpaRepository categoryRepository;
     private final EventJpaRepository eventRepository;
     private final OrderJpaRepository orderRepository;
@@ -106,118 +109,69 @@ public class DataInitializer implements ApplicationRunner {
     private List<UserJpaEntity> createHosts() {
         String encodedPassword = passwordEncoder.encode("Host1234!");
 
-        return userRepository.saveAll(List.of(
-                UserJpaEntity.builder()
-                        .email("contact@nextcode.kr")
+        // 호스트 정보 배열 (User + HostProfile 데이터)
+        record HostData(String email, String nickname, String profileImg, String phone,
+                        String orgName, String orgNumber, String managerName, String orgDescription) {}
+
+        List<HostData> hostDataList = List.of(
+                new HostData("contact@nextcode.kr", "NextCode", "nextcode.png", "02-1234-5678",
+                        "넥스트코드", "123-45-67890", "김개발",
+                        "AI와 클라우드 기술 전문 교육 기업. 현직 개발자가 이끄는 실무 중심 코딩 부트캠프와 기술 세미나를 운영합니다."),
+                new HostData("hello@designbridge.co.kr", "DesignBridge", "designbridge.png", "02-2345-6789",
+                        "디자인브릿지", "234-56-78901", "이디자인",
+                        "UX/UI 디자인 전문 에이전시. 실무 프로젝트 기반의 디자인 워크숍과 포트폴리오 클래스를 제공합니다."),
+                new HostData("info@sparkventures.io", "SparkVentures", "sparkventures.png", "02-3456-7890",
+                        "스파크벤처스", "345-67-89012", "박벤처",
+                        "초기 스타트업을 위한 액셀러레이터. 투자 유치 전략, 비즈니스 모델 설계, 네트워킹 이벤트를 정기적으로 개최합니다."),
+                new HostData("wellness@greenlife.kr", "GreenLifeAcademy", "greenlife-academy.png", "02-4567-8901",
+                        "그린라이프 아카데미", "456-78-90123", "최건강",
+                        "건강한 라이프스타일을 위한 웰니스 교육 플랫폼. 요가, 명상, 영양학 클래스와 건강 세미나를 운영합니다."),
+                new HostData("art@artspaceseoul.com", "ArtSpaceSeoul", "artspace-seoul.png", "02-5678-9012",
+                        "아트스페이스 서울", "567-89-01234", "정예술",
+                        "서울 성수동 소재 복합 문화 공간. 전시, 공연, 아트 워크숍 등 다양한 문화 이벤트를 기획하고 운영합니다."),
+                new HostData("consulting@bizon.co.kr", "BizOnConsulting", "bizon-consulting.png", "02-6789-0123",
+                        "비즈온 컨설팅", "678-90-12345", "강전략",
+                        "기업 성장 전략 전문 컨설팅 펌. 리더십, 마케팅, 데이터 기반 의사결정 등 비즈니스 컨퍼런스와 세미나를 개최합니다."),
+                new HostData("chef@foodlabseoul.kr", "FoodLabSeoul", "foodlab-seoul.png", "02-7890-1234",
+                        "푸드랩 서울", "789-01-23456", "한요리",
+                        "셰프와 미식가를 위한 쿠킹 스튜디오. 한식, 양식, 베이킹 클래스와 푸드 네트워킹 밋업을 정기적으로 운영합니다."),
+                new HostData("invest@moneyflow.co.kr", "MoneyFlow", "moneyflow.png", "02-8901-2345",
+                        "머니플로우", "890-12-34567", "윤재테크",
+                        "개인 투자자와 금융 전문가를 연결하는 핀테크 교육 플랫폼. 주식, 부동산, 가상자산 세미나와 재테크 컨퍼런스를 개최합니다."),
+                new HostData("hello@creatorshub.kr", "CreatorsHub", "creators-hub.png", "02-9012-3456",
+                        "크리에이터즈 허브", "901-23-45678", "신미디어",
+                        "유튜버, 인플루언서, 콘텐츠 크리에이터를 위한 미디어 교육 기관. 영상 편집, SNS 마케팅, 브랜딩 클래스를 운영합니다."),
+                new HostData("forum@seoulscience.org", "SeoulScienceForum", "seoul-science-forum.png", "02-0123-4567",
+                        "서울사이언스포럼", "012-34-56789", "조과학",
+                        "과학 기술 대중화를 위한 비영리 학술 단체. 최신 연구 동향 발표, 과학 강연, 학술 컨퍼런스를 주최합니다.")
+        );
+
+        // 1) User 엔티티 저장
+        List<UserJpaEntity> hostUsers = userRepository.saveAll(
+                hostDataList.stream().map(d -> UserJpaEntity.builder()
+                        .email(d.email())
                         .password(encodedPassword)
-                        .nickname("NextCode")
+                        .nickname(d.nickname())
                         .role(UserRole.HOST)
-                        .profileImg("nextcode.png")
-                        .phone("02-1234-5678")
-                        .orgName("넥스트코드")
-                        .orgNumber("123-45-67890")
-                        .orgDescription("AI와 클라우드 기술 전문 교육 기업. 현직 개발자가 이끄는 실무 중심 코딩 부트캠프와 기술 세미나를 운영합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("hello@designbridge.co.kr")
-                        .password(encodedPassword)
-                        .nickname("DesignBridge")
-                        .role(UserRole.HOST)
-                        .profileImg("designbridge.png")
-                        .phone("02-2345-6789")
-                        .orgName("디자인브릿지")
-                        .orgNumber("234-56-78901")
-                        .orgDescription("UX/UI 디자인 전문 에이전시. 실무 프로젝트 기반의 디자인 워크숍과 포트폴리오 클래스를 제공합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("info@sparkventures.io")
-                        .password(encodedPassword)
-                        .nickname("SparkVentures")
-                        .role(UserRole.HOST)
-                        .profileImg("sparkventures.png")
-                        .phone("02-3456-7890")
-                        .orgName("스파크벤처스")
-                        .orgNumber("345-67-89012")
-                        .orgDescription("초기 스타트업을 위한 액셀러레이터. 투자 유치 전략, 비즈니스 모델 설계, 네트워킹 이벤트를 정기적으로 개최합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("wellness@greenlife.kr")
-                        .password(encodedPassword)
-                        .nickname("GreenLifeAcademy")
-                        .role(UserRole.HOST)
-                        .profileImg("greenlife-academy.png")
-                        .phone("02-4567-8901")
-                        .orgName("그린라이프 아카데미")
-                        .orgNumber("456-78-90123")
-                        .orgDescription("건강한 라이프스타일을 위한 웰니스 교육 플랫폼. 요가, 명상, 영양학 클래스와 건강 세미나를 운영합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("art@artspaceseoul.com")
-                        .password(encodedPassword)
-                        .nickname("ArtSpaceSeoul")
-                        .role(UserRole.HOST)
-                        .profileImg("artspace-seoul.png")
-                        .phone("02-5678-9012")
-                        .orgName("아트스페이스 서울")
-                        .orgNumber("567-89-01234")
-                        .orgDescription("서울 성수동 소재 복합 문화 공간. 전시, 공연, 아트 워크숍 등 다양한 문화 이벤트를 기획하고 운영합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("consulting@bizon.co.kr")
-                        .password(encodedPassword)
-                        .nickname("BizOnConsulting")
-                        .role(UserRole.HOST)
-                        .profileImg("bizon-consulting.png")
-                        .phone("02-6789-0123")
-                        .orgName("비즈온 컨설팅")
-                        .orgNumber("678-90-12345")
-                        .orgDescription("기업 성장 전략 전문 컨설팅 펌. 리더십, 마케팅, 데이터 기반 의사결정 등 비즈니스 컨퍼런스와 세미나를 개최합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("chef@foodlabseoul.kr")
-                        .password(encodedPassword)
-                        .nickname("FoodLabSeoul")
-                        .role(UserRole.HOST)
-                        .profileImg("foodlab-seoul.png")
-                        .phone("02-7890-1234")
-                        .orgName("푸드랩 서울")
-                        .orgNumber("789-01-23456")
-                        .orgDescription("셰프와 미식가를 위한 쿠킹 스튜디오. 한식, 양식, 베이킹 클래스와 푸드 네트워킹 밋업을 정기적으로 운영합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("invest@moneyflow.co.kr")
-                        .password(encodedPassword)
-                        .nickname("MoneyFlow")
-                        .role(UserRole.HOST)
-                        .profileImg("moneyflow.png")
-                        .phone("02-8901-2345")
-                        .orgName("머니플로우")
-                        .orgNumber("890-12-34567")
-                        .orgDescription("개인 투자자와 금융 전문가를 연결하는 핀테크 교육 플랫폼. 주식, 부동산, 가상자산 세미나와 재테크 컨퍼런스를 개최합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("hello@creatorshub.kr")
-                        .password(encodedPassword)
-                        .nickname("CreatorsHub")
-                        .role(UserRole.HOST)
-                        .profileImg("creators-hub.png")
-                        .phone("02-9012-3456")
-                        .orgName("크리에이터즈 허브")
-                        .orgNumber("901-23-45678")
-                        .orgDescription("유튜버, 인플루언서, 콘텐츠 크리에이터를 위한 미디어 교육 기관. 영상 편집, SNS 마케팅, 브랜딩 클래스를 운영합니다.")
-                        .build(),
-                UserJpaEntity.builder()
-                        .email("forum@seoulscience.org")
-                        .password(encodedPassword)
-                        .nickname("SeoulScienceForum")
-                        .role(UserRole.HOST)
-                        .profileImg("seoul-science-forum.png")
-                        .phone("02-0123-4567")
-                        .orgName("서울사이언스포럼")
-                        .orgNumber("012-34-56789")
-                        .orgDescription("과학 기술 대중화를 위한 비영리 학술 단체. 최신 연구 동향 발표, 과학 강연, 학술 컨퍼런스를 주최합니다.")
+                        .profileImg(d.profileImg())
+                        .phone(d.phone())
                         .build()
-        ));
+                ).toList()
+        );
+
+        // 2) HostProfile 엔티티 저장
+        for (int i = 0; i < hostUsers.size(); i++) {
+            HostData d = hostDataList.get(i);
+            hostProfileRepository.save(HostProfileJpaEntity.builder()
+                    .user(hostUsers.get(i))
+                    .orgName(d.orgName())
+                    .orgNumber(d.orgNumber())
+                    .managerName(d.managerName())
+                    .orgDescription(d.orgDescription())
+                    .build());
+        }
+
+        return hostUsers;
     }
 
     private List<CategoryJpaEntity> createCategories() {

--- a/backend/src/main/java/com/venueon/common/config/DevDataController.java
+++ b/backend/src/main/java/com/venueon/common/config/DevDataController.java
@@ -42,7 +42,6 @@ public class DevDataController {
                     map.put("email", u.getEmail());
                     map.put("nickname", u.getNickname());
                     map.put("role", u.getRole().name());
-                    map.put("orgName", u.getOrgName());
                     return map;
                 }).collect(Collectors.toList());
 

--- a/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 // 인증 불필요 경로
-                .requestMatchers("/auth/signup", "/auth/login").permitAll()
+                .requestMatchers("/auth/signup", "/auth/host/signup", "/auth/login").permitAll()
                 // Swagger UI
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 // Actuator

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -3,6 +3,7 @@ package com.venueon.user.adapter.in.web;
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.user.adapter.in.web.dto.*;
 import com.venueon.user.application.port.in.GetUserInfoUseCase;
+import com.venueon.user.application.port.in.HostSignUpUseCase;
 import com.venueon.user.application.port.in.LoginUseCase;
 import com.venueon.user.application.port.in.SignUpUseCase;
 import com.venueon.user.domain.model.User;
@@ -15,7 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * /auth/signup, /auth/login, /auth/me 엔드포인트
+ * /auth/signup, /auth/host/signup, /auth/login, /auth/me 엔드포인트
  */
 @Slf4j
 @RestController
@@ -24,11 +25,12 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final SignUpUseCase signUpUseCase;
+    private final HostSignUpUseCase hostSignUpUseCase;
     private final LoginUseCase loginUseCase;
     private final GetUserInfoUseCase getUserInfoUseCase;
 
     /**
-     * POST /auth/signup — 회원가입
+     * POST /auth/signup — 일반 회원가입
      */
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserInfoResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
@@ -39,6 +41,32 @@ public class AuthController {
                 request.password(),
                 request.nickname(),
                 request.role()
+        );
+
+        UserInfoResponse response = new UserInfoResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole().name()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * POST /auth/host/signup — 호스트 회원가입
+     */
+    @PostMapping("/host/signup")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> hostSignUp(@Valid @RequestBody HostSignUpRequest request) {
+        log.debug("호스트 회원가입 요청: email={}, orgName={}", request.email(), request.orgName());
+
+        User user = hostSignUpUseCase.hostSignUp(
+                request.email(),
+                request.password(),
+                request.managerName(),
+                request.orgName(),
+                request.orgNumber(),
+                request.orgDescription()
         );
 
         UserInfoResponse response = new UserInfoResponse(

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/HostSignUpRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/HostSignUpRequest.java
@@ -1,0 +1,29 @@
+package com.venueon.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 호스트 회원가입 요청 DTO
+ */
+public record HostSignUpRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "담당자명은 필수입니다.")
+        String managerName,
+
+        @NotBlank(message = "기관명은 필수입니다.")
+        String orgName,
+
+        @NotBlank(message = "사업자등록번호는 필수입니다.")
+        String orgNumber,
+
+        String orgDescription
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/HostProfilePersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/HostProfilePersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.venueon.user.adapter.out.persistence;
+
+import com.venueon.user.adapter.out.persistence.entity.HostProfileJpaEntity;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.HostProfileJpaRepository;
+import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import com.venueon.user.application.port.out.HostProfileRepositoryPort;
+import com.venueon.user.domain.model.HostProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * HostProfileRepositoryPort 구현체 — JPA 연동
+ */
+@Component
+@RequiredArgsConstructor
+public class HostProfilePersistenceAdapter implements HostProfileRepositoryPort {
+
+    private final HostProfileJpaRepository hostProfileJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public HostProfile save(HostProfile hostProfile) {
+        UserJpaEntity userEntity = userJpaRepository.findById(hostProfile.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + hostProfile.getUserId()));
+
+        HostProfileJpaEntity entity = HostProfileJpaEntity.builder()
+                .id(hostProfile.getId())
+                .user(userEntity)
+                .orgName(hostProfile.getOrgName())
+                .orgNumber(hostProfile.getOrgNumber())
+                .managerName(hostProfile.getManagerName())
+                .orgDescription(hostProfile.getOrgDescription())
+                .build();
+
+        HostProfileJpaEntity saved = hostProfileJpaRepository.save(entity);
+
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<HostProfile> findByUserId(Long userId) {
+        return hostProfileJpaRepository.findByUserId(userId)
+                .map(this::toDomain);
+    }
+
+    private HostProfile toDomain(HostProfileJpaEntity entity) {
+        return new HostProfile(
+                entity.getId(),
+                entity.getUser().getId(),
+                entity.getOrgName(),
+                entity.getOrgNumber(),
+                entity.getManagerName(),
+                entity.getOrgDescription(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
@@ -22,9 +22,6 @@ public class UserMapper {
                 .role(user.getRole())
                 .profileImg(user.getProfileImg())
                 .phone(user.getPhone())
-                .orgName(user.getOrgName())
-                .orgNumber(user.getOrgNumber())
-                .orgDescription(user.getOrgDescription())
                 .build();
     }
 
@@ -40,11 +37,9 @@ public class UserMapper {
                 entity.getRole(),
                 entity.getProfileImg(),
                 entity.getPhone(),
-                entity.getOrgName(),
-                entity.getOrgNumber(),
-                entity.getOrgDescription(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt()
         );
     }
 }
+

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/HostProfileJpaEntity.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/HostProfileJpaEntity.java
@@ -1,6 +1,5 @@
 package com.venueon.user.adapter.out.persistence.entity;
 
-import com.venueon.user.domain.model.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -9,38 +8,32 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users")
+@Table(name = "host_profiles")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserJpaEntity {
+public class HostProfileJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private UserJpaEntity user;
 
-    @Column(nullable = false)
-    private String password;
+    @Column(name = "org_name", nullable = false)
+    private String orgName;
 
-    @Column(nullable = false)
-    private String nickname;
+    @Column(name = "org_number", nullable = false)
+    private String orgNumber;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private UserRole role;
+    @Column(name = "manager_name")
+    private String managerName;
 
-    @Column(name = "profile_img")
-    private String profileImg;
-
-    private String phone;
-
-    @Column(name = "is_active", nullable = false)
-    @Builder.Default
-    private boolean isActive = true;
+    @Column(name = "org_description", length = 1000)
+    private String orgDescription;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -50,4 +43,3 @@ public class UserJpaEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }
-

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/repository/HostProfileJpaRepository.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/repository/HostProfileJpaRepository.java
@@ -1,0 +1,11 @@
+package com.venueon.user.adapter.out.persistence.repository;
+
+import com.venueon.user.adapter.out.persistence.entity.HostProfileJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HostProfileJpaRepository extends JpaRepository<HostProfileJpaEntity, Long> {
+
+    Optional<HostProfileJpaEntity> findByUserId(Long userId);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/HostSignUpUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/HostSignUpUseCase.java
@@ -1,0 +1,12 @@
+package com.venueon.user.application.port.in;
+
+import com.venueon.user.domain.model.User;
+
+/**
+ * 호스트 회원가입 유스케이스 (Port-In)
+ */
+public interface HostSignUpUseCase {
+
+    User hostSignUp(String email, String password, String managerName,
+                    String orgName, String orgNumber, String orgDescription);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/out/HostProfileRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/user/application/port/out/HostProfileRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.venueon.user.application.port.out;
+
+import com.venueon.user.domain.model.HostProfile;
+
+import java.util.Optional;
+
+/**
+ * 호스트 프로필 저장/조회 인터페이스 (Port-Out)
+ */
+public interface HostProfileRepositoryPort {
+
+    HostProfile save(HostProfile hostProfile);
+
+    Optional<HostProfile> findByUserId(Long userId);
+}

--- a/backend/src/main/java/com/venueon/user/application/service/AuthService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/AuthService.java
@@ -5,9 +5,12 @@ import com.venueon.common.exception.BusinessException;
 import com.venueon.common.exception.ErrorCode;
 import com.venueon.user.adapter.in.security.JwtTokenProvider;
 import com.venueon.user.application.port.in.GetUserInfoUseCase;
+import com.venueon.user.application.port.in.HostSignUpUseCase;
 import com.venueon.user.application.port.in.LoginUseCase;
 import com.venueon.user.application.port.in.SignUpUseCase;
+import com.venueon.user.application.port.out.HostProfileRepositoryPort;
 import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.HostProfile;
 import com.venueon.user.domain.model.User;
 import com.venueon.user.domain.model.UserRole;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +22,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * - BCrypt 비밀번호 암호화
  * - 이메일 중복 체크
  * - JWT 발급 위임
+ * - 호스트 가입 시 HostProfile 분리 저장
  */
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
-public class AuthService implements SignUpUseCase, LoginUseCase, GetUserInfoUseCase {
+public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCase, GetUserInfoUseCase {
 
     private final UserRepositoryPort userRepositoryPort;
+    private final HostProfileRepositoryPort hostProfileRepositoryPort;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -51,10 +56,39 @@ public class AuthService implements SignUpUseCase, LoginUseCase, GetUserInfoUseC
 
         // 도메인 모델 생성 및 저장
         User user = new User(null, email, encodedPassword, nickname, userRole,
-                null, null, null, null, null, null, null);
+                null, null, null, null);
         User savedUser = userRepositoryPort.save(user);
 
         log.info("회원가입 완료: email={}, role={}", email, userRole);
+        return savedUser;
+    }
+
+    @Override
+    public User hostSignUp(String email, String password, String managerName,
+                           String orgName, String orgNumber, String orgDescription) {
+        log.debug("호스트 회원가입 시도: email={}", email);
+
+        // 이메일 중복 체크
+        if (userRepositoryPort.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL, "이미 사용 중인 이메일입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // User 저장 (role=HOST)
+        User user = new User(null, email, encodedPassword, managerName, UserRole.HOST,
+                null, null, null, null);
+        User savedUser = userRepositoryPort.save(user);
+
+        // HostProfile 저장
+        HostProfile hostProfile = new HostProfile(
+                null, savedUser.getId(), orgName, orgNumber,
+                managerName, orgDescription, null, null
+        );
+        hostProfileRepositoryPort.save(hostProfile);
+
+        log.info("호스트 회원가입 완료: email={}, orgName={}", email, orgName);
         return savedUser;
     }
 
@@ -84,3 +118,4 @@ public class AuthService implements SignUpUseCase, LoginUseCase, GetUserInfoUseC
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
     }
 }
+

--- a/backend/src/main/java/com/venueon/user/domain/model/HostProfile.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/HostProfile.java
@@ -1,0 +1,54 @@
+package com.venueon.user.domain.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * HostProfile 도메인 모델 (순수 POJO)
+ * 호스트 전용 프로필 정보 — users 테이블과 1:1 관계
+ */
+public class HostProfile {
+
+    private Long id;
+    private Long userId;
+    private String orgName;
+    private String orgNumber;
+    private String managerName;
+    private String orgDescription;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    protected HostProfile() {}
+
+    public HostProfile(Long id, Long userId, String orgName, String orgNumber,
+                       String managerName, String orgDescription,
+                       LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.orgName = orgName;
+        this.orgNumber = orgNumber;
+        this.managerName = managerName;
+        this.orgDescription = orgDescription;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // --- 비즈니스 행위 ---
+
+    public void updateProfile(String orgName, String orgDescription, String managerName) {
+        this.orgName = orgName;
+        this.orgDescription = orgDescription;
+        this.managerName = managerName;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // --- Getters ---
+
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public String getOrgName() { return orgName; }
+    public String getOrgNumber() { return orgNumber; }
+    public String getManagerName() { return managerName; }
+    public String getOrgDescription() { return orgDescription; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/venueon/user/domain/model/User.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/User.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 /**
  * User 도메인 모델 (순수 POJO)
  * JPA/Spring 의존 없음 — 비즈니스 로직만 포함
+ * 호스트 전용 프로필 정보는 HostProfile 도메인에서 관리
  */
 public class User {
 
@@ -15,9 +16,6 @@ public class User {
     private UserRole role;
     private String profileImg;
     private String phone;
-    private String orgName;
-    private String orgNumber;
-    private String orgDescription;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -26,8 +24,8 @@ public class User {
 
     // 전체 필드 생성자
     public User(Long id, String email, String password, String nickname, UserRole role,
-                String profileImg, String phone, String orgName, String orgNumber,
-                String orgDescription, LocalDateTime createdAt, LocalDateTime updatedAt) {
+                String profileImg, String phone,
+                LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -35,9 +33,6 @@ public class User {
         this.role = role;
         this.profileImg = profileImg;
         this.phone = phone;
-        this.orgName = orgName;
-        this.orgNumber = orgNumber;
-        this.orgDescription = orgDescription;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -58,16 +53,6 @@ public class User {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateHostProfile(String orgName, String orgDescription, String phone) {
-        if (!isHost()) {
-            throw new IllegalStateException("HOST 역할만 기업 프로필을 수정할 수 있습니다.");
-        }
-        this.orgName = orgName;
-        this.orgDescription = orgDescription;
-        this.phone = phone;
-        this.updatedAt = LocalDateTime.now();
-    }
-
     // --- Getters ---
 
     public Long getId() { return id; }
@@ -77,9 +62,7 @@ public class User {
     public UserRole getRole() { return role; }
     public String getProfileImg() { return profileImg; }
     public String getPhone() { return phone; }
-    public String getOrgName() { return orgName; }
-    public String getOrgNumber() { return orgNumber; }
-    public String getOrgDescription() { return orgDescription; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
 }
+

--- a/frontend/src/app/(auth)/_components/AuthFormLayout.tsx
+++ b/frontend/src/app/(auth)/_components/AuthFormLayout.tsx
@@ -14,6 +14,9 @@ interface AuthFormLayoutProps {
   footerText: string;
   footerLinkText: string;
   footerLinkHref: string;
+  secondaryFooterText?: string;
+  secondaryFooterLinkText?: string;
+  secondaryFooterLinkHref?: string;
 }
 
 export default function AuthFormLayout({
@@ -27,6 +30,9 @@ export default function AuthFormLayout({
   footerText,
   footerLinkText,
   footerLinkHref,
+  secondaryFooterText,
+  secondaryFooterLinkText,
+  secondaryFooterLinkHref,
 }: AuthFormLayoutProps) {
   return (
     <div className={styles.container}>
@@ -48,6 +54,16 @@ export default function AuthFormLayout({
           {footerLinkText}
         </Link>
       </div>
+
+      {secondaryFooterText && secondaryFooterLinkText && secondaryFooterLinkHref && (
+        <div className={styles.footer} style={{ marginTop: '8px' }}>
+          {secondaryFooterText}{" "}
+          <Link href={secondaryFooterLinkHref} className={styles.link}>
+            {secondaryFooterLinkText}
+          </Link>
+        </div>
+      )}
     </div>
   );
 }
+

--- a/frontend/src/app/(auth)/host-signup/_components/HostAgreementSection/HostAgreementSection.module.css
+++ b/frontend/src/app/(auth)/host-signup/_components/HostAgreementSection/HostAgreementSection.module.css
@@ -1,0 +1,67 @@
+.agreementSection {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+  border: 1px solid var(--color-text-gray-300);
+  border-radius: var(--radius-md);
+  padding: 16px;
+}
+
+.allAgree {
+  padding: 14px 16px;
+  background-color: #f1f3f5;
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+  transition: background-color 0.2s ease;
+  cursor: pointer;
+}
+
+.allAgree:hover {
+  background-color: #e9ecef;
+}
+
+.allAgreeLabel {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--color-text);
+}
+
+.agreementList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 0 8px;
+}
+
+.agreementItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.itemLabel {
+  font-size: 14px;
+  color: var(--color-text-gray-700);
+}
+
+.requiredBadge {
+  font-size: 13px;
+  color: var(--color-primary);
+  font-weight: 600;
+  margin-left: 4px;
+}
+
+.viewLink {
+  font-size: 13px;
+  color: var(--color-text-gray-400);
+  text-decoration: underline;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: 12px;
+  background: none;
+  border: none;
+}
+
+.viewLink:hover {
+  color: var(--color-text-gray-700);
+}

--- a/frontend/src/app/(auth)/host-signup/_components/HostAgreementSection/HostAgreementSection.tsx
+++ b/frontend/src/app/(auth)/host-signup/_components/HostAgreementSection/HostAgreementSection.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React, { useState } from "react";
+import Checkbox from "@/components/ui/Checkbox";
+import HostTermsModal, { HostTermType } from "../HostTermsModal/HostTermsModal";
+import styles from "./HostAgreementSection.module.css";
+
+export interface HostAgreementState {
+  termsOfService: boolean;   // [필수] 이용약관
+  privacyPolicy: boolean;    // [필수] 개인정보 처리방침
+  hostTerms: boolean;        // [필수] 호스트 이용약관
+}
+
+interface HostAgreementSectionProps {
+  agreements: HostAgreementState;
+  onChange: (agreements: HostAgreementState) => void;
+}
+
+/** 호스트 필수 약관이 모두 체크되었는지 확인 */
+export function isHostRequiredAgreed(agreements: HostAgreementState): boolean {
+  return agreements.termsOfService && agreements.privacyPolicy && agreements.hostTerms;
+}
+
+export default function HostAgreementSection({ agreements, onChange }: HostAgreementSectionProps) {
+  const [modalType, setModalType] = useState<HostTermType | null>(null);
+
+  const allChecked = agreements.termsOfService && agreements.privacyPolicy && agreements.hostTerms;
+
+  const handleAllChange = () => {
+    const next = !allChecked;
+    onChange({
+      termsOfService: next,
+      privacyPolicy: next,
+      hostTerms: next,
+    });
+  };
+
+  const handleSingleChange = (key: keyof HostAgreementState) => {
+    onChange({
+      ...agreements,
+      [key]: !agreements[key],
+    });
+  };
+
+  const handleAgreeInModal = (type: HostTermType) => {
+    onChange({
+      ...agreements,
+      [type]: true,
+    });
+    setModalType(null);
+  };
+
+  return (
+    <>
+      <div className={styles.agreementSection}>
+        <div className={styles.allAgree}>
+          <Checkbox
+            checked={allChecked}
+            onChange={handleAllChange}
+            label={<span className={styles.allAgreeLabel}>전체 약관 동의</span>}
+          />
+        </div>
+
+        <div className={styles.agreementList}>
+          <div className={styles.agreementItem}>
+            <Checkbox
+              checked={agreements.termsOfService}
+              onChange={() => handleSingleChange("termsOfService")}
+              label={
+                <span className={styles.itemLabel}>
+                  이용약관 동의
+                  <span className={styles.requiredBadge}>(필수)</span>
+                </span>
+              }
+            />
+            <button
+              type="button"
+              className={styles.viewLink}
+              onClick={() => setModalType("termsOfService")}
+            >
+              보기
+            </button>
+          </div>
+
+          <div className={styles.agreementItem}>
+            <Checkbox
+              checked={agreements.privacyPolicy}
+              onChange={() => handleSingleChange("privacyPolicy")}
+              label={
+                <span className={styles.itemLabel}>
+                  개인정보 처리방침 동의
+                  <span className={styles.requiredBadge}>(필수)</span>
+                </span>
+              }
+            />
+            <button
+              type="button"
+              className={styles.viewLink}
+              onClick={() => setModalType("privacyPolicy")}
+            >
+              보기
+            </button>
+          </div>
+
+          <div className={styles.agreementItem}>
+            <Checkbox
+              checked={agreements.hostTerms}
+              onChange={() => handleSingleChange("hostTerms")}
+              label={
+                <span className={styles.itemLabel}>
+                  호스트 이용약관 동의
+                  <span className={styles.requiredBadge}>(필수)</span>
+                </span>
+              }
+            />
+            <button
+              type="button"
+              className={styles.viewLink}
+              onClick={() => setModalType("hostTerms")}
+            >
+              보기
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <HostTermsModal
+        type={modalType || "termsOfService"}
+        isOpen={modalType !== null}
+        isChecked={modalType ? agreements[modalType] : false}
+        onClose={() => setModalType(null)}
+        onAgree={handleAgreeInModal}
+      />
+    </>
+  );
+}

--- a/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.module.css
+++ b/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.module.css
@@ -1,0 +1,98 @@
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modalContent {
+  background-color: var(--color-bg);
+  border-radius: var(--radius-lg);
+  width: 90%;
+  max-width: 480px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.modalHeader {
+  padding: 24px 24px 20px 24px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modalTitle {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--color-text-gray-400);
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px;
+}
+
+.closeButton:hover {
+  color: var(--color-text);
+}
+
+.modalBody {
+  padding: 24px;
+  overflow-y: auto;
+  font-size: 14px;
+  line-height: 1.8;
+  color: var(--color-text-gray-700);
+  background-color: var(--color-surface);
+}
+
+.modalFooter {
+  padding: 20px 24px;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+  display: flex;
+  align-items: center;
+}
+
+.termSection {
+  margin-bottom: 24px;
+}
+
+.termSection:last-child {
+  margin-bottom: 0;
+}
+
+.termHeading {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.termParagraph {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.termParagraph:last-child {
+  margin-bottom: 0;
+}
+
+.footerLabel {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--color-text);
+}

--- a/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.tsx
+++ b/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import Checkbox from "@/components/ui/Checkbox";
+import styles from "./HostTermsModal.module.css";
+
+export type HostTermType = "termsOfService" | "privacyPolicy" | "hostTerms";
+
+interface HostTermsModalProps {
+  type: HostTermType;
+  isOpen: boolean;
+  isChecked: boolean;
+  onClose: () => void;
+  onAgree: (type: HostTermType) => void;
+}
+
+const TERMS_DATA: Record<HostTermType, { title: string; sections: { heading: string; body: string[] }[] }> = {
+  termsOfService: {
+    title: "이용약관 동의",
+    sections: [
+      {
+        heading: "제1조 (목적)",
+        body: [
+          "본 약관은 VenueOn(이하 '회사'라 합니다)가 제공하는 제반 서비스의 이용과 관련하여 회사와 회원과의 권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 합니다."
+        ]
+      },
+      {
+        heading: "제2조 (회원의 의무)",
+        body: [
+          "1. 회원은 회사의 서비스를 이용함에 있어 불법적인 행위를 해서는 안 됩니다.",
+          "2. 다른 회원의 서비스 이용을 방해하거나, 일방적인 혐오 발언 등 운영 원칙에 위배되는 행동을 금지합니다.",
+          "3. 회원은 회원가입 시 허위 정보를 기재해서는 안 되며, 자신의 정보가 변경되었을 경우 즉시 수정해야 합니다."
+        ]
+      },
+      {
+        heading: "제3조 (서비스의 변경 및 중지)",
+        body: [
+          "회사는 서비스 향상을 위해 운영상의 필요에 따라 제공하고 있는 서비스의 퀄리티나 내용을 변경할 수 있으며, 이로 인해 회원에게 발생하는 손해에 대해서는 책임지지 않습니다."
+        ]
+      }
+    ]
+  },
+  privacyPolicy: {
+    title: "개인정보 처리방침 동의",
+    sections: [
+      {
+        heading: "1. 수집하는 개인정보 항목",
+        body: [
+          "회사는 회원가입, 상담, 서비스 신청 등을 위해 아래와 같은 개인정보를 안전하게 수집하고 있습니다.",
+          "- 필수 수집항목: 이메일, 이름, 비밀번호",
+          "- 호스트 추가 수집항목: 기관명, 담당자명, 사업자등록번호, 사업자등록증 이미지",
+          "- 자동 수집항목: IP 주소, 쿠키 등 브라우저 환경 데이터"
+        ]
+      },
+      {
+        heading: "2. 개인정보의 수집 및 이용목적",
+        body: [
+          "회사는 수집한 개인정보를 다음의 핵심 목적을 위해 엄격히 활용합니다.",
+          "- 서비스 제공에 관한 계약 이행 및 요금 정산",
+          "- 회원제 서비스 이용에 따른 본인확인 및 개인 식별",
+          "- 호스트 자격 심사 및 사업자 인증"
+        ]
+      },
+      {
+        heading: "3. 개인정보의 보유 및 이용기간",
+        body: [
+          "원칙적으로 개인정보 수집 및 이용 목적이 달성된 후에는 해당 정보를 지체 없이 안전하게 파기합니다. 단, 관계법령의 규정에 의하여 보존할 필요가 있는 경우 일정 기간 동안 보관합니다."
+        ]
+      }
+    ]
+  },
+  hostTerms: {
+    title: "호스트 이용약관 동의",
+    sections: [
+      {
+        heading: "제1조 (호스트의 정의)",
+        body: [
+          "호스트란 VenueOn 플랫폼을 통해 공연, 전시, 이벤트 등의 행사를 등록하고 티켓을 판매하는 사업자(개인 또는 법인)를 의미합니다."
+        ]
+      },
+      {
+        heading: "제2조 (호스트의 의무)",
+        body: [
+          "1. 호스트는 등록하는 행사 정보가 정확하고 사실에 부합함을 보장해야 합니다.",
+          "2. 행사 취소 또는 변경 시 최소 3일 전에 구매자에게 통보해야 합니다.",
+          "3. 호스트는 관련 법규를 준수하며, 유효한 사업자등록증을 보유해야 합니다.",
+          "4. 허위 행사 등록, 부정 판매 등의 행위가 적발될 경우 즉시 자격이 정지됩니다."
+        ]
+      },
+      {
+        heading: "제3조 (수수료 및 정산)",
+        body: [
+          "1. 회사는 티켓 판매 금액의 일정 비율을 플랫폼 이용 수수료로 차감합니다.",
+          "2. 정산은 행사 종료 후 영업일 기준 7일 이내에 호스트의 등록 계좌로 지급됩니다.",
+          "3. 환불 발생 시 환불 금액 및 관련 수수료는 호스트 부담으로 합니다."
+        ]
+      },
+      {
+        heading: "제4조 (서비스 이용 제한)",
+        body: [
+          "회사는 호스트가 본 약관을 위반하거나, 서비스 운영에 심각한 지장을 초래하는 경우 사전 통보 후 호스트 자격을 일시 정지하거나 해지할 수 있습니다."
+        ]
+      }
+    ]
+  }
+};
+
+export default function HostTermsModal({ type, isOpen, isChecked, onClose, onAgree }: HostTermsModalProps) {
+  if (!isOpen) return null;
+
+  const data = TERMS_DATA[type];
+
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked) {
+      onAgree(type);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h3 className={styles.modalTitle}>{data.title}</h3>
+          <button type="button" className={styles.closeButton} onClick={onClose}>
+            &times;
+          </button>
+        </div>
+
+        <div className={styles.modalBody}>
+          {data.sections.map((section, idx) => (
+            <div key={idx} className={styles.termSection}>
+              <h4 className={styles.termHeading}>{section.heading}</h4>
+              {section.body.map((paragraph, pIdx) => (
+                <p key={pIdx} className={styles.termParagraph}>{paragraph}</p>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.modalFooter}>
+          <Checkbox
+            checked={isChecked}
+            onChange={handleCheckboxChange}
+            label={<span className={styles.footerLabel}>위 약관에 동의합니다.</span>}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/host-signup/page.module.css
+++ b/frontend/src/app/(auth)/host-signup/page.module.css
@@ -1,0 +1,23 @@
+/* 호스트 회원가입 페이지 전용 스타일 */
+
+.sectionDivider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0;
+}
+
+.sectionDivider::before,
+.sectionDivider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background-color: var(--color-border);
+}
+
+.sectionLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}

--- a/frontend/src/app/(auth)/host-signup/page.tsx
+++ b/frontend/src/app/(auth)/host-signup/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { authAPI } from "@/lib/auth-api";
+import { useUIStore } from "@/store/useUIStore";
+import InputField from "@/components/ui/InputField";
+import UploadField from "@/components/ui/UploadField";
+import AuthFormLayout from "../_components/AuthFormLayout";
+import HostAgreementSection, {
+  HostAgreementState,
+  isHostRequiredAgreed,
+} from "./_components/HostAgreementSection/HostAgreementSection";
+import styles from "./page.module.css";
+
+export default function HostSignupPage() {
+  const router = useRouter();
+  const { showToast } = useUIStore();
+
+  // 계정 정보
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  // 호스트 정보
+  const [organizationName, setOrganizationName] = useState("");
+  const [managerName, setManagerName] = useState("");
+  const [businessNumber, setBusinessNumber] = useState("");
+  const [businessLicense, setBusinessLicense] = useState<File | null>(null);
+
+  // 약관 동의
+  const [agreements, setAgreements] = useState<HostAgreementState>({
+    termsOfService: false,
+    privacyPolicy: false,
+    hostTerms: false,
+  });
+
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    // 필수 약관 체크
+    if (!isHostRequiredAgreed(agreements)) {
+      setError("필수 약관에 모두 동의해 주세요.");
+      showToast("필수 약관에 모두 동의해 주세요.", "error");
+      return;
+    }
+
+
+
+    setLoading(true);
+
+    try {
+      if (password !== passwordConfirm) {
+        throw new Error("비밀번호가 일치하지 않습니다.");
+      }
+      if (password.length < 8) {
+        throw new Error("비밀번호는 8자 이상이어야 합니다.");
+      }
+
+      // 호스트 전용 signup API 호출
+      await authAPI.hostSignup({
+        email,
+        password,
+        managerName,
+        orgName: organizationName,
+        orgNumber: businessNumber,
+        orgDescription: "",
+      });
+
+      showToast("호스트 가입 신청이 완료되었습니다.", "success");
+      router.push("/login");
+    } catch (err: any) {
+      const msg = err.message || "호스트 가입에 실패했습니다.";
+      setError(msg);
+      showToast(msg, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthFormLayout
+      title="호스트 회원 가입"
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="호스트 가입 신청"
+      loadingText="신청 처리 중..."
+      error={error}
+      footerText="일반 회원으로 가입하시겠어요?"
+      footerLinkText="일반 회원가입"
+      footerLinkHref="/signup"
+    >
+      {/* ── 계정 정보 ── */}
+      <InputField
+        id="host-email"
+        label="이메일"
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="이메일을 입력하세요."
+      />
+      <InputField
+        id="host-password"
+        label="비밀번호"
+        type="password"
+        required
+        minLength={8}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="********"
+      />
+      <InputField
+        id="host-passwordConfirm"
+        label="비밀번호 확인"
+        type="password"
+        required
+        minLength={8}
+        value={passwordConfirm}
+        onChange={(e) => setPasswordConfirm(e.target.value)}
+        placeholder="********"
+      />
+
+      {/* ── 호스트 정보 구분선 ── */}
+      <div className={styles.sectionDivider}>
+        <span className={styles.sectionLabel}>호스트 정보</span>
+      </div>
+
+      <InputField
+        id="organizationName"
+        label="기관명"
+        type="text"
+        required
+        value={organizationName}
+        onChange={(e) => setOrganizationName(e.target.value)}
+        placeholder="기관명을 입력하세요."
+      />
+      <InputField
+        id="managerName"
+        label="담당자명"
+        type="text"
+        required
+        value={managerName}
+        onChange={(e) => setManagerName(e.target.value)}
+        placeholder="담당자 이름을 입력하세요."
+      />
+      <InputField
+        id="businessNumber"
+        label="사업자등록번호"
+        type="text"
+        required
+        value={businessNumber}
+        onChange={(e) => setBusinessNumber(e.target.value)}
+        placeholder="사업자등록번호를 입력하세요."
+      />
+      <UploadField
+        label="사업자등록증 (선택)"
+        accept="image/*,.pdf"
+        onFileSelect={(file) => setBusinessLicense(file)}
+      />
+
+      {/* ── 약관 동의 ── */}
+      <HostAgreementSection agreements={agreements} onChange={setAgreements} />
+    </AuthFormLayout>
+  );
+}

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -66,6 +66,9 @@ export default function SignupPage() {
       footerText="이미 계정이 있으신가요?"
       footerLinkText="로그인 하기"
       footerLinkHref="/login"
+      secondaryFooterText="호스트로 가입하시겠어요?"
+      secondaryFooterLinkText="호스트 가입"
+      secondaryFooterLinkHref="/host-signup"
     >
       <InputField
         id="email"

--- a/frontend/src/app/api/auth/host/signup/route.ts
+++ b/frontend/src/app/api/auth/host/signup/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+    const res = await fetch(`${API_BASE}/auth/host/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json().catch(() => ({}));
+
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error("Host Signup API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -9,6 +9,16 @@ export const authAPI = {
     if (!res.ok) throw new Error(result.message || result.error || '회원가입 실패');
     return result;
   },
+  hostSignup: async (data: any) => {
+    const res = await fetch('/api/auth/host/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '호스트 가입 실패');
+    return result;
+  },
   login: async (email: string, password: string) => {
     const res = await fetch('/api/auth/login', {
       method: 'POST',


### PR DESCRIPTION
## 📋 관련 티켓
- **VO-602**: A-011 호스트 전용 회원가입
- **VO-603**: A-012 호스트 전용 로그인 (로그인은 기존 엔드포인트 공유, 추후 별도 작업)

---

## ✅ [VO-602] A-011: 호스트 전용 회원가입

### 프론트엔드

#### 호스트 회원가입 페이지 (`/host-signup`)
- 계정 정보: 이메일, 비밀번호, 비밀번호 확인
- 호스트 정보: 기관명, 담당자명, 사업자등록번호(필수), 사업자등록증 업로드(선택)
- 약관 동의: 이용약관 + 개인정보 처리방침 + **호스트 이용약관** (모달 포함)
- 일반 가입 ↔ 호스트 가입 간 상호 링크

#### 컴포넌트 구조
```
(auth)/host-signup/
├── _components/
│   ├── HostAgreementSection/
│   │   ├── HostAgreementSection.tsx
│   │   └── HostAgreementSection.module.css
│   └── HostTermsModal/
│       ├── HostTermsModal.tsx
│       └── HostTermsModal.module.css
├── page.tsx
└── page.module.css
```

#### 기타 프론트엔드 변경
- `AuthFormLayout`에 `secondaryFooter` props 추가 (일반 가입 페이지에서 호스트 가입 링크)
- `auth-api.ts`에 `hostSignup()` 함수 추가
- BFF 프록시 라우트 `/api/auth/host/signup` 추가
- 일반 회원가입 페이지(`/signup`)에 "호스트로 가입하시겠어요?" 안내 링크 추가

---

### 백엔드

#### HostProfile 도메인 분리 (핵심 변경)
- `users` 테이블에서 `org_name`, `org_number`, `org_description` 컬럼 제거
- `host_profiles` 테이블 신규 생성 (users와 1:1 관계)
- `User` 도메인 모델에서 org 필드 제거 → `HostProfile` 도메인 모델로 분리
- 일반 회원 조회 시 `users` 테이블만 조회 (기존과 동일)
- 호스트 정보 필요 시에만 `host_profiles` JOIN

#### 헥사고날 아키텍처 구현
| 계층 | 파일 | 설명 |
|------|------|------|
| Domain | `HostProfile.java` | 호스트 전용 도메인 모델 (순수 POJO) |
| Port-In | `HostSignUpUseCase.java` | 호스트 가입 유스케이스 인터페이스 |
| Port-Out | `HostProfileRepositoryPort.java` | 호스트 프로필 저장/조회 포트 |
| Service | `AuthService.java` | `hostSignUp()` 메서드 추가 |
| Adapter-In | `AuthController.java` | `POST /auth/host/signup` 엔드포인트 |
| Adapter-In | `HostSignUpRequest.java` | 호스트 가입 요청 DTO (validation 포함) |
| Adapter-Out | `HostProfileJpaEntity.java` | JPA 엔티티 (1:1 관계) |
| Adapter-Out | `HostProfileJpaRepository.java` | JPA Repository |
| Adapter-Out | `HostProfilePersistenceAdapter.java` | Port-Out 구현체 |

#### DB 구조 변경
```
users (공통)                     host_profiles (호스트 전용)
───────────────────              ───────────────────────────
id, email, password,             id, user_id(FK), org_name,
nickname, role, phone,           org_number, manager_name,
profile_img, is_active           org_description
created_at, updated_at           created_at, updated_at
```

#### 기타 백엔드 변경
- `UserJpaEntity`: org 컬럼 제거
- `UserMapper`: org 매핑 제거
- `DevDataController`: `orgName` 참조 제거
- `DataInitializer`: Host 생성 시 User 저장 → HostProfile 별도 저장 (2단계)
- `SecurityConfig`: `/auth/host/signup` permitAll 추가

---

## 🔜 [VO-603] A-012: 호스트 전용 로그인
- 로그인 엔드포인트는 일반/호스트 공유 (`POST /auth/login`)
- 로그인 후 `role` 값에 따른 라우팅 분기 (메인 vs 호스트 대시보드)는 별도 작업 예정


[VO-602]: https://venueon.atlassian.net/browse/VO-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VO-603]: https://venueon.atlassian.net/browse/VO-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ