### PR TITLE
[VO-610] 이벤트 상세 페이지(Phase 2) 및 주최자(Host) 정보 연동

### DIFF
--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventDetailResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventDetailResponse.java
@@ -1,5 +1,6 @@
 package com.venueon.event.adapter.in.web.dto;
 
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
@@ -7,7 +8,7 @@ import com.venueon.event.domain.model.EventType;
 import java.time.LocalDateTime;
 
 /**
- * 이벤트 상세 응답 DTO
+ * 이벤트 상세 응답 DTO (Host 정보 포함)
  */
 public record EventDetailResponse(
         Long id,
@@ -25,9 +26,31 @@ public record EventDetailResponse(
         Long categoryId,
         Long creatorId,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        HostInfoDto host
 ) {
+    /**
+     * Host 정보가 없는 경우 (fallback)
+     */
     public static EventDetailResponse from(Event event) {
+        return from(event, null);
+    }
+
+    /**
+     * Host 정보를 포함한 생성
+     */
+    public static EventDetailResponse from(Event event, HostInfo hostInfo) {
+        HostInfoDto hostDto = null;
+        if (hostInfo != null) {
+            hostDto = new HostInfoDto(
+                    hostInfo.userId(),
+                    hostInfo.nickname(),
+                    hostInfo.profileImg(),
+                    hostInfo.orgName(),
+                    hostInfo.orgDescription()
+            );
+        }
+
         return new EventDetailResponse(
                 event.getId(),
                 event.getTitle(),
@@ -44,7 +67,19 @@ public record EventDetailResponse(
                 event.getCategoryId(),
                 event.getCreatorId(),
                 event.getCreatedAt(),
-                event.getUpdatedAt()
+                event.getUpdatedAt(),
+                hostDto
         );
     }
+
+    /**
+     * 주최자 정보 내장 DTO
+     */
+    public record HostInfoDto(
+            Long userId,
+            String nickname,
+            String profileImg,
+            String orgName,
+            String orgDescription
+    ) {}
 }

--- a/backend/src/main/java/com/venueon/event/adapter/out/internal/HostInfoAdapter.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/internal/HostInfoAdapter.java
@@ -1,0 +1,42 @@
+package com.venueon.event.adapter.out.internal;
+
+import com.venueon.event.application.port.out.LoadHostInfoPort;
+import com.venueon.user.adapter.out.persistence.entity.HostProfileJpaEntity;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.HostProfileJpaRepository;
+import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Event 모듈 → User 모듈 연결 어댑터
+ * LoadHostInfoPort 구현체로, User/HostProfile JPA 엔티티를 조회하여 HostInfo로 변환
+ */
+@Component
+@RequiredArgsConstructor
+public class HostInfoAdapter implements LoadHostInfoPort {
+
+    private final UserJpaRepository userJpaRepository;
+    private final HostProfileJpaRepository hostProfileJpaRepository;
+
+    @Override
+    public Optional<HostInfo> findByUserId(Long userId) {
+        Optional<UserJpaEntity> userOpt = userJpaRepository.findById(userId);
+        if (userOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        UserJpaEntity user = userOpt.get();
+        Optional<HostProfileJpaEntity> hostProfileOpt = hostProfileJpaRepository.findByUserId(userId);
+
+        return Optional.of(new HostInfo(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImg(),
+                hostProfileOpt.map(HostProfileJpaEntity::getOrgName).orElse(user.getNickname()),
+                hostProfileOpt.map(HostProfileJpaEntity::getOrgDescription).orElse(null)
+        ));
+    }
+}

--- a/backend/src/main/java/com/venueon/event/application/port/out/LoadHostInfoPort.java
+++ b/backend/src/main/java/com/venueon/event/application/port/out/LoadHostInfoPort.java
@@ -1,0 +1,23 @@
+package com.venueon.event.application.port.out;
+
+import java.util.Optional;
+
+/**
+ * 호스트(주최자) 정보를 조회하기 위한 Port-Out
+ * Event 모듈이 User 모듈에 직접 의존하지 않도록 인터페이스로 분리
+ */
+public interface LoadHostInfoPort {
+
+    Optional<HostInfo> findByUserId(Long userId);
+
+    /**
+     * 호스트 정보 Value Object
+     */
+    record HostInfo(
+            Long userId,
+            String nickname,
+            String profileImg,
+            String orgName,
+            String orgDescription
+    ) {}
+}

--- a/backend/src/main/java/com/venueon/event/application/service/EventQueryService.java
+++ b/backend/src/main/java/com/venueon/event/application/service/EventQueryService.java
@@ -4,6 +4,8 @@ import com.venueon.common.annotation.UseCase;
 import com.venueon.event.application.port.in.GetEventDetailUseCase;
 import com.venueon.event.application.port.in.GetEventListUseCase;
 import com.venueon.event.application.port.out.EventRepositoryPort;
+import com.venueon.event.application.port.out.LoadHostInfoPort;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
 import com.venueon.event.domain.model.Event;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 public class EventQueryService implements GetEventListUseCase, GetEventDetailUseCase {
 
     private final EventRepositoryPort eventRepositoryPort;
+    private final LoadHostInfoPort loadHostInfoPort;
 
     @Override
     public Page<Event> getEventList(EventSearchCondition condition, Pageable pageable) {
@@ -27,5 +30,12 @@ public class EventQueryService implements GetEventListUseCase, GetEventDetailUse
     public Event getEventById(Long eventId) {
         return eventRepositoryPort.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다. ID: " + eventId));
+    }
+
+    /**
+     * 이벤트 상세 + Host 정보 함께 조회
+     */
+    public HostInfo getHostInfoByCreatorId(Long creatorId) {
+        return loadHostInfoPort.findByUserId(creatorId).orElse(null);
     }
 }

--- a/backend/src/main/java/com/venueon/event/presentation/EventController.java
+++ b/backend/src/main/java/com/venueon/event/presentation/EventController.java
@@ -3,9 +3,10 @@ package com.venueon.event.presentation;
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.event.adapter.in.web.dto.EventDetailResponse;
 import com.venueon.event.adapter.in.web.dto.EventListResponse;
-import com.venueon.event.application.port.in.GetEventDetailUseCase;
-import com.venueon.event.application.port.in.GetEventListUseCase;
 import com.venueon.event.application.port.in.GetEventListUseCase.EventSearchCondition;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
+import com.venueon.event.application.service.EventQueryService;
+import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,8 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class EventController {
 
-    private final GetEventListUseCase getEventListUseCase;
-    private final GetEventDetailUseCase getEventDetailUseCase;
+    private final EventQueryService eventQueryService;
 
     /**
      * 이벤트 목록 조회 (검색/필터/페이징)
@@ -48,7 +48,7 @@ public class EventController {
 
         Pageable pageable = createPageable(page, size, sort);
 
-        Page<EventListResponse> result = getEventListUseCase
+        Page<EventListResponse> result = eventQueryService
                 .getEventList(condition, pageable)
                 .map(EventListResponse::from);
 
@@ -56,14 +56,14 @@ public class EventController {
     }
 
     /**
-     * 이벤트 상세 조회
+     * 이벤트 상세 조회 (Host 정보 포함)
      * GET /events/{id}
      */
     @GetMapping("/{id}")
     public ApiResponse<EventDetailResponse> getEventDetail(@PathVariable Long id) {
-        EventDetailResponse response = EventDetailResponse.from(
-                getEventDetailUseCase.getEventById(id)
-        );
+        Event event = eventQueryService.getEventById(id);
+        HostInfo hostInfo = eventQueryService.getHostInfoByCreatorId(event.getCreatorId());
+        EventDetailResponse response = EventDetailResponse.from(event, hostInfo);
         return ApiResponse.success(response);
     }
 

--- a/docs/VenueOn_최종_API_스펙_v5.1.md
+++ b/docs/VenueOn_최종_API_스펙_v5.1.md
@@ -3,7 +3,8 @@
 > **작성일:** 2026-04-02  
 > **기반:** 목표 아키텍처 v5 + 최종 기능·페이지 정의서 v2  
 > **이전 버전:** VenueOn_최종_API_스펙_v5.md  
-> **Base URL:** `/api/v1`  
+> **규칙:** 모든 백엔드 경로에 `/api` 미포함 (프론트엔드 BFF에서만 `/api/` 접두사 사용)
+> **Base URL:** `/v1`
 > **인증:** JWT Bearer Token (`Authorization: Bearer {token}`)  
 > **공통 응답:** `{ "status": "SUCCESS|ERROR", "data": {...}, "message": "..." }`
 
@@ -70,7 +71,7 @@ RECEIVED → REVIEWING → ACTIONED → COMPLETED
 
 ---
 
-## 📌 1. User 모듈 (`/api/v1/auth`, `/api/v1/users`)
+## 📌 1. User 모듈 (`/v1/auth`, `/v1/users`)
 
 ### 1-1. 인증 API
 
@@ -203,7 +204,7 @@ RECEIVED → REVIEWING → ACTIONED → COMPLETED
 
 ---
 
-## 📌 2. Event 모듈 (`/api/v1/events`)
+## 📌 2. Event 모듈 (`/v1/events`)
 
 ### 2-1. 이벤트 목록/검색 API
 
@@ -418,7 +419,7 @@ Query Parameters:
 
 ---
 
-## 📌 3. Community 모듈 (`/api/v1/communities`)
+## 📌 3. Community 모듈 (`/v1/communities`)
 
 ### 3-1. 커뮤니티 CRUD API
 
@@ -518,7 +519,7 @@ Query Parameters:
 
 ---
 
-## 📌 4. Order 모듈 (`/api/v1/orders`) — 결제/환불
+## 📌 4. Order 모듈 (`/v1/orders`) — 결제/환불
 
 ### 4-1. 주문/결제 API
 
@@ -631,7 +632,7 @@ Query Parameters:
 }
 ```
 
-## 📌 5. Wishlist / Cart 모듈 (`/api/v1/wishlist`, `/api/v1/cart`)
+## 📌 5. Wishlist / Cart 모듈 (`/v1/wishlist`, `/v1/cart`)
 
 ### 5-1. 찜 목록 API
 
@@ -696,7 +697,7 @@ Query Parameters:
 
 ---
 
-## 📌 6. Badge 모듈 (`/api/v1/badges`)
+## 📌 6. Badge 모듈 (`/v1/badges`)
 
 ### 6-1. 뱃지 관리 API
 
@@ -736,7 +737,7 @@ Query Parameters:
 
 ---
 
-## 📌 7. Notification 모듈 (`/api/v1/notifications`)
+## 📌 7. Notification 모듈 (`/v1/notifications`)
 
 ### 7-1. 알림 API
 
@@ -786,7 +787,7 @@ Query Parameters:
 
 ---
 
-## 📌 8. Report 모듈 (`/api/v1/reports`)
+## 📌 8. Report 모듈 (`/v1/reports`)
 
 ### 8-1. 신고 API
 
@@ -824,7 +825,7 @@ Query Parameters:
 
 ---
 
-## 📌 9. Admin 모듈 (`/api/v1/admin`)
+## 📌 9. Admin 모듈 (`/v1/admin`)
 
 ### 9-1. 대시보드 API
 
@@ -959,7 +960,7 @@ Query Parameters:
 
 ---
 
-## 📌 10. Notice 모듈 (`/api/v1/notices`, `/api/v1/requests`)
+## 📌 10. Notice 모듈 (`/v1/notices`, `/v1/requests`)
 
 ### 10-1. 공지사항 API
 
@@ -1019,7 +1020,7 @@ GET /notices Query Parameters:
 
 ---
 
-## 📌 11. 마이페이지 통합 API (`/api/v1/mypage`)
+## 📌 11. 마이페이지 통합 API (`/v1/mypage`)
 
 | # | Method | Path | Auth | 설명 | 에러 |
 |---|--------|------|------|------|------|
@@ -1033,7 +1034,7 @@ GET /notices Query Parameters:
 
 ---
 
-## 📌 12. 파일 업로드 API (`/api/v1/upload`)
+## 📌 12. 파일 업로드 API (`/v1/upload`)
 
 | # | Method | Path | Auth | 설명 | 에러 |
 |---|--------|------|------|------|------|

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "date-fns": "^4.1.0",
         "iron-session": "^8.0.4",
+        "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4335,6 +4336,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "date-fns": "^4.1.0",
     "iron-session": "^8.0.4",
+    "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/frontend/src/app/api/events/[id]/route.ts
+++ b/frontend/src/app/api/events/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const response = await fetch(`${BACKEND_URL}/events/${id}`);
+    const data = await response.json();
+
+    if (!response.ok) {
+        return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching event details:', error);
+    return NextResponse.json(
+      { success: false, message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/events/[id]/page.module.css
+++ b/frontend/src/app/events/[id]/page.module.css
@@ -1,0 +1,172 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-48) var(--space-24);
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.topBar {
+  margin-bottom: var(--space-24);
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-8) var(--space-12);
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-gray-700);
+  font: var(--text-label-medium);
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.backButton:hover {
+  background: var(--color-gray-100);
+}
+
+.headerSection {
+  margin-bottom: var(--space-32);
+}
+
+.titleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--space-16);
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.moreButton {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--color-text-gray-500);
+  cursor: pointer;
+  padding: var(--space-4);
+}
+
+.thumbnailWrapper {
+  width: 100%;
+  background-color: var(--color-gray-100);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  margin-bottom: var(--space-48);
+  display: flex;
+  justify-content: center;
+}
+
+.thumbnail {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+  margin-bottom: var(--space-48);
+}
+
+.sectionTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.description {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--color-text-gray-700);
+  margin-bottom: var(--space-24);
+  white-space: pre-wrap;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-24);
+  margin-top: var(--space-16);
+}
+
+.infoItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.infoLabel {
+  font: var(--text-body-small);
+  color: var(--color-text-gray-500);
+}
+
+.infoValue {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-gray-900);
+  word-break: keep-all;
+}
+
+.hostCard {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-24);
+  padding-top: var(--space-16);
+}
+
+.hostImageWrapper {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--color-primary-main);
+  flex-shrink: 0;
+}
+
+.hostImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hostInfo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.hostName {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.hostDesc {
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--color-text-gray-600);
+  margin: 0;
+}
+
+.bottomActionArea {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-16);
+  margin-top: var(--space-48);
+}
+
+@media screen and (max-width: 768px) {
+  .infoGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -1,17 +1,162 @@
+export const dynamic = 'force-dynamic';
+
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import styles from './page.module.css';
+import { Tag, Button } from '@/components/ui';
+import { format } from 'date-fns';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+// API Fetch 함수
+async function getEventDetail(id: string) {
+  try {
+    const url = `${BACKEND_URL}/events/${id}`;
+    const res = await fetch(url, {
+      cache: 'no-store'
+    });
+
+    const text = await res.text();
+    // 응답이 JSON 형식이 아닌 경우 로깅
+    if (!text.startsWith('{') && !text.startsWith('[')) {
+      console.error(`Backend returned non-JSON response from ${url}:`, text);
+      return { error: 'Non-JSON response', detail: text, url };
+    }
+
+    const data = JSON.parse(text);
+    if (data.success) {
+      return data.data;
+    }
+    return { error: 'Success false from backend', data };
+  } catch (error: any) {
+    console.error('Failed to fetch event details', error);
+    return { error: 'Fetch catch err', message: error?.message };
+  }
+}
+
 interface Props {
   params: Promise<{ id: string }>;
 }
 
 export default async function EventDetailPage({ params }: Props) {
   const { id } = await params;
+  const event = await getEventDetail(id);
+
+  if (!event || event.error) {
+    return (
+      <div className={styles.container} style={{ textAlign: 'center', padding: '100px 0' }}>
+        <h2>이벤트를 찾을 수 없거나 불러오지 못했습니다.</h2>
+        <p>삭제되었거나 존재하지 않는 이벤트입니다.</p>
+        <div style={{ marginTop: 20, color: 'red', textAlign: 'left', background: '#ffebee', padding: 16 }}>
+          <pre>{JSON.stringify(event, null, 2)}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  const STATUS_MAP: Record<string, { label: string; variant: 'green' | 'purple' | 'gray' | 'red' }> = {
+    PUBLISHED: { label: '모집 중', variant: 'green' },
+    ONGOING: { label: '진행 중', variant: 'purple' },
+    DRAFT: { label: '게시 전', variant: 'gray' },
+    ENDED: { label: '종료', variant: 'gray' },
+    CANCELLED: { label: '취소', variant: 'red' },
+  };
+
+  const statusInfo = STATUS_MAP[event.status] || { label: event.status, variant: 'gray' };
+  const imageUrl = event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : '';
 
   return (
-    <div style={{ padding: "var(--space-8)" }}>
-      <h1>이벤트 상세</h1>
-      <p style={{ color: "var(--color-text-muted)" }}>
-        이벤트 ID: {id}
-      </p>
-      {/* TODO: EventDetail + TicketSection 컴포넌트 */}
+    <div className={styles.container}>
+
+      {/* 뒤로 가기 바 */}
+      <div className={styles.topBar}>
+        <Link href="/" className={styles.backButton}>
+          ← 강의 목록 보기
+        </Link>
+      </div>
+
+      {/* 헤더 섹션 (상태 태그, 제목, 액션 버튼) */}
+      <div className={styles.headerSection}>
+        <Tag variant={statusInfo.variant}>{statusInfo.label}</Tag>
+        <div className={styles.titleRow}>
+          <h1 className={styles.title}>{event.title}</h1>
+          <button className={styles.moreButton}>...</button>
+        </div>
+      </div>
+
+      {/* 썸네일 */}
+      <div className={styles.thumbnailWrapper}>
+        {imageUrl ? (
+          <img src={imageUrl} alt={event.title} className={styles.thumbnail} />
+        ) : (
+          <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            미리보기 이미지가 없습니다
+          </div>
+        )}
+      </div>
+
+      {/* 강의 정보 섹션 */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>강의 정보</h3>
+        <div className={styles.description}>
+          {event.description}
+        </div>
+
+        <div className={styles.infoGrid}>
+          <div className={styles.infoItem}>
+            <span className={styles.infoLabel}>총 가격</span>
+            <span className={styles.infoValue}>
+              {event.price === 0 ? '무료' : `₩${event.price.toLocaleString()}`}
+            </span>
+          </div>
+          <div className={styles.infoItem}>
+            <span className={styles.infoLabel}>날짜</span>
+            <span className={styles.infoValue}>
+              {format(new Date(event.startDate), 'yyyy-MM-dd')}
+            </span>
+          </div>
+          <div className={styles.infoItem}>
+            <span className={styles.infoLabel}>장소</span>
+            <span className={styles.infoValue}>
+              {event.isOnline ? '온라인 이벤트' : event.location}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* 주최자 정보 섹션 */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>주최자 정보</h3>
+        <div className={styles.hostCard}>
+          <div className={styles.hostImageWrapper}>
+            {event.host?.profileImg ? (
+              <img src={`${BACKEND_URL}/upload/company-logo/${event.host.profileImg}`} alt={event.host.orgName} className={styles.hostImage} />
+            ) : (
+              <div style={{ width: '100%', height: '100%' }} />
+            )}
+          </div>
+          <div className={styles.hostInfo}>
+            <h4 className={styles.hostName}>{event.host?.orgName || `Host ${event.creatorId}`}</h4>
+            <p className={styles.hostDesc}>{event.host?.orgDescription || '주최자 소개가 없습니다.'}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* 하단 액션 버튼 */}
+      <div className={styles.bottomActionArea}>
+        <Link href="/" style={{ textDecoration: 'none' }}>
+          <Button variant="outlined" size="large">강의 목록</Button>
+        </Link>
+        <Button
+          variant="primary"
+          size="large"
+          disabled={event.status !== 'PUBLISHED'}
+        >
+          {event.status === 'PUBLISHED' ? '수강 신청' : '신청 불가'}
+        </Button>
+      </div>
+
     </div>
   );
 }

--- a/frontend/src/app/events/page.tsx
+++ b/frontend/src/app/events/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
 import styles from './page.module.css';
 import { Card, CardGrid, InputField, Tabs, Pagination } from '@/components/ui';
 import { format } from 'date-fns';
@@ -106,18 +107,19 @@ export default function EventsPage() {
           ) : (
             <CardGrid layout="3-cols">
               {events.map((event) => (
-                <Card
-                  key={event.id}
-                  title={event.title}
-                  imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
-                  organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 실제 회사이름으로 변경
-                  dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
-                  location={event.isOnline ? '온라인' : event.location}
-                  price={event.price}
-                  status={event.status}
-                  tagVariant="green"
-                  tagText="모집 중" // 일단 하드코딩 피그마 처럼
-                />
+                <Link href={`/events/${event.id}`} key={event.id} style={{ textDecoration: 'none', color: 'inherit' }}>
+                  <Card
+                    title={event.title}
+                    imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
+                    organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 실제 회사이름으로 변경
+                    dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
+                    location={event.isOnline ? '온라인' : event.location}
+                    price={event.price}
+                    status={event.status}
+                    tagVariant="green"
+                    tagText="모집 중" // 일단 하드코딩 피그마 처럼
+                  />
+                </Link>
               ))}
             </CardGrid>
           )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
 import styles from './page.module.css';
 import { Card, CardGrid, InputField, Tabs, Pagination } from '@/components/ui';
 import { format } from 'date-fns';
@@ -125,16 +126,17 @@ export default function Home() {
           ) : (
             <CardGrid layout="3-cols">
               {events.map((event) => (
-                <Card
-                  key={event.id}
-                  title={event.title}
-                  imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
-                  organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 시 실제 이름으로 변경
-                  dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
-                  location={event.isOnline ? '온라인' : event.location}
-                  price={event.price}
-                  status={event.status}
-                />
+                <Link href={`/events/${event.id}`} key={event.id} style={{ textDecoration: 'none', color: 'inherit' }}>
+                  <Card
+                    title={event.title}
+                    imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
+                    organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 시 실제 이름으로 변경
+                    dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
+                    location={event.isOnline ? '온라인' : event.location}
+                    price={event.price}
+                    status={event.status}
+                  />
+                </Link>
               ))}
             </CardGrid>
           )}


### PR DESCRIPTION
### 📝 [VO-610] Phase 2: 이벤트 상세 페이지 기능 완수

이벤트 리스트(메인 페이지)에서 개별 이벤트 상세뷰로 진입할 때 필요한 전체 사이클(DB -> Backend -> BFF -> Frontend) 기능을 완성했습니다.

#### 🛠 주요 구현 내용 (Phase 2 전체 대상)

**1. 프론트엔드 (UI & BFF)**
* Next.js 서버 컴포넌트(Server Component)를 활용한 동적 렌더링 최적화 (`app/events/[id]/page.tsx`)
* 프론트엔드 BFF 프록시 라우트 신규 생성 (`api/events/[id]/route.ts`)
* 최신 Figma 목표 레이아웃에 맞춘 단일 컬럼(Single-column) 기반 UI 작성 및 `page.module.css` 리디자인 (중간 구분선 제거, 간격 재조정 완료)
* 행사 가격, 장소, 일정 등 이벤트 핵심 정보 Grid 레이아웃 표출
* 호스트(주최자) 프로필 정보 카드 맵핑 및 `company-logo` 연동 출력

**2. 백엔드 (Domain & API)**
* 이벤트 단건 조회(Detail) 비즈니스 로직(UseCase/Query) 신규 구현
* 도메인 연관관계를 고려하여 주최자 유저 정보와 커뮤니티 정보를 엮어주는 아웃바운드 어댑터(`LoadHostInfoPort`, `HostInfoAdapter`) 작성
* 단일 호출로 클라이언트에 최적화된 데이터를 내려주는 `EventDetailResponse` / `HostInfoDto` 응답 스펙 설계 및 반영

**3. 아키텍처 규칙 & 문서화**
* 팀 API 설계 규칙에 따라 `VenueOn_최종_API_스펙_v5.1.md`에 백엔드 Base URL(`/v1`) 규칙 명문화 (불필요한 `/api` 접두사 분리) 기재


[VO-610]: https://venueon.atlassian.net/browse/VO-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ