### PR TITLE
fix: checkout, success, fail 페이지에 Suspense 추가하여 Next.js 프로덕션 빌드(정적 렌더링) 시 발생하는 useSearchParams 예외 해결

### DIFF
--- a/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
@@ -32,7 +32,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(org.springframework.web.servlet.resource.NoResourceFoundException.class)
-    protected ResponseEntity<String> handleNoResourceFound(org.springframework.web.servlet.resource.NoResourceFoundException e) {
+    protected ResponseEntity<String> handleNoResourceFound(
+            org.springframework.web.servlet.resource.NoResourceFoundException e) {
         log.warn("Resource Not Found: {}", e.getMessage());
         return ResponseEntity.status(404).body("Not Found");
     }
@@ -53,4 +54,3 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 }
-

--- a/frontend/src/app/orders/checkout/fail/page.tsx
+++ b/frontend/src/app/orders/checkout/fail/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import styles from '../checkout.module.css';
 import { Button } from '@/components/ui';
 
-export default function CheckoutFailPage() {
+function CheckoutFailContent() {
   const searchParams = useSearchParams();
   const code = searchParams.get('code') || '알 수 없는 오류';
   const message = searchParams.get('message') || '결제 처리 중 문제가 발생했습니다.';
@@ -30,5 +30,13 @@ export default function CheckoutFailPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function CheckoutFailPage() {
+  return (
+    <Suspense fallback={<div className={styles.checkoutContainer}><div className={styles.checkoutCard}><p>로딩 중...</p></div></div>}>
+      <CheckoutFailContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { Suspense, useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 import styles from './checkout.module.css';
 import { Button } from '@/components/ui';
@@ -18,6 +18,14 @@ interface CreateOrderData {
 }
 
 export default function CheckoutPage() {
+  return (
+    <Suspense fallback={<div className={styles.checkoutContainer}><div className={styles.checkoutCard}><p style={{ textAlign: 'center', padding: '40px 0' }}>로딩 중...</p></div></div>}>
+      <CheckoutContent />
+    </Suspense>
+  );
+}
+
+function CheckoutContent() {
   const searchParams = useSearchParams();
   const [widgets, setWidgets] = useState<any>(null);
   const [orderData, setOrderData] = useState<CreateOrderData | null>(null);

--- a/frontend/src/app/orders/checkout/success/page.tsx
+++ b/frontend/src/app/orders/checkout/success/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import styles from '../checkout.module.css';
 import { Button } from '@/components/ui';
 
 export default function CheckoutSuccessPage() {
+  return (
+    <Suspense fallback={<div className={styles.checkoutContainer}><div className={styles.checkoutCard}><p style={{ textAlign: 'center', padding: '40px 0' }}>로딩 중...</p></div></div>}>
+      <CheckoutSuccessContent />
+    </Suspense>
+  );
+}
+
+function CheckoutSuccessContent() {
   const searchParams = useSearchParams();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState('결제를 승인하는 중입니다...');


### PR DESCRIPTION
# Next.js 빌드 에러 트러블슈팅: useSearchParams와 Suspense

## 🚨 에러 증상 (빌드 실패)
GitHub Actions에서 프론트엔드(`venueon-frontend`) 도커 빌드 중 다음과 같은 에러가 발생하며 프로세스가 중단되었습니다.

```text
useSearchParams() should be wrapped in a suspense boundary at page "/orders/checkout/fail".
Error occurred prerendering page "/orders/checkout/fail".
```

## 🔍 원인 분석
이 에러는 Next.js(App Router)의 **정적 렌더링(Static Rendering)** 메커니즘과 연관이 있습니다.

1. Next.js는 `npm run build`를 실행할 때, 가능한 한 많은 페이지를 서버에서 미리 만들어 두려고(Pre-rendering) 시도합니다.
2. 하지만 `useSearchParams()`는 사용자가 접속할 때 브라우저의 접속 정보(쿼리 스트링)를 읽어오는 함수이므로 **빌드 시점에는 그 값을 알 수 없습니다.**
3. 페이지 최상단 컴포넌트에서 `useSearchParams()`를 호출하게 되면, Next.js는 이 페이지를 정적으로 미리 렌더링할 수 없다고 판단하고(Bailout), 엄격한 설정 하에서는 아예 위와 같은 예외를 뱉으며 빌드를 실패 처리합니다.

## 🛠️ 해결 방법
`useSearchParams()` 로직을 수행하는 실제 컴포넌트를 분리하고, 이를 React의 **`<Suspense>` boundary**로 감싸주어야 합니다. 

이것은 Next.js 서버에게 *"이 부분은 미리 만들려고 시도하지 말고, 서버사이드 렌더링 시에는 `fallback` UI(=로딩중 화면)를 보여준 뒤 브라우저 클라이언트가 로드된 이후에 처리해"* 라고 위임하는 것과 같습니다.

### 변경 전 (에러 발생 패턴)
최상단 컴포넌트에서 URL 정보에 직접 접근하려 하여 빌드 에러를 유발합니다.
```tsx
"use client";
import { useSearchParams } from 'next/navigation';

export default function CheckoutPage() {
  // ⛔ 여기서 에러 발생
  const searchParams = useSearchParams(); 
  
  return <div>결제 페이지</div>;
}
```

### 변경 후 (해결된 패턴)
최상단 페이지는 껍데기만 역할을 하고, 실제 쿼리를 사용하는 로직을 `<Suspense>` 안쪽의 자식 컴포넌트로 격리합니다.
```tsx
"use client";
import React, { Suspense } from 'react';
import { useSearchParams } from 'next/navigation';

// 실제 비즈니스 로직을 처리하는 분리된 자식 컴포넌트
function CheckoutContent() {
  // ✅ Suspense 안쪽이므로 안전하게 빌드 통과!
  const searchParams = useSearchParams(); 
  return <div>결제 페이지</div>;
}

// 라우터가 직접 그리는 최상단 부모 컴포넌트
export default function CheckoutPage() {
  return (
    <Suspense fallback={<div>로딩 중...</div>}>
       <CheckoutContent />
    </Suspense>
  )
}
```

## 💡 결론
본 프로젝트에서는 `/orders/checkout/page.tsx`, `/orders/checkout/success/page.tsx`, `/orders/checkout/fail/page.tsx` 총 3곳에서 동일한 문제를 유발하고 있었으며, 위와 같은 방식으로 컴포넌트를 격리하여 Next.js 프로덕션 빌드 캐시 에러를 성공적으로 해결하였습니다.
