### PR TITLE
fix(VO-814): Header 로그인 상태 미반영 수정

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,105 +1,87 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button, UserProfile, Logo } from '@/components/ui';
+import { useAuth } from '@/store/useAuthStore';
 import styles from './Header.module.css';
 
-export interface HeaderProps {
-  role?: 'user' | 'host' | 'admin';
-  status?: 'public' | 'signedIn' | 'myPage' | 'auth';
-  // 프로필에 표시될 이름이나 사진을 부모에서 전달받을 수 있도록 설정 (기본값 제공)
-  userName?: string;
-  userImageUrl?: string;
-  className?: string;
-}
+export default function Header({ className = '' }: { className?: string }) {
+  const pathname = usePathname();
+  const { user, isLoggedIn, isLoading, checkSession, logout } = useAuth();
 
-export default function Header({ 
-  role = 'user', 
-  status = 'public',
-  userName = '홍길동',
-  userImageUrl,
-  className = ''
-}: HeaderProps) {
-  
+  // 최초 마운트 시 세션 확인
+  useEffect(() => {
+    checkSession();
+  }, [checkSession]);
+
+  // 현재 경로가 로그인/회원가입 페이지인지 확인
+  const isAuthPage = ['/login', '/signup', '/host/signup'].includes(pathname);
+
+  // Auth 상태에서 role 파생
+  const role = user?.role?.toLowerCase() as 'user' | 'host' | 'admin' | undefined;
+
   // 우측에 렌더링될 버튼/프로필 그룹 로직
   const renderActions = () => {
-    
-    // Auth (로그인/회원가입 등 집중이 필요한 화면)
-    if (status === 'auth') {
-      if (role === 'user') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/host/intro">
-              <Button variant="outlined" size="medium">호스트 센터</Button>
-            </Link>
-          </div>
-        );
-      }
-      // host일 땐 텅 비움
+
+    // 로딩 중이면 빈 공간 (깜빡임 방지)
+    if (isLoading) {
       return <div className={styles.actionGroup} />;
     }
 
-    // Role: User (일반 사용자)
-    if (role === 'user') {
-      if (status === 'public') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/login"><Button variant="primary" size="medium">로그인</Button></Link>
-            <Link href="/signup"><Button variant="secondary" size="medium">회원가입</Button></Link>
-            <Link href="/host/intro"><Button variant="outlined" size="medium">호스트 센터</Button></Link>
-          </div>
-        );
-      }
-      if (status === 'signedIn') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/dashboard"><Button variant="outlined" size="medium">내 강의실</Button></Link>
-            <UserProfile name={userName} imageUrl={userImageUrl} size="large" />
-          </div>
-        );
-      }
-      if (status === 'myPage') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/seminars"><Button variant="secondary" size="medium">강의 목록</Button></Link>
-            <Link href="/dashboard"><Button variant="outlined" size="medium">내 강의실</Button></Link>
-            <UserProfile name={userName} imageUrl={userImageUrl} size="large" />
-          </div>
-        );
-      }
-    }
-
-    // Role: Host (호스트)
-    if (role === 'host') {
-      if (status === 'public') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/login"><Button variant="primary" size="medium">로그인</Button></Link>
-            <Link href="/signup"><Button variant="secondary" size="medium">회원가입</Button></Link>
-          </div>
-        );
-      }
-      if (status === 'signedIn') {
-        return (
-          <div className={styles.actionGroup}>
-            <Link href="/host/dashboard">
-              <Button variant="outlined" size="medium">내 강의실</Button>
-            </Link>
-            <UserProfile name={userName} imageUrl={userImageUrl} size="large" />
-          </div>
-        );
-      }
-    }
-
-    // Role: Admin (관리자)
-    if (role === 'admin') {
+    // Auth 페이지 (로그인/회원가입)에서는 최소한의 버튼만
+    if (isAuthPage) {
       return (
         <div className={styles.actionGroup}>
-          <UserProfile name={userName} imageUrl={userImageUrl} size="large" />
+          <Link href="/host/intro">
+            <Button variant="outlined" size="medium">호스트 센터</Button>
+          </Link>
         </div>
       );
     }
 
-    return null;
+    // 비로그인 상태
+    if (!isLoggedIn) {
+      return (
+        <div className={styles.actionGroup}>
+          <Link href="/login"><Button variant="primary" size="medium">로그인</Button></Link>
+          <Link href="/signup"><Button variant="secondary" size="medium">회원가입</Button></Link>
+          <Link href="/host/intro"><Button variant="outlined" size="medium">호스트 센터</Button></Link>
+        </div>
+      );
+    }
+
+    // 로그인 상태: Role별 분기
+    if (role === 'admin') {
+      return (
+        <div className={styles.actionGroup}>
+          <UserProfile name={user?.nickname || '관리자'} size="large" />
+          <Button variant="secondary" size="medium" onClick={logout}>로그아웃</Button>
+        </div>
+      );
+    }
+
+    if (role === 'host') {
+      return (
+        <div className={styles.actionGroup}>
+          <Link href="/host/dashboard">
+            <Button variant="outlined" size="medium">내 강의실</Button>
+          </Link>
+          <UserProfile name={user?.nickname || '호스트'} size="large" />
+          <Button variant="secondary" size="medium" onClick={logout}>로그아웃</Button>
+        </div>
+      );
+    }
+
+    // 기본: USER
+    return (
+      <div className={styles.actionGroup}>
+        <Link href="/dashboard"><Button variant="outlined" size="medium">내 강의실</Button></Link>
+        <UserProfile name={user?.nickname || '사용자'} size="large" />
+        <Button variant="secondary" size="medium" onClick={logout}>로그아웃</Button>
+      </div>
+    );
   };
 
   return (
@@ -109,3 +91,4 @@ export default function Header({
     </header>
   );
 }
+


### PR DESCRIPTION
### 🐛 문제
로그인 성공 후에도 Header가 항상 `public` 상태(로그인/회원가입 버튼)로 표시되는 문제

### 📝 관련 티켓
- **VO-814**: Header Auth State Fix

### 🔍 원인 분석
- Header 컴포넌트가 서버 컴포넌트로 동작하여 `useAuthStore`(Zustand)를 구독하지 못함
- `layout.tsx`에서 `<Header />`를 props 없이 사용 → 항상 `status='public'` 고정
- 로그인 페이지에서 `checkSession()` 호출로 store가 업데이트되어도 Header에 반영 불가

### ✅ 수정 내용
1. **Header를 클라이언트 컴포넌트(`'use client'`)로 전환**
2. **`useAuth()` store 직접 구독**: `isLoggedIn`, `user`, `role` 자동 반영
3. **`useEffect`로 `checkSession()` 호출**: 페이지 새로고침/첫 접속 시에도 세션 자동 복원
4. **`usePathname()`으로 auth 페이지 자동 감지**: 로그인/회원가입 페이지에서는 최소 UI
5. **로그아웃 버튼 추가**: 로그인 상태에서 헤더 우측에 로그아웃 버튼 노출
6. **Role별 동적 렌더링**: USER/HOST/ADMIN 역할에 따라 적절한 버튼 그룹 표시
7. **로딩 중 빈 공간 처리**: 세션 체크 중 깜빡임 방지