### PR TITLE
feat(VO-813, VO-574): 커뮤니티 UI 컴포넌트 추가 및 기존 컴포넌트 수정

### DIFF
--- a/frontend/src/app/community/components/CommunityCommentItem.module.css
+++ b/frontend/src/app/community/components/CommunityCommentItem.module.css
@@ -1,0 +1,71 @@
+/* src/components/ui/CommunityCommentItem.module.css */
+
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0;
+  gap: var(--space-12);
+  width: 100%;
+
+  background: var(--color-text-gray-50);          /* #F9FAFB */
+  border-radius: var(--radius-lg);                /* 12px */
+}
+
+/* --------- 상단 행 (프로필 + 날짜 + 더보기) --------- */
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-12);
+  align-self: stretch;
+}
+
+.headerLeft {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-12);
+}
+
+/* --------- 날짜 --------- */
+.date {
+  font: var(--text-caption-regular);              /* 400 12px/150% */
+  color: var(--color-text-gray-500);              /* #6B7280 */
+  white-space: nowrap;
+}
+
+/* --------- 더보기 버튼 + 메뉴 wrapper --------- */
+.moreWrapper {
+  position: relative;
+}
+
+.moreButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;   /* 24px */
+  height: 1.5rem;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-gray-500);              /* #6B7280 */
+  padding: 0;
+}
+
+/* --------- 댓글 본문 --------- */
+.content {
+  font: var(--text-body-medium);                  /* 500 14px/150% */
+  color: var(--color-text-gray-900);              /* #111827 */
+  align-self: stretch;
+  margin: 0;
+
+  /* 최대 3줄 말줄임 */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/frontend/src/app/community/components/CommunityCommentItem.tsx
+++ b/frontend/src/app/community/components/CommunityCommentItem.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { useState } from 'react';
+import styles from './CommunityCommentItem.module.css';
+import UserProfile from './UserProfile';
+import PopoverMenu, { PopoverMenuItem } from './PopoverMenu';
+import { MoreIcon } from '@/components/icons';
+
+export interface CommunityCommentItemProps {
+  /** 작성자 이름 */
+  username: string;
+  /** 작성 날짜 (예: "2026.03.30 / 10:35") */
+  date: string;
+  /** 댓글 내용 */
+  content: string;
+  /** 프로필 이미지 URL (없으면 기본 배경색 원) */
+  avatarUrl?: string;
+  /** 더보기 메뉴 항목 목록 */
+  menuItems?: PopoverMenuItem[];
+  /** 더보기 메뉴 항목 선택 시 콜백 */
+  onMenuSelect?: (value: string) => void;
+}
+
+export default function CommunityCommentItem({
+  username,
+  date,
+  content,
+  avatarUrl,
+  menuItems,
+  onMenuSelect,
+}: CommunityCommentItemProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <div className={styles.item}>
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <UserProfile name={username} imageUrl={avatarUrl} size="large" />
+          <span className={styles.date}>{date}</span>
+        </div>
+
+        {menuItems && menuItems.length > 0 && (
+          <div className={styles.moreWrapper}>
+            <button
+              className={styles.moreButton}
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              aria-label="더보기"
+              type="button"
+            >
+              <MoreIcon />
+            </button>
+            {isMenuOpen && (
+              <PopoverMenu
+                items={menuItems}
+                onSelect={(value) => {
+                  onMenuSelect?.(value);
+                  setIsMenuOpen(false);
+                }}
+                onClose={() => setIsMenuOpen(false)}
+                width={120}
+                style={{ top: '100%', right: 0, marginTop: '4px' }}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <p className={styles.content}>{content}</p>
+    </div>
+  );
+}

--- a/frontend/src/app/community/components/CommunityPostItem.module.css
+++ b/frontend/src/app/community/components/CommunityPostItem.module.css
@@ -1,0 +1,64 @@
+/* src/components/ui/CommunityPostItem.module.css */
+
+/* --------- 기본(default) 상태 --------- */
+.item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: var(--space-16);
+  gap: var(--space-12);
+  width: 100%;
+  box-sizing: border-box;
+
+  background: var(--color-text-gray-50);  /* #F9FAFB */
+  border-radius: var(--radius-md);        /* 8px */
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+/* --------- 선택(selected) 상태 --------- */
+.selected {
+  background: var(--color-text-gray-900); /* #111827 */
+}
+
+/* --------- 제목 --------- */
+.title {
+  font: var(--text-body-bold);            /* 700 14px/150% */
+  color: var(--color-text-gray-900);      /* #111827 */
+  margin: 0;
+  align-self: stretch;
+
+  /* 2줄 말줄임 */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.selected .title {
+  color: var(--color-text-white);         /* #FFFFFF */
+}
+
+/* --------- 하단 메타 행 (프로필 + 날짜) --------- */
+.meta {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-8);
+  align-self: stretch;
+}
+
+/* --------- 날짜 --------- */
+.date {
+  font: var(--text-caption-regular);      /* 400 12px/150% */
+  color: var(--color-text-gray-500);      /* #6B7280 */
+  margin-left: auto;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.selected .date {
+  color: var(--color-text-gray-300);      /* #D1D5DB */
+}

--- a/frontend/src/app/community/components/CommunityPostItem.tsx
+++ b/frontend/src/app/community/components/CommunityPostItem.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import styles from './CommunityPostItem.module.css';
+import UserProfile from './UserProfile';
+
+export interface CommunityPostItemProps {
+  /** 게시글 제목 */
+  title: string;
+  /** 작성자 이름 */
+  username: string;
+  /** 작성 날짜 (예: "2026.03.30 / 10:35") */
+  date: string;
+  /** 프로필 이미지 URL (없으면 기본 배경색 원) */
+  avatarUrl?: string;
+  /** 선택 상태 */
+  selected?: boolean;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+}
+
+export default function CommunityPostItem({
+  title,
+  username,
+  date,
+  avatarUrl,
+  selected = false,
+  onClick,
+}: CommunityPostItemProps) {
+  const rootClass = selected
+    ? `${styles.item} ${styles.selected}`
+    : styles.item;
+
+  return (
+    <div className={rootClass} onClick={onClick} role="button" tabIndex={0}>
+      <p className={styles.title}>{title}</p>
+
+      <div className={styles.meta}>
+        <UserProfile name={username} imageUrl={avatarUrl} size="medium" />
+        <span className={styles.date}>{date}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/ui-test/page.tsx
+++ b/frontend/src/app/ui-test/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Button, Checkbox, Toggle, Radio, SelectBox, Pagination, UserProfile, Logo, Tag, Card, CardGrid, Tabs, InputField, TextareaField, Dropdown, UploadField } from '@/components/ui';
+import { Button, Checkbox, Toggle, Radio, SelectBox, Pagination, UserProfile, Logo, Tag, Card, CardGrid, Tabs, InputField, TextareaField, Dropdown, UploadField, CommentInput } from '@/components/ui';
+import CommunityPostItem from '@/app/community/components/CommunityPostItem';
+import CommunityCommentItem from '@/app/community/components/CommunityCommentItem';
 import { ConfirmModal, InputModal, UploadModal, PaymentModal } from '@/components/modal';
 import { useUIStore } from '@/store/useUIStore';
 
@@ -437,6 +439,78 @@ export default function UITestPage() {
         <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
           <Button variant="primary" onClick={() => showToast('저장이 완료되었습니다.', 'success', '성공적으로 데이터를 저장했습니다.')}>Success 토스트</Button>
           <Button variant="outlined" onClick={() => showToast('결제에 실패했습니다.', 'error', '잔액이 부족하거나 네트웍 오류입니다.')}>Fail 토스트</Button>
+        </div>
+      </div>
+
+      {/* 17. Community Components */}
+      <div style={sectionStyle}>
+        <h2 style={titleStyle}>17. Community Components</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+
+          {/* CommunityPostItem */}
+          <div>
+            <p style={{ marginBottom: '12px', color: '#6B7280' }}>CommunityPostItem (게시글 목록 아이템)</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', maxWidth: '400px' }}>
+              <CommunityPostItem
+                title="이번 세미나 듣고 실무에 바로 적용해본 후기 + 궁금한 점"
+                username="사용자 이름"
+                date="2026.03.30 / 10:35"
+                selected={true}
+              />
+              <CommunityPostItem
+                title="이번 세미나 듣고 실무에 바로 적용해본 후기 + 궁금한 점"
+                username="사용자 이름"
+                date="2026.03.30 / 10:35"
+                selected={false}
+              />
+              <CommunityPostItem
+                title="프론트엔드 개발자가 알아야 할 디자인 시스템 구축 방법론과 실전 사례 공유"
+                username="김디자인"
+                date="2026.04.01 / 09:15"
+                selected={false}
+              />
+            </div>
+          </div>
+
+          {/* CommentInput */}
+          <div>
+            <p style={{ marginBottom: '12px', color: '#6B7280' }}>CommentInput (댓글 입력)</p>
+            <div style={{ maxWidth: '600px' }}>
+              <CommentInput
+                onSubmit={(value) => alert(`댓글 등록: ${value}`)}
+              />
+            </div>
+          </div>
+
+          {/* CommunityCommentItem */}
+          <div>
+            <p style={{ marginBottom: '12px', color: '#6B7280' }}>CommunityCommentItem (댓글 표시)</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', maxWidth: '600px' }}>
+              <CommunityCommentItem
+                username="사용자 이름"
+                date="2026.03.30 / 10:35"
+                content="저도 프롬프트 지니 쓰다가 최근에는 클로드로 넘어왔는데, 마케팅 문구는 클로드가 훨씬 자연스러운 것 같아요!"
+                menuItems={[
+                  { value: 'edit', label: '수정하기' },
+                  { value: 'delete', label: '삭제하기' },
+                  { value: 'report', label: '신고하기' },
+                ]}
+                onMenuSelect={(v) => alert(`선택: ${v}`)}
+              />
+              <CommunityCommentItem
+                username="김개발"
+                date="2026.04.02 / 14:20"
+                content="세미나 자료 공유해주실 수 있나요? 정말 유익한 내용이었습니다."
+                menuItems={[
+                  { value: 'edit', label: '수정하기' },
+                  { value: 'delete', label: '삭제하기' },
+                  { value: 'report', label: '신고하기' },
+                ]}
+                onMenuSelect={(v) => alert(`선택: ${v}`)}
+              />
+            </div>
+          </div>
+
         </div>
       </div>
 

--- a/frontend/src/components/ui/Button.module.css
+++ b/frontend/src/components/ui/Button.module.css
@@ -21,7 +21,7 @@
 
 .medium {
   padding: var(--space-8) var(--space-16);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   height: var(--space-36);
 }
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -6,26 +6,27 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   size?: 'medium' | 'large';
 }
 
-export default function Button({ 
-  variant = 'primary', 
-  size = 'medium', 
-  className = '', 
-  children, 
-  ...props 
+export default function Button({
+  variant = 'primary',
+  size = 'medium',
+  className = '',
+  children,
+  ...props
 }: ButtonProps) {
   const baseClass = styles.btn;
-  const variantClass = variant === 'primary' 
-    ? styles.primary 
-    : variant === 'secondary' 
-      ? styles.secondary 
+  const variantClass = variant === 'primary'
+    ? styles.primary
+    : variant === 'secondary'
+      ? styles.secondary
       : variant === 'outlined'
         ? styles.outlined
         : styles.danger;
   const sizeClass = size === 'large' ? styles.large : styles.medium;
 
+
   return (
-    <button 
-      className={`${baseClass} ${variantClass} ${sizeClass} ${className}`.trim()} 
+    <button
+      className={`${baseClass} ${variantClass} ${sizeClass} ${className}`.trim()}
       {...props}
     >
       {children}

--- a/frontend/src/components/ui/Card.module.css
+++ b/frontend/src/components/ui/Card.module.css
@@ -33,9 +33,7 @@
 }
 
 .title {
-  font: var(--text-h1-bold);
-  /* 24px로 렌더링됨 */
-  line-height: 1.2;
+  font: var(--text-h1-card-regular);
   color: var(--color-text-gray-900);
   margin: 0;
   /* 2줄 이상 넘어갈 시 말줄임표 처리 */
@@ -52,8 +50,8 @@
   aspect-ratio: 362 / 204;
   background-color: var(--color-text-gray-300);
   /* #D1D5DB 썸네일 플레이스홀더 */
-  border-radius: var(--space-16);
-  /* 16px */
+  border-radius: var(--radius-xl);
+  /* 24px */
   overflow: hidden;
   flex: none;
   /* 이미지 찌그러짐 방지 */

--- a/frontend/src/components/ui/CommentInput.module.css
+++ b/frontend/src/components/ui/CommentInput.module.css
@@ -1,0 +1,40 @@
+/* src/components/ui/CommentInput.module.css */
+
+.wrapper {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  padding: var(--space-16);
+  gap: var(--space-8);
+  width: 100%;
+
+  background: var(--color-bg);
+  /* #FFFFFF */
+  border: 1px solid var(--color-text-gray-300);
+  /* #D1D5DB */
+  border-radius: var(--radius-lg);
+  /* 12px */
+}
+
+/* --------- 텍스트 입력 영역 --------- */
+.textarea {
+  flex: 1;
+  height: 63px;
+  /* 고정 높이 */
+  border: none;
+  outline: none;
+  background: transparent;
+  resize: none;
+
+  font: var(--text-body-medium);
+  /* 500 14px/150% */
+  color: var(--color-text-gray-700);
+  /* #374151 */
+  overflow-y: auto;
+}
+
+.textarea::placeholder {
+  color: var(--color-text-gray-500);
+  /* #6B7280 */
+}

--- a/frontend/src/components/ui/CommentInput.tsx
+++ b/frontend/src/components/ui/CommentInput.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React, { useState } from 'react';
+import styles from './CommentInput.module.css';
+import Button from './Button';
+
+export interface CommentInputProps {
+  /** placeholder 텍스트 */
+  placeholder?: string;
+  /** 등록 버튼 텍스트 */
+  submitText?: string;
+  /** 등록 시 호출되는 콜백 (입력값 전달 후 초기화) */
+  onSubmit?: (value: string) => void;
+  /** 외부에서 비활성화 제어 */
+  disabled?: boolean;
+}
+
+export default function CommentInput({
+  placeholder = '댓글을 입력하세요..',
+  submitText = '등록',
+  onSubmit,
+  disabled = false,
+}: CommentInputProps) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit?.(trimmed);
+    setValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    /* Ctrl/Cmd + Enter로도 제출 가능 */
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <textarea
+        className={styles.textarea}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      <Button
+        variant="primary"
+        size="medium"
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim()}
+        type="button"
+      >
+        {submitText}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styles from './Dropdown.module.css';
 import { ArrowDownIcon } from '@/components/icons';
+import PopoverMenu from './PopoverMenu';
 
 export interface DropdownOption {
   value: string;
@@ -54,7 +55,7 @@ export default function Dropdown({
     if (onChange) {
       onChange(val);
     }
-    setIsOpen(false); // 선택 후 메뉴 닫기
+    setIsOpen(false);
   };
 
   return (
@@ -80,24 +81,19 @@ export default function Dropdown({
         </div>
       </div>
 
-      {/* 3. 드롭다운 팝업 리스트 */}
+      {/* 3. 드롭다운 팝업 리스트 — PopoverMenu 재사용 */}
       {isOpen && (
-        <div className={styles.list}>
-          {options.map((opt) => {
-            const isSelected = opt.value === value;
-            return (
-              <div 
-                key={opt.value} 
-                className={`${styles.menuItem} ${isSelected ? styles.menuItemSelected : ''}`}
-                onClick={() => handleSelect(opt.value)}
-              >
-                <span className={styles.menuItemText}>{opt.label}</span>
-              </div>
-            );
-          })}
-        </div>
+        <PopoverMenu
+          items={options}
+          onSelect={handleSelect}
+          onClose={() => setIsOpen(false)}
+          selectedValue={value}
+          width="100%"
+          style={{ top: '100%', left: 0, marginTop: '4px' }}
+        />
       )}
       
     </div>
   );
 }
+

--- a/frontend/src/components/ui/PopoverMenu.module.css
+++ b/frontend/src/components/ui/PopoverMenu.module.css
@@ -1,0 +1,52 @@
+/* src/components/ui/PopoverMenu.module.css */
+
+/* --------- 메뉴 리스트 컨테이너 --------- */
+.menu {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: var(--space-8) 0;
+  gap: var(--space-4);
+
+  position: absolute;
+  z-index: 50;
+
+  background: var(--color-bg);                    /* #FFFFFF */
+  border: 1px solid var(--color-text-gray-300);   /* #D1D5DB */
+  border-radius: var(--radius-md);                /* 8px */
+  box-shadow: var(--shadow-md);
+
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+/* --------- 메뉴 아이템 --------- */
+.menuItem {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: var(--space-8) var(--space-12);
+  gap: var(--space-8);
+  width: 100%;
+  height: 37px;
+  cursor: pointer;
+  background: var(--color-bg);                    /* #FFFFFF */
+  user-select: none;
+  transition: background var(--transition);
+}
+
+.menuItem:hover {
+  background: var(--color-surface);               /* #F3F4F6 */
+}
+
+.menuItemText {
+  font: var(--text-body-medium);
+  color: var(--color-text-gray-500);              /* #6B7280 */
+  white-space: nowrap;
+}
+
+.menuItemSelected .menuItemText {
+  color: var(--color-text-gray-700);              /* #374151 */
+}

--- a/frontend/src/components/ui/PopoverMenu.tsx
+++ b/frontend/src/components/ui/PopoverMenu.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, { useRef, useEffect } from 'react';
+import styles from './PopoverMenu.module.css';
+
+export interface PopoverMenuItem {
+  value: string;
+  label: string;
+}
+
+export interface PopoverMenuProps {
+  /** 메뉴 항목 목록 */
+  items: PopoverMenuItem[];
+  /** 항목 클릭 시 콜백 */
+  onSelect: (value: string) => void;
+  /** 메뉴 닫기 콜백 (바깥 클릭 시) */
+  onClose: () => void;
+  /** 현재 선택된 값 (선택 표시용, optional) */
+  selectedValue?: string;
+  /** 메뉴 너비 (기본: 240px) */
+  width?: number | string;
+  /** 추가 스타일 */
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+export default function PopoverMenu({
+  items,
+  onSelect,
+  onClose,
+  selectedValue,
+  width = 240,
+  style,
+  className = '',
+}: PopoverMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  /* 바깥 클릭 시 닫기 */
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className={`${styles.menu} ${className}`.trim()}
+      style={{ width, ...style }}
+    >
+      {items.map((item) => {
+        const isSelected = item.value === selectedValue;
+        return (
+          <div
+            key={item.value}
+            className={`${styles.menuItem} ${isSelected ? styles.menuItemSelected : ''}`}
+            onClick={() => onSelect(item.value)}
+          >
+            <span className={styles.menuItemText}>{item.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/SelectBox.module.css
+++ b/frontend/src/components/ui/SelectBox.module.css
@@ -3,9 +3,9 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 14px var(--space-24);
+  padding: var(--space-12) var(--space-24);
   gap: var(--space-8);
-  width: 352px;
+  width: 100%;
   height: var(--space-48);
   border-radius: var(--radius-md);
   cursor: pointer;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,4 +15,6 @@ export { default as InputField } from './InputField';
 export { default as TextareaField } from './TextareaField';
 export { default as Dropdown } from './Dropdown';
 export { default as UploadField } from './UploadField';
+export { default as CommentInput } from './CommentInput';
+export { default as PopoverMenu } from './PopoverMenu';
 


### PR DESCRIPTION
📋 관련 이슈
closes #813
closes #574
📋 Summary
커뮤니티 페이지에 필요한 UI 컴포넌트 4종을 신규 생성하고, 기존 Dropdown 내부의 메뉴 리스트를 범용 PopoverMenu 컴포넌트로 분리하여 재사용성을 높였습니다. 또한 커뮤니티 전용 컴포넌트(CommunityPostItem, CommunityCommentItem)를 app/community/components/ 폴더로 분리하여 도메인별 폴더 구조를 정리했습니다.

✨ 새로운 컴포넌트
CommunityPostItem — 커뮤니티 게시글 목록 아이템 (app/community/components/)
CommunityCommentItem — 댓글 표시 (app/community/components/)
CommentInput — 댓글 입력 + 등록 버튼
PopoverMenu — 범용 팝업 메뉴 (Dropdown에서 분리)
🔄 리팩토링
Dropdown: 내부 리스트 렌더링을 PopoverMenu로 교체
Button.module.css, Card.module.css, SelectBox.module.css: 스타일 수정
index.ts: 신규 컴포넌트 export 추가
ui-test/page.tsx: 커뮤니티 컴포넌트 테스트 섹션 추가
✅ 체크리스트
 컴포넌트 폴더 구조 준수 (도메인별 분리)
 기존 기능 동작에 영향 없음
 컴파일/빌드 정상