### PR TITLE
feat(auth): 구글 소셜 로그인 및 호스트 업그레이드 기능 완료

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
       API_BASE_URL: ${{ vars.API_BASE_URL }}
       TOSS_CLIENT_KEY: ${{ vars.TOSS_CLIENT_KEY }}
       TOSS_SECRET_KEY: ${{ secrets.TOSS_SECRET_KEY }}
+      GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
 
     steps:
       # 1. ✅ 소스코드 체크아웃 (GitHub Actions 표준 방식)
@@ -63,6 +64,7 @@ jobs:
           API_BASE_URL=${{ vars.API_BASE_URL }}
           TOSS_CLIENT_KEY=${{ vars.TOSS_CLIENT_KEY }}
           TOSS_SECRET_KEY=${{ secrets.TOSS_SECRET_KEY }}
+          GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
           ENVEOF
           # 앞쪽 공백 제거
           sed -i 's/^[[:space:]]*//' .env

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// Google OAuth2 (ID Token 검증)
+	implementation 'com.google.api-client:google-api-client:2.7.2'
+
 	// PostgreSQL
 	runtimeOnly 'org.postgresql:postgresql'
 

--- a/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 // 인증 불필요 경로
-                .requestMatchers("/auth/signup", "/auth/host/signup", "/auth/login").permitAll()
+                .requestMatchers("/auth/signup", "/auth/host/signup", "/auth/login", "/auth/google").permitAll()
                 // Swagger UI
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 // Actuator

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -2,10 +2,7 @@ package com.venueon.user.adapter.in.web;
 
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.user.adapter.in.web.dto.*;
-import com.venueon.user.application.port.in.GetUserInfoUseCase;
-import com.venueon.user.application.port.in.HostSignUpUseCase;
-import com.venueon.user.application.port.in.LoginUseCase;
-import com.venueon.user.application.port.in.SignUpUseCase;
+import com.venueon.user.application.port.in.*;
 import com.venueon.user.domain.model.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * /auth/signup, /auth/host/signup, /auth/login, /auth/me 엔드포인트
+ * /auth/signup, /auth/host/signup, /auth/login, /auth/google, /auth/me 엔드포인트
  */
 @Slf4j
 @RestController
@@ -27,7 +24,9 @@ public class AuthController {
     private final SignUpUseCase signUpUseCase;
     private final HostSignUpUseCase hostSignUpUseCase;
     private final LoginUseCase loginUseCase;
+    private final GoogleLoginUseCase googleLoginUseCase;
     private final GetUserInfoUseCase getUserInfoUseCase;
+    private final UpgradeToHostUseCase upgradeToHostUseCase;
 
     /**
      * POST /auth/signup — 일반 회원가입
@@ -98,6 +97,55 @@ public class AuthController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * POST /auth/google — 구글 소셜 로그인 (Google ID Token → JWT 발급)
+     */
+    @PostMapping("/google")
+    public ResponseEntity<LoginResponse> googleLogin(@Valid @RequestBody GoogleLoginRequest request) {
+        log.debug("구글 소셜 로그인 요청");
+
+        LoginUseCase.LoginResult result = googleLoginUseCase.googleLogin(request.idToken());
+
+        LoginResponse response = new LoginResponse(
+                result.token(),
+                result.email(),
+                result.nickname(),
+                result.role()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * POST /auth/host/upgrade — 호스트 업그레이드 (JWT 인증 필요)
+     * 구글 소셜 로그인으로 가입한 USER가 호스트 정보를 추가하여 HOST로 전환
+     */
+    @PostMapping("/host/upgrade")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> upgradeToHost(
+            Authentication authentication,
+            @Valid @RequestBody UpgradeToHostRequest request) {
+        String email = authentication.getName();
+        log.debug("호스트 업그레이드 요청: email={}", email);
+
+        User user = upgradeToHostUseCase.upgradeToHost(
+                email,
+                request.managerName(),
+                request.orgName(),
+                request.orgNumber(),
+                request.orgDescription()
+        );
+
+        UserInfoResponse response = new UserInfoResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole().name(),
+                user.getProfileImg()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/GoogleLoginRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/GoogleLoginRequest.java
@@ -1,0 +1,12 @@
+package com.venueon.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 구글 소셜 로그인 요청 DTO
+ * 프론트엔드에서 받은 Google ID Token을 전달
+ */
+public record GoogleLoginRequest(
+        @NotBlank(message = "Google ID Token은 필수입니다.")
+        String idToken
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpgradeToHostRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpgradeToHostRequest.java
@@ -1,0 +1,14 @@
+package com.venueon.user.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * POST /auth/host/upgrade 요청 DTO
+ * 구글 소셜 로그인 후 호스트 정보를 보완하여 HOST로 업그레이드
+ */
+public record UpgradeToHostRequest(
+        @NotBlank(message = "담당자명은 필수입니다.") String managerName,
+        @NotBlank(message = "기관명은 필수입니다.") String orgName,
+        @NotBlank(message = "사업자등록번호는 필수입니다.") String orgNumber,
+        String orgDescription
+) {}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
@@ -20,6 +20,7 @@ public class UserMapper {
                 .password(user.getPassword())
                 .nickname(user.getNickname())
                 .role(user.getRole())
+                .provider(user.getProvider())
                 .profileImg(user.getProfileImg())
                 .phone(user.getPhone())
                 .build();
@@ -35,6 +36,7 @@ public class UserMapper {
                 entity.getPassword(),
                 entity.getNickname(),
                 entity.getRole(),
+                entity.getProvider(),
                 entity.getProfileImg(),
                 entity.getPhone(),
                 entity.getCreatedAt(),
@@ -42,4 +44,3 @@ public class UserMapper {
         );
     }
 }
-

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
@@ -1,5 +1,6 @@
 package com.venueon.user.adapter.out.persistence.entity;
 
+import com.venueon.user.domain.model.AuthProvider;
 import com.venueon.user.domain.model.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,6 +34,11 @@ public class UserJpaEntity {
     @Column(nullable = false)
     private UserRole role;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private AuthProvider provider = AuthProvider.LOCAL;
+
     @Column(name = "profile_img")
     private String profileImg;
 
@@ -50,4 +56,3 @@ public class UserJpaEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }
-

--- a/backend/src/main/java/com/venueon/user/application/port/in/GoogleLoginUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/GoogleLoginUseCase.java
@@ -1,0 +1,18 @@
+package com.venueon.user.application.port.in;
+
+/**
+ * 구글 소셜 로그인 유스케이스 (Port-In)
+ * Google ID Token을 검증하고 JWT를 발급한다.
+ */
+public interface GoogleLoginUseCase {
+
+    /**
+     * 구글 ID Token으로 로그인/회원가입 처리
+     * - 기존 회원이면 JWT 발급
+     * - 신규 회원이면 자동 가입 후 JWT 발급
+     *
+     * @param idTokenString 프론트엔드에서 전달받은 Google ID Token
+     * @return LoginResult (JWT + 사용자 정보)
+     */
+    LoginUseCase.LoginResult googleLogin(String idTokenString);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/UpgradeToHostUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/UpgradeToHostUseCase.java
@@ -1,0 +1,12 @@
+package com.venueon.user.application.port.in;
+
+import com.venueon.user.domain.model.User;
+
+/**
+ * 인증된 일반 사용자(USER) → 호스트(HOST)로 업그레이드
+ * 구글 소셜 로그인 후 호스트 가입 2단계에서 사용
+ */
+public interface UpgradeToHostUseCase {
+    User upgradeToHost(String email, String managerName,
+                       String orgName, String orgNumber, String orgDescription);
+}

--- a/backend/src/main/java/com/venueon/user/application/service/AuthService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/AuthService.java
@@ -1,21 +1,28 @@
 package com.venueon.user.application.service;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
 import com.venueon.common.annotation.UseCase;
 import com.venueon.common.exception.BusinessException;
 import com.venueon.common.exception.ErrorCode;
 import com.venueon.user.adapter.in.security.JwtTokenProvider;
-import com.venueon.user.application.port.in.GetUserInfoUseCase;
-import com.venueon.user.application.port.in.HostSignUpUseCase;
-import com.venueon.user.application.port.in.LoginUseCase;
-import com.venueon.user.application.port.in.SignUpUseCase;
+import com.venueon.user.application.port.in.*;
 import com.venueon.user.application.port.out.HostProfileRepositoryPort;
 import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.AuthProvider;
 import com.venueon.user.domain.model.HostProfile;
 import com.venueon.user.domain.model.User;
 import com.venueon.user.domain.model.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * 회원가입/로그인 비즈니스 로직
@@ -23,16 +30,20 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * - 이메일 중복 체크
  * - JWT 발급 위임
  * - 호스트 가입 시 HostProfile 분리 저장
+ * - 구글 소셜 로그인 (ID Token 검증 + 자동 가입)
  */
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
-public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCase, GetUserInfoUseCase {
+public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCase, GetUserInfoUseCase, GoogleLoginUseCase, UpgradeToHostUseCase {
 
     private final UserRepositoryPort userRepositoryPort;
     private final HostProfileRepositoryPort hostProfileRepositoryPort;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${google.client-id:}")
+    private String googleClientId;
 
     @Override
     public User signUp(String email, String password, String nickname, String role) {
@@ -56,7 +67,7 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
 
         // 도메인 모델 생성 및 저장
         User user = new User(null, email, encodedPassword, nickname, userRole,
-                null, null, null, null);
+                AuthProvider.LOCAL, null, null, null, null);
         User savedUser = userRepositoryPort.save(user);
 
         log.info("회원가입 완료: email={}, role={}", email, userRole);
@@ -78,7 +89,7 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
 
         // User 저장 (role=HOST)
         User user = new User(null, email, encodedPassword, managerName, UserRole.HOST,
-                null, null, null, null);
+                AuthProvider.LOCAL, null, null, null, null);
         User savedUser = userRepositoryPort.save(user);
 
         // HostProfile 저장
@@ -100,6 +111,11 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
         User user = userRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."));
 
+        // 구글 소셜 계정은 비밀번호 로그인 불가
+        if (user.isGoogleUser()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "구글 소셜 로그인으로 가입된 계정입니다. 구글 로그인을 이용해 주세요.");
+        }
+
         // 비밀번호 검증
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
@@ -113,9 +129,109 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
     }
 
     @Override
+    public LoginResult googleLogin(String idTokenString) {
+        log.debug("구글 소셜 로그인 시도");
+
+        // 1. Google ID Token 검증
+        GoogleIdToken.Payload payload = verifyGoogleToken(idTokenString);
+        String email = payload.getEmail();
+        String name = (String) payload.get("name");
+        String picture = (String) payload.get("picture");
+
+        log.debug("구글 토큰 검증 완료: email={}, name={}", email, name);
+
+        // 2. 기존 회원 조회 or 자동 가입
+        Optional<User> existingUser = userRepositoryPort.findByEmail(email);
+        User user;
+
+        if (existingUser.isPresent()) {
+            user = existingUser.get();
+            log.info("구글 로그인 - 기존 회원: email={}", email);
+        } else {
+            // 소셜 로그인 사용자는 랜덤 비밀번호 (비밀번호 로그인 불가)
+            String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+            String nickname = (name != null && !name.isBlank()) ? name : email.split("@")[0];
+
+            user = new User(null, email, randomPassword, nickname, UserRole.USER,
+                    AuthProvider.GOOGLE, picture, null, null, null);
+            user = userRepositoryPort.save(user);
+
+            log.info("구글 로그인 - 자동 가입 완료: email={}, nickname={}", email, nickname);
+        }
+
+        // 3. JWT 발급
+        String token = jwtTokenProvider.generateToken(user.getEmail(), user.getRole().name());
+
+        return new LoginResult(token, user.getEmail(), user.getNickname(), user.getRole().name());
+    }
+
+    @Override
+    public User upgradeToHost(String email, String managerName,
+                              String orgName, String orgNumber, String orgDescription) {
+        log.debug("호스트 업그레이드 시도: email={}", email);
+
+        // 사용자 조회
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+
+        // 이미 HOST인 경우
+        if (user.getRole() == UserRole.HOST) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 호스트로 등록된 계정입니다.");
+        }
+
+        // role 업그레이드: USER → HOST
+        User upgradedUser = new User(
+                user.getId(), user.getEmail(), user.getPassword(), managerName,
+                UserRole.HOST, user.getProvider(),
+                user.getProfileImg(), user.getPhone(), user.getCreatedAt(), user.getUpdatedAt()
+        );
+        User savedUser = userRepositoryPort.save(upgradedUser);
+
+        // HostProfile 생성
+        HostProfile hostProfile = new HostProfile(
+                null, savedUser.getId(), orgName, orgNumber,
+                managerName, orgDescription != null ? orgDescription : "", null, null
+        );
+        hostProfileRepositoryPort.save(hostProfile);
+
+        log.info("호스트 업그레이드 완료: email={}, orgName={}", email, orgName);
+        return savedUser;
+    }
+
+    @Override
     public User getUserByEmail(String email) {
         return userRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
     }
-}
 
+    /**
+     * Google ID Token 검증
+     */
+    private GoogleIdToken.Payload verifyGoogleToken(String idTokenString) {
+        try {
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
+                    new NetHttpTransport(), GsonFactory.getDefaultInstance())
+                    .setAudience(Collections.singletonList(googleClientId))
+                    .build();
+
+            GoogleIdToken idToken = verifier.verify(idTokenString);
+            if (idToken == null) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED, "유효하지 않은 구글 토큰입니다.");
+            }
+
+            GoogleIdToken.Payload payload = idToken.getPayload();
+
+            // 이메일 인증 여부 확인
+            if (!Boolean.TRUE.equals(payload.getEmailVerified())) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 인증이 완료되지 않은 구글 계정입니다.");
+            }
+
+            return payload;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("구글 토큰 검증 실패", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "구글 토큰 검증에 실패했습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/venueon/user/domain/model/AuthProvider.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/AuthProvider.java
@@ -1,0 +1,10 @@
+package com.venueon.user.domain.model;
+
+/**
+ * 인증 제공자 구분
+ * - LOCAL: 이메일/비밀번호 회원가입
+ * - GOOGLE: 구글 소셜 로그인
+ */
+public enum AuthProvider {
+    LOCAL, GOOGLE
+}

--- a/backend/src/main/java/com/venueon/user/domain/model/User.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/User.java
@@ -14,6 +14,7 @@ public class User {
     private String password;
     private String nickname;
     private UserRole role;
+    private AuthProvider provider;
     private String profileImg;
     private String phone;
     private LocalDateTime createdAt;
@@ -24,17 +25,25 @@ public class User {
 
     // 전체 필드 생성자
     public User(Long id, String email, String password, String nickname, UserRole role,
-                String profileImg, String phone,
+                AuthProvider provider, String profileImg, String phone,
                 LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.role = role;
+        this.provider = provider != null ? provider : AuthProvider.LOCAL;
         this.profileImg = profileImg;
         this.phone = phone;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    // 이전 생성자와의 호환성 유지
+    public User(Long id, String email, String password, String nickname, UserRole role,
+                String profileImg, String phone,
+                LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this(id, email, password, nickname, role, AuthProvider.LOCAL, profileImg, phone, createdAt, updatedAt);
     }
 
     // --- 비즈니스 행위 메서드 ---
@@ -45,6 +54,10 @@ public class User {
 
     public boolean isAdmin() {
         return this.role == UserRole.ADMIN;
+    }
+
+    public boolean isGoogleUser() {
+        return this.provider == AuthProvider.GOOGLE;
     }
 
     public void updateProfile(String nickname, String profileImg) {
@@ -65,9 +78,9 @@ public class User {
     public String getPassword() { return password; }
     public String getNickname() { return nickname; }
     public UserRole getRole() { return role; }
+    public AuthProvider getProvider() { return provider; }
     public String getProfileImg() { return profileImg; }
     public String getPhone() { return phone; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
 }
-

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -31,3 +31,6 @@ logging.level.org.hibernate.SQL=DEBUG
 # Toss Payments (Test)
 toss.client-key=${TOSS_CLIENT_KEY}
 toss.secret-key=${TOSS_SECRET_KEY}
+
+# Google OAuth2
+google.client-id=${GOOGLE_CLIENT_ID:}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       # Toss Payments
       - TOSS_CLIENT_KEY=${TOSS_CLIENT_KEY}
       - TOSS_SECRET_KEY=${TOSS_SECRET_KEY}
+      # Google OAuth2
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       # CORS
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
       # 이미지 업로드 (컨테이너 내부 경로)
@@ -66,6 +68,7 @@ services:
       - SESSION_SECRET=${SESSION_SECRET}
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
       - API_BASE_URL=${API_BASE_URL}
+      - NEXT_PUBLIC_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@tosspayments/tosspayments-sdk": "^2.3.1",
+        "@tosspayments/tosspayments-sdk": "^2.6.0",
         "date-fns": "^4.1.0",
         "iron-session": "^8.0.4",
         "lucide-react": "^1.7.0",
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1287,7 +1286,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1347,7 +1345,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1873,7 +1870,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2217,7 +2213,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2791,7 +2786,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2977,7 +2971,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4891,7 +4884,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4901,7 +4893,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5569,7 +5560,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5732,7 +5722,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6014,7 +6003,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tosspayments/tosspayments-sdk": "^2.6.0",
     "date-fns": "^4.1.0",
-    "@tosspayments/tosspayments-sdk": "^2.3.1",
     "iron-session": "^8.0.4",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",

--- a/frontend/src/app/(auth)/_components/AuthFormLayout.tsx
+++ b/frontend/src/app/(auth)/_components/AuthFormLayout.tsx
@@ -17,6 +17,10 @@ interface AuthFormLayoutProps {
   secondaryFooterText?: string;
   secondaryFooterLinkText?: string;
   secondaryFooterLinkHref?: string;
+  /** 상단 영역 밖의 추가 UI (예: 회원가입용 위쪽 구글 소셜 로그인) */
+  topSlot?: React.ReactNode;
+  /** 하단 영역 추가 UI (예: 로그인용 아래쪽 구글 소셜 로그인) */
+  bottomSlot?: React.ReactNode;
 }
 
 export default function AuthFormLayout({
@@ -33,10 +37,15 @@ export default function AuthFormLayout({
   secondaryFooterText,
   secondaryFooterLinkText,
   secondaryFooterLinkHref,
+  topSlot,
+  bottomSlot,
 }: AuthFormLayoutProps) {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>{title}</h1>
+
+      {/* 상단 추가 영역 */}
+      {topSlot}
 
       <form onSubmit={onSubmit} className={styles.form}>
         {children}
@@ -47,6 +56,9 @@ export default function AuthFormLayout({
           {loading ? loadingText : submitText}
         </Button>
       </form>
+
+      {/* 하단 추가 영역 */}
+      {bottomSlot}
 
       <div className={styles.footer}>
         {footerText}{" "}
@@ -66,4 +78,3 @@ export default function AuthFormLayout({
     </div>
   );
 }
-

--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.module.css
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.module.css
@@ -1,0 +1,58 @@
+.container {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+/* ── 구분선: "또는" ── */
+.divider {
+  position: relative;
+  width: 100%;
+  text-align: center;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: calc(50% - 24px);
+  height: 1px;
+  background-color: var(--color-border, #ddd);
+}
+
+.divider::before {
+  left: 0;
+}
+
+.divider::after {
+  right: 0;
+}
+
+.dividerText {
+  display: inline-block;
+  padding: 0 12px;
+  font-size: 13px;
+  color: var(--color-text-muted, #888);
+  background-color: var(--color-bg, #fff);
+  position: relative;
+  z-index: 1;
+}
+
+/* ── 구글 버튼 래퍼 ── */
+.googleButton {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+/* Google 렌더 버튼이 width 100%를 차지하도록 */
+.googleButton > div {
+  width: 100% !important;
+}
+
+.googleButton iframe {
+  width: 100% !important;
+}

--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useRef, useCallback, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { authAPI } from "@/lib/auth-api";
+import { useAuth } from "@/store/useAuthStore";
+import { useUIStore } from "@/store/useUIStore";
+import styles from "./GoogleLoginButton.module.css";
+
+/**
+ * 구글 소셜 로그인 버튼
+ * Google Identity Services (GIS) 라이브러리를 사용하여
+ * 사용자가 구글 계정으로 로그인/회원가입할 수 있도록 한다.
+ * NEXT_PUBLIC_GOOGLE_CLIENT_ID 가 설정되지 않으면 아무것도 렌더링하지 않는다.
+ *
+ * ※ SSR/CSR hydration mismatch 방지를 위해
+ *   초기 렌더에서는 항상 null → useEffect 후에만 표시
+ */
+interface GoogleLoginButtonProps {
+  /** "top"이면 상단 배치용 (버튼 -> 구분선), "bottom"이면 하단 배치용 (구분선 -> 버튼) */
+  position?: "top" | "bottom";
+  /** 구글 로그인 완료 후 이동할 경로 (지정하지 않으면 searchParams의 redirect 또는 "/" 로 이동) */
+  redirectTo?: string;
+}
+
+function GoogleLoginButtonContent({ position = "bottom", redirectTo }: GoogleLoginButtonProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { checkSession } = useAuth();
+  const { showToast } = useUIStore();
+  const googleButtonRef = useRef<HTMLDivElement>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const handleGoogleCallback = useCallback(
+    async (response: { credential: string }) => {
+      try {
+        await authAPI.googleLogin(response.credential);
+        await checkSession();
+        showToast("구글 로그인 성공!", "success");
+        const nextUrl = redirectTo || searchParams.get("redirect") || "/";
+        router.push(nextUrl);
+        router.refresh();
+      } catch (err: any) {
+        const msg = err.message || "구글 로그인에 실패했습니다.";
+        showToast(msg, "error");
+      }
+    },
+    [router, searchParams, checkSession, showToast, redirectTo]
+  );
+
+  // 1단계: 클라이언트에서만 isReady 판별
+  useEffect(() => {
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    if (clientId) {
+      setIsReady(true);
+    }
+  }, []);
+
+  // 2단계: isReady && ref가 DOM에 붙은 뒤 Google 스크립트 초기화
+  useEffect(() => {
+    if (!isReady) return;
+
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
+
+    function initializeGoogle() {
+      const google = (window as any).google;
+      if (!google?.accounts?.id || !googleButtonRef.current) return;
+
+      google.accounts.id.initialize({
+        client_id: clientId,
+        callback: handleGoogleCallback,
+      });
+
+      google.accounts.id.renderButton(googleButtonRef.current, {
+        type: "standard",
+        theme: "outline",
+        size: "large",
+        text: "continue_with",
+        shape: "rectangular",
+        logo_alignment: "left",
+        width: googleButtonRef.current.offsetWidth,
+        locale: "ko",
+      });
+    }
+
+    const existingScript = document.querySelector(
+      'script[src="https://accounts.google.com/gsi/client"]'
+    );
+
+    if (!existingScript) {
+      const script = document.createElement("script");
+      script.src = "https://accounts.google.com/gsi/client";
+      script.async = true;
+      script.defer = true;
+      script.onload = () => initializeGoogle();
+      document.head.appendChild(script);
+    } else if ((window as any).google?.accounts?.id) {
+      initializeGoogle();
+    } else {
+      existingScript.addEventListener("load", () => initializeGoogle());
+    }
+  }, [isReady, handleGoogleCallback]);
+
+  // SSR과 CSR 초기 렌더 모두 null → hydration mismatch 없음
+  if (!isReady) return null;
+
+  return (
+    <div className={styles.container}>
+      {position === "top" ? (
+        <>
+          <div ref={googleButtonRef} className={styles.googleButton} />
+          <div className={styles.divider}>
+            <span className={styles.dividerText}>또는</span>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className={styles.divider}>
+            <span className={styles.dividerText}>또는</span>
+          </div>
+          <div ref={googleButtonRef} className={styles.googleButton} />
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function GoogleLoginButton(props: GoogleLoginButtonProps) {
+  return (
+    <Suspense fallback={null}>
+      <GoogleLoginButtonContent {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/(auth)/host-signup/complete/page.tsx
+++ b/frontend/src/app/(auth)/host-signup/complete/page.tsx
@@ -1,27 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { authAPI } from "@/lib/auth-api";
+import { useAuth } from "@/store/useAuthStore";
 import { useUIStore } from "@/store/useUIStore";
 import InputField from "@/components/ui/InputField";
 import UploadField from "@/components/ui/UploadField";
-import AuthFormLayout from "../_components/AuthFormLayout";
-import GoogleLoginButton from "../_components/GoogleLoginButton";
+import AuthFormLayout from "../../_components/AuthFormLayout";
 import HostAgreementSection, {
   HostAgreementState,
   isHostRequiredAgreed,
-} from "./_components/HostAgreementSection/HostAgreementSection";
-import styles from "./page.module.css";
+} from "../_components/HostAgreementSection/HostAgreementSection";
 
-export default function HostSignupPage() {
+export default function HostSignupCompletePage() {
   const router = useRouter();
+  const { user, checkSession } = useAuth();
   const { showToast } = useUIStore();
-
-  // 계정 정보
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [passwordConfirm, setPasswordConfirm] = useState("");
 
   // 호스트 정보
   const [organizationName, setOrganizationName] = useState("");
@@ -39,6 +34,17 @@ export default function HostSignupPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    // 세션이 없으면 로그인 페이지로 리다이렉트
+    if (!user) {
+      showToast("로그인이 필요합니다.", "error");
+      router.push("/login?redirect=/host-signup/complete");
+    } else if (user.role === "HOST") {
+      showToast("이미 호스트로 등록된 계정입니다.", "error");
+      router.push("/host/dashboard");
+    }
+  }, [user, router, showToast]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -50,32 +56,23 @@ export default function HostSignupPage() {
       return;
     }
 
-
-
     setLoading(true);
 
     try {
-      if (password !== passwordConfirm) {
-        throw new Error("비밀번호가 일치하지 않습니다.");
-      }
-      if (password.length < 8) {
-        throw new Error("비밀번호는 8자 이상이어야 합니다.");
-      }
-
-      // 호스트 전용 signup API 호출
-      await authAPI.hostSignup({
-        email,
-        password,
+      // 업그레이드 API 호출
+      await authAPI.upgradeToHost({
         managerName,
         orgName: organizationName,
         orgNumber: businessNumber,
         orgDescription: "",
       });
 
-      showToast("호스트 가입 신청이 완료되었습니다.", "success");
-      router.push("/login");
+      // 세션 다시 확인 (역할 갱신)
+      await checkSession();
+      showToast("호스트 프로필 등록이 완료되었습니다.", "success");
+      router.push("/host/dashboard");
     } catch (err: any) {
-      const msg = err.message || "호스트 가입에 실패했습니다.";
+      const msg = err.message || "호스트 정보 등록에 실패했습니다.";
       setError(msg);
       showToast(msg, "error");
     } finally {
@@ -83,53 +80,23 @@ export default function HostSignupPage() {
     }
   };
 
+  if (!user || user.role === "HOST") return null;
+
   return (
     <AuthFormLayout
-      title="호스트 회원 가입"
+      title="호스트 정보 입력"
       onSubmit={handleSubmit}
       loading={loading}
-      submitText="호스트 가입 신청"
-      loadingText="신청 처리 중..."
+      submitText="호스트 정보 등록 완료"
+      loadingText="등록 처리 중..."
       error={error}
-      footerText="일반 회원으로 가입하시겠어요?"
-      footerLinkText="일반 회원가입"
-      footerLinkHref="/signup"
-      topSlot={<GoogleLoginButton position="top" redirectTo="/host-signup/complete" />}
+      footerText=""
+      footerLinkText="이전으로 돌아가기"
+      footerLinkHref="/host-signup"
     >
-      {/* ── 계정 정보 ── */}
-      <InputField
-        id="host-email"
-        label="이메일"
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="이메일을 입력하세요."
-      />
-      <InputField
-        id="host-password"
-        label="비밀번호"
-        type="password"
-        required
-        minLength={8}
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="********"
-      />
-      <InputField
-        id="host-passwordConfirm"
-        label="비밀번호 확인"
-        type="password"
-        required
-        minLength={8}
-        value={passwordConfirm}
-        onChange={(e) => setPasswordConfirm(e.target.value)}
-        placeholder="********"
-      />
-
-      {/* ── 호스트 정보 구분선 ── */}
-      <div className={styles.sectionDivider}>
-        <span className={styles.sectionLabel}>호스트 정보</span>
+      <div style={{ marginBottom: "20px", textAlign: "center", color: "#666" }}>
+        <p>구글 계정으로 로그인되었습니다.</p>
+        <p>호스트로 활동하기 위해 추가 정보를 입력해 주세요.</p>
       </div>
 
       <InputField

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/store/useAuthStore";
 import { useUIStore } from "@/store/useUIStore";
 import InputField from "@/components/ui/InputField";
 import AuthFormLayout from "../_components/AuthFormLayout";
+import GoogleLoginButton from "../_components/GoogleLoginButton";
 import React from "react";
 
 function LoginContent() {
@@ -52,6 +53,7 @@ function LoginContent() {
       footerText="비밀번호를 잊으셨나요?"
       footerLinkText="비밀번호 찾기"
       footerLinkHref="#"
+      bottomSlot={<GoogleLoginButton position="bottom" />}
     >
       <InputField
         id="email"
@@ -82,4 +84,3 @@ export default function LoginPage() {
     </React.Suspense>
   );
 }
-

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -6,6 +6,7 @@ import { authAPI } from "@/lib/auth-api";
 import { useUIStore } from "@/store/useUIStore";
 import InputField from "@/components/ui/InputField";
 import AuthFormLayout from "../_components/AuthFormLayout";
+import GoogleLoginButton from "../_components/GoogleLoginButton";
 import AgreementSection, { AgreementState, isRequiredAgreed } from "./_components/AgreementSection/AgreementSection";
 
 export default function SignupPage() {
@@ -69,6 +70,7 @@ export default function SignupPage() {
       secondaryFooterText="호스트로 가입하시겠어요?"
       secondaryFooterLinkText="호스트 가입"
       secondaryFooterLinkHref="/host-signup"
+      topSlot={<GoogleLoginButton position="top" />}
     >
       <InputField
         id="email"
@@ -112,4 +114,3 @@ export default function SignupPage() {
     </AuthFormLayout>
   );
 }
-

--- a/frontend/src/app/api/auth/google/route.ts
+++ b/frontend/src/app/api/auth/google/route.ts
@@ -1,0 +1,65 @@
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/auth/google — 구글 소셜 로그인 BFF
+ * 1. 프론트엔드에서 Google ID Token 수신
+ * 2. Spring Boot /auth/google 로 전달 → JWT + 사용자정보 반환
+ * 3. iron-session에 저장 후 클라이언트에 사용자정보 전달
+ */
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+    // 1. Spring Boot Google 로그인 엔드포인트 호출
+    const googleRes = await fetch(`${API_BASE}/auth/google`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ idToken: body.idToken }),
+    });
+
+    if (!googleRes.ok) {
+      const error = await googleRes.json().catch(() => ({}));
+      return NextResponse.json(error, { status: googleRes.status });
+    }
+
+    const loginData = await googleRes.json();
+
+    // 2. JWT로 사용자 정보 조회
+    const meRes = await fetch(`${API_BASE}/auth/me`, {
+      headers: { Authorization: `Bearer ${loginData.token}` },
+    });
+
+    const userData = meRes.ok ? await meRes.json() : loginData;
+
+    // 3. iron-session에 JWT + 사용자 정보 저장
+    const cookieStore = await cookies();
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+    session.jwt = loginData.token;
+    session.email = userData.email;
+    session.nickname = userData.nickname;
+    session.profileImg = userData.profileImg;
+    session.role = userData.role;
+    session.userId = userData.id;
+    session.isLoggedIn = true;
+    await session.save();
+
+    // 4. 브라우저에겐 JWT 없이 사용자 정보만 반환
+    return NextResponse.json({
+      user: {
+        id: userData.id,
+        email: userData.email,
+        nickname: userData.nickname,
+        role: userData.role,
+        profileImg: userData.profileImg,
+      },
+      success: true,
+    });
+  } catch (error) {
+    console.error("Google Login API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/auth/host/upgrade/route.ts
+++ b/frontend/src/app/api/auth/host/upgrade/route.ts
@@ -1,0 +1,42 @@
+import { getIronSession } from "iron-session";
+import { cookies } from "next/headers";
+import { SessionData, sessionOptions } from "@/lib/session";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const cookieStore = await cookies();
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+
+    if (!session.jwt) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const API_BASE = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+    const res = await fetch(`${API_BASE}/auth/host/upgrade`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.jwt}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    // 세션 정보 업데이트 (USER -> HOST)
+    session.role = "HOST";
+    await session.save();
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Host Upgrade API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -35,7 +35,8 @@ export default function Header({
 
   // /mypage 경로일 때는 항상 'signedIn' 해더(내 강의실 + 프로필)를 보여주도록 강제
   const isMyPage = pathname?.startsWith('/mypage');
-  const status = propStatus || (isMyPage ? 'signedIn' : 'public');
+  // user가 로그인되어 있으면 signedIn, 아니면 public (propStatus가 있으면 우선)
+  const status = propStatus || (user ? 'signedIn' : (isMyPage ? 'signedIn' : 'public'));
 
   // 우측에 렌더링될 버튼/프로필 그룹 로직
   const renderActions = () => {
@@ -71,6 +72,7 @@ export default function Header({
           <div className={styles.actionGroup}>
             <Link href="/dashboard"><Button variant="outlined" size="medium">내 강의실</Button></Link>
             <UserProfile name={displayUserName} imageUrl={displayUserImage} size="large" />
+            <Button variant="secondary" size="medium" onClick={logout}>로그아웃</Button>
           </div>
         );
       }

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -29,6 +29,31 @@ export const authAPI = {
     if (!res.ok) throw new Error(result.message || result.error || '로그인 실패');
     return result;
   },
+  googleLogin: async (idToken: string) => {
+    const res = await fetch('/api/auth/google', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ idToken }),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '구글 로그인 실패');
+    return result;
+  },
+  upgradeToHost: async (data: {
+    managerName: string;
+    orgName: string;
+    orgNumber: string;
+    orgDescription?: string;
+  }) => {
+    const res = await fetch('/api/auth/host/upgrade', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '호스트 가입 처리에 실패했습니다.');
+    return result;
+  },
   logout: async () => {
     const res = await fetch('/api/auth/logout', { method: 'POST' });
     return res.json().catch(() => ({}));

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,29 @@
+## Ticket
+- **VO-559**: 구글 소셜 로그인 연동 (일반 회원가입/로그인)
+- **VO-600**: 구글 로그인 기반 호스트 업그레이드 연동 (2단계 플로우)
+
+## Description
+본 PR은 VenueOn 플랫폼에 **Google Social Login (Google Identity Services)** 연동을 성공적으로 구현하고, 호스트 회원가입의 **2단계 플로우 (일반가입 -> 호스트 정보작성)** 기능을 완료한 작업입니다.
+
+### 1. 구글 소셜 로그인
+- **BFF (Backend-for-Frontend) Proxy**: `/api/auth/google` 구현. Google ID 토큰을 백엔드로 안전하게 전달
+- **Backend Auth Flow (`AuthController`)**: 전달받은 ID Token을 검증 후 신규 유저는 자동 회원가입 처리, 기존 유저는 즉시 로그인 처리
+- **Frontend Components**: `GoogleLoginButton` 구현
+  - 로그인/회원가입/호스트가입 각 용도에 맞추어 `position`과 `redirectTo` prop 적용
+  - Hydration mismatch와 SSR+CSR 이슈를 효과적으로 해결하기 위한 단계적 스크립트 로드 적용
+  - 빌드 시 에러 방지(`useSearchParams` CSR 렌더 처리)를 위해 React Suspense 래핑 적용
+
+### 2. 호스트 업그레이드 플로우 (2-Step)
+- **Backend (`UpgradeToHostUseCase`)**: `POST /auth/host/upgrade` 라우트 구현
+  - 일반 `USER` 권한 사용자가 추가 정보(기관명, 담당자명, 사업자번호 등)를 제공 시 `HOST`로 권한 갱신 및 `HostProfile` 생성
+- **Frontend Flow**: 
+  - 호스트 회원가입 페이지에서 구글 로그인 시 `/host-signup/complete` 로 리다이렉트 (회원정보 외 추가 정보만 입력하여 UX 개선)
+  - BFF에 `/api/auth/host/upgrade` 라우트 생성 (세션내 JWT 포함하여 서버 요청 & 요청 성공 시 Session Update)
+
+### 3. 헤더 UI 버그 픽스 및 로그인 관리
+- `Header.tsx`: React Hydration 이후 Auth Store 상태를 정상적으로 활용하도록 `signedIn` 상태 결정 로직 보완
+- 사용자 Action 분기점에 로그아웃 버튼 노출 보장
+
+## To Reviewers
+- 구글 로그인은 현재 개발환경에서 `application-dev.properties` 및 `.env` 등에서 발급받은 `GOOGLE_CLIENT_ID`가 필요합니다. 테스트를 위해 해당 변수를 확인해주세요.
+- 추후 배포 파이프라인에서 Variable 지원을 하도록 `.github/workflows/deploy.yml` 에 `GOOGLE_CLIENT_ID` 환경 변수 주입 맵핑이 추가되었습니다! 


### PR DESCRIPTION
## Ticket
- **VO-559**: 구글 소셜 로그인 연동 (일반 회원가입/로그인)
- **VO-600**: 구글 회원가입 기반 호스트 업그레이드 연동 (2단계 플로우)

## Description
본 PR은 VenueOn 플랫폼에 **Google Social Login (Google Identity Services)** 연동을 성공적으로 구현하고, 호스트 회원가입의 **2단계 플로우 (일반가입 -> 호스트 정보작성)** 기능을 완료한 작업입니다.

### 1. 구글 소셜 로그인
- **BFF (Backend-for-Frontend) Proxy**: `/api/auth/google` 구현. Google ID 토큰을 백엔드로 안전하게 전달
- **Backend Auth Flow (`AuthController`)**: 전달받은 ID Token을 검증 후 신규 유저는 자동 회원가입 처리, 기존 유저는 즉시 로그인 처리
- **Frontend Components**: `GoogleLoginButton` 구현
  - 로그인/회원가입/호스트가입 각 용도에 맞추어 `position`과 `redirectTo` prop 적용
  - Hydration mismatch와 SSR+CSR 이슈를 효과적으로 해결하기 위한 단계적 스크립트 로드 적용
  - 빌드 시 에러 방지(`useSearchParams` CSR 렌더 처리)를 위해 React Suspense 래핑 적용

### 2. 호스트 업그레이드 플로우 (2-Step)
- **Backend (`UpgradeToHostUseCase`)**: `POST /auth/host/upgrade` 라우트 구현
  - 일반 `USER` 권한 사용자가 추가 정보(기관명, 담당자명, 사업자번호 등)를 제공 시 `HOST`로 권한 갱신 및 `HostProfile` 생성
- **Frontend Flow**: 
  - 호스트 회원가입 페이지에서 구글 로그인 시 `/host-signup/complete` 로 리다이렉트 (회원정보 외 추가 정보만 입력하여 UX 개선)
  - BFF에 `/api/auth/host/upgrade` 라우트 생성 (세션내 JWT 포함하여 서버 요청 & 요청 성공 시 Session Update)

### 3. 헤더 UI 버그 픽스 및 로그인 관리
- `Header.tsx`: React Hydration 이후 Auth Store 상태를 정상적으로 활용하도록 `signedIn` 상태 결정 로직 보완
- 사용자 Action 분기점에 로그아웃 버튼 노출 보장

## To Reviewers
- 구글 로그인은 현재 개발환경에서 `application-dev.properties` 및 `.env` 등에서 발급받은 `GOOGLE_CLIENT_ID`가 필요합니다. 테스트를 위해 해당 변수를 확인해주세요.
- 추후 배포 파이프라인에서 Variable 지원을 하도록 `.github/workflows/deploy.yml` 에 `GOOGLE_CLIENT_ID` 환경 변수 주입 맵핑이 추가되었습니다! 
