### PR TITLE
feat: 토스페이먼츠 연결, 결제 검증(web hook), 결제 실패 처리 및 재시도 기능 구현

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/ConfirmPaymentResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/ConfirmPaymentResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ConfirmPaymentResponse {
     private Long orderId;
+    private String orderName;
     private String status;
     private int amount;
     private String paymentMethod;

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -143,11 +143,17 @@ public class OrderService {
      */
     @Transactional
     public void handleTossWebhook(Map<String, Object> payload) {
-        String paymentKey = (String) payload.get("paymentKey");
-        String tossOrderId = (String) payload.get("orderId");
-        String status = (String) payload.get("status");
+        log.info("토스 Webhook 원본 수신: {}", payload);
 
-        log.info("토스 Webhook 수신: tossOrderId={}, status={}", tossOrderId, status);
+        // 토스 웹훅은 보통 "data" 필드 안에 실제 상태값들이 들어 있습니다.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) payload.getOrDefault("data", payload);
+
+        String paymentKey = (String) data.get("paymentKey");
+        String tossOrderId = (String) data.get("orderId");
+        String status = (String) data.get("status");
+
+        log.info("토스 Webhook 파싱: tossOrderId={}, status={}", tossOrderId, status);
 
         // 1. 주문 모델 조회
         Order order = orderRepository.findByTossOrderId(tossOrderId).orElse(null);

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -128,8 +128,14 @@ public class OrderService {
 
         log.info("결제 승인 완료: orderId={}, paymentKey={}", orderId, request.getPaymentKey());
 
+        // 이벤트명(강의명) 조회
+        String orderName = eventRepository.findById(order.getEventId())
+                .map(com.venueon.event.adapter.out.persistence.entity.EventJpaEntity::getTitle)
+                .orElse("VenueOn 강의");
+
         return ConfirmPaymentResponse.builder()
                 .orderId(order.getId())
+                .orderName(orderName)
                 .status(order.getStatus().name())
                 .amount(order.getAmount())
                 .paymentMethod(order.getPaymentMethod())

--- a/frontend/src/app/orders/checkout/fail/fail.module.css
+++ b/frontend/src/app/orders/checkout/fail/fail.module.css
@@ -1,0 +1,45 @@
+/* 성공 페이지와 통일된 실패 페이지 레이아웃 */
+.pageContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 100px 24px;
+  gap: 32px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.headerSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  font-family: var(--font-inter, sans-serif);
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--color-error, #EF4444); /* 실패 느낌을 주는 붉은색 */
+  line-height: 1.2;
+  margin: 0;
+  text-align: center;
+}
+
+.subtitle {
+  font-family: var(--font-inter, sans-serif);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-gray-500, #6b7280);
+  line-height: 1.5;
+  margin: 0;
+  text-align: center;
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+  justify-content: center;
+}

--- a/frontend/src/app/orders/checkout/fail/page.tsx
+++ b/frontend/src/app/orders/checkout/fail/page.tsx
@@ -3,31 +3,53 @@
 import React, { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import styles from '../checkout.module.css';
+import failStyles from './fail.module.css';
 import { Button } from '@/components/ui';
 
 function CheckoutFailContent() {
   const searchParams = useSearchParams();
-  const code = searchParams.get('code') || '알 수 없는 오류';
-  const message = searchParams.get('message') || '결제 처리 중 문제가 발생했습니다.';
+  const rawCode = searchParams.get('code') || 'UNKNOWN_ERROR';
+  const rawMessage = searchParams.get('message') || '결제 처리 중 문제가 발생했습니다.';
+
+  // 토스 에러 코드 친화적 매핑 (대표적인 에러 위주로 처리)
+  let userFriendlyMessage = rawMessage;
+  if (rawCode === 'PAY_PROCESS_CANCELED') {
+    userFriendlyMessage = '결제를 진행 중에 취소하셨습니다.';
+  } else if (rawCode === 'PAY_PROCESS_ABORTED') {
+    userFriendlyMessage = '승인 과정에서 결제가 중단되었습니다.';
+  } else if (rawCode === 'REJECT_CARD_COMPANY') {
+    userFriendlyMessage = '카드사에 의해 결제가 거절되었습니다. 잔액이나 한도를 확인해주세요.';
+  } else if (rawCode === 'INVALID_CARD_COMPANY') {
+    userFriendlyMessage = '유효하지 않은 카드이거나, 카드 정보가 잘못 입력되었습니다.';
+  }
 
   return (
-    <div className={styles.checkoutContainer}>
-      <div className={styles.checkoutCard}>
-        <div style={{ textAlign: 'center', padding: '40px 0' }}>
-          <div style={{ fontSize: '48px', marginBottom: '16px' }}>❌</div>
-          <h2 style={{ marginBottom: '16px', color: 'var(--color-error)' }}>결제 실패</h2>
-          <p style={{ marginBottom: '24px' }}>
-            에러 코드: {code}<br />
-            {message && <span>메시지: {message}</span>}
-          </p>
-          <Button
-            variant="primary"
-            size="large"
-            onClick={() => window.history.back()}
-          >
-            다시 시도하기
-          </Button>
-        </div>
+    <div className={failStyles.pageContainer}>
+      <div className={failStyles.headerSection}>
+        <h1 className={failStyles.title}>결제에 실패했습니다</h1>
+        <p className={failStyles.subtitle}>
+          {userFriendlyMessage}<br />
+          아래 버튼을 눌러 다시 시도해주시거나 다른 결제 수단을 선택해주세요.
+        </p>
+      </div>
+
+      <div className={failStyles.buttonGroup}>
+        <Button
+          variant="outlined"
+          size="large"
+          style={{ flex: 1, backgroundColor: '#FFFFFF', borderColor: 'var(--color-gray-200, #E5E7EB)' }}
+          onClick={() => window.location.href = '/orders'}
+        >
+          내 주문 내역
+        </Button>
+        <Button
+          variant="primary"
+          size="large"
+          style={{ flex: 1, backgroundColor: 'var(--color-gray-900, #111827)', color: 'white', border: 'none' }}
+          onClick={() => window.history.back()}
+        >
+          결제 다시 시도
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/app/orders/checkout/success/page.tsx
+++ b/frontend/src/app/orders/checkout/success/page.tsx
@@ -3,6 +3,7 @@
 import React, { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import styles from '../checkout.module.css';
+import successStyles from './success.module.css';
 import { Button } from '@/components/ui';
 
 export default function CheckoutSuccessPage() {
@@ -69,7 +70,25 @@ function CheckoutSuccessContent() {
       } catch (err: any) {
         console.error('결제 승인 에러:', err);
         setStatus('error');
-        setMessage(err.message || '결제 승인 중 오류가 발생했습니다.');
+        
+        let friendlyMessage = '결제 승인 중 오류가 발생했습니다.';
+        const rawError = err.message || '';
+        
+        // 백엔드에서 뱉는 형태: "토스 결제 승인 실패: 400 Bad Request: "{...}"" 에서 메시지 추출
+        try {
+          const messageMatch = rawError.match(/"message":"([^"]+)"/);
+          if (messageMatch && messageMatch[1]) {
+            friendlyMessage = messageMatch[1];
+          } else if (rawError.includes('ALREADY_PROCESSED_PAYMENT')) {
+            friendlyMessage = '이미 처리된 결제입니다.';
+          } else {
+            // 다른 텍스트만 있다면 그대로 노출 방지(안전을 위해 일반화)
+          }
+        } catch(e) {
+          // 파싱 실패시 기본 메시지
+        }
+        
+        setMessage(friendlyMessage);
       }
     };
 
@@ -79,6 +98,65 @@ function CheckoutSuccessContent() {
   const formatPrice = (price: number) =>
     new Intl.NumberFormat('ko-KR').format(price) + '원';
 
+  if (status === 'success') {
+    return (
+      <div className={successStyles.pageContainer}>
+        <div className={successStyles.headerSection}>
+          <h1 className={successStyles.title}>수강 신청 완료!</h1>
+          <p className={successStyles.subtitle}>
+            교육 프로그램 등록이 완료되었습니다.<br />
+            상세 내역은 내 강의 목록에서 확인하실 수 있습니다.
+          </p>
+        </div>
+
+        {paymentInfo && (
+          <div className={successStyles.cardSection}>
+            <div className={successStyles.cardRow}>
+              <p className={successStyles.cardLabel}>주문 번호</p>
+              <p className={successStyles.cardValue}>#{paymentInfo.orderId}</p>
+            </div>
+            <div className={successStyles.cardRow}>
+              <p className={successStyles.cardLabel}>강의명</p>
+              <p className={successStyles.cardValue}>{paymentInfo.orderName || 'VenueOn 강의'}</p>
+            </div>
+            <div className={successStyles.cardRow}>
+              <p className={successStyles.cardLabel}>결제 금액</p>
+              <p className={successStyles.cardValue}>{formatPrice(paymentInfo.amount)}</p>
+            </div>
+          </div>
+        )}
+
+        <div className={successStyles.buttonGroup}>
+          <Button
+            variant="outlined"
+            size="large"
+            style={{ flex: 1, backgroundColor: '#FFFFFF', borderColor: 'var(--color-gray-200, #E5E7EB)' }}
+            onClick={() => window.location.href = '/orders'}
+          >
+            내 강의 목록
+          </Button>
+          <Button
+            variant="primary"
+            size="large"
+            style={{ flex: 1, backgroundColor: 'var(--color-gray-900, #111827)', color: 'white', border: 'none' }}
+            onClick={() => window.location.href = '/'}
+          >
+            커뮤니티 입장
+          </Button>
+        </div>
+
+        {/* 우측 하단 토스트 모달 (필요시 유지) */}
+        <div className={successStyles.toastContainer}>
+          <div className={successStyles.toastIcon}>🎉</div>
+          <div className={successStyles.toastContent}>
+            <h4 className={successStyles.toastTitle}>수강신청 완료!</h4>
+            <p className={successStyles.toastMessage}>성공적으로 등록되었습니다.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.checkoutContainer}>
       <div className={styles.checkoutCard}>
@@ -87,28 +165,6 @@ function CheckoutSuccessContent() {
             <>
               <div style={{ fontSize: '48px', marginBottom: '16px' }}>⏳</div>
               <p>{message}</p>
-            </>
-          )}
-
-          {status === 'success' && (
-            <>
-              <div style={{ fontSize: '48px', marginBottom: '16px' }}>✅</div>
-              <h2 style={{ marginBottom: '16px' }}>{message}</h2>
-              {paymentInfo && (
-                <div style={{ textAlign: 'left', margin: '24px 0', padding: '16px', background: 'var(--color-gray-50, #f9fafb)', borderRadius: '8px' }}>
-                  <p><strong>주문 번호:</strong> {paymentInfo.orderId}</p>
-                  <p><strong>결제 금액:</strong> {formatPrice(paymentInfo.amount)}</p>
-                  <p><strong>결제 수단:</strong> {paymentInfo.paymentMethod}</p>
-                  <p><strong>결제 상태:</strong> {paymentInfo.status}</p>
-                </div>
-              )}
-              <Button
-                variant="primary"
-                size="large"
-                onClick={() => window.location.href = '/orders'}
-              >
-                주문 내역으로 이동
-              </Button>
             </>
           )}
 

--- a/frontend/src/app/orders/checkout/success/success.module.css
+++ b/frontend/src/app/orders/checkout/success/success.module.css
@@ -1,0 +1,126 @@
+/* 피그마 디자인 기반 성공 페이지 레이아웃 */
+.pageContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 100px 24px;
+  gap: 32px;
+  max-width: 600px; /* 데스크탑 중앙 정렬을 위한 적절한 너비 */
+  margin: 0 auto;
+}
+
+.headerSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  font-family: var(--font-inter, sans-serif);
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--color-gray-900, #111827);
+  line-height: 1.2;
+  margin: 0;
+  text-align: center;
+}
+
+.subtitle {
+  font-family: var(--font-inter, sans-serif);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-gray-500, #6b7280);
+  line-height: 1.5;
+  margin: 0;
+  text-align: center;
+}
+
+.cardSection {
+  background: var(--color-gray-50, #f9fafb);
+  border-radius: 12px;
+  padding: 32px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.cardRow {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.cardRow:last-child {
+  margin-bottom: 0;
+}
+
+.cardLabel {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-gray-500, #6b7280);
+  margin: 0;
+}
+
+.cardValue {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-gray-900, #111827);
+  margin: 0;
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+  justify-content: center;
+}
+
+/* 토스트 모달 유지 */
+.toastContainer {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background-color: white;
+  padding: 16px 24px;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  z-index: 1000;
+  animation: slideInRight 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  border-left: 4px solid var(--color-primary);
+}
+
+.toastIcon {
+  font-size: 24px;
+}
+
+.toastContent {
+  text-align: left;
+}
+
+.toastTitle {
+  margin: 0 0 4px 0;
+  font-size: 16px;
+  color: var(--color-text-gray-900);
+}
+
+.toastMessage {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-secondary);
+}
+
+@keyframes slideInRight {
+  0% {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
🎯 작업 목적 및 배경
사용자가 세미나/강의를 결제할 수 있도록 토스 페이먼츠 결제 위젯을 성공적으로 연동하기 위함입니다. (VO-670)
클라이언트 조작 방지와 확실한 결제 승인을 위해 백엔드 Webhook 기반 결제 검증 로직을 추가했습니다. (VO-671)
결제 중도 취소나 잔액 부족 등 예외 상황 발생 시, 사용자에게 자연스러운 실패 안내와 재시도 경험을 제공하기 위해 UI/UX를 개선했습니다. (VO-672)

💡 주요 변경 사항
1. 토스 페이먼츠 연동 및 성공 페이지 (Success Page)
결제 위젯 연동 후 성공 시 반환되는 파라미터(orderId, paymentKey, amount)를 활용해 커스텀 백엔드 승인 API 호출.
피그마 디자인을 반영하여 세련된 회색 계열의 UI 카드로 success/page.tsx 레이아웃 개편.
결제가 완벽히 승인되었을 때 화면 우측 하단에서 나타나는 '🎉 수강신청 완료' 토스트 모달 애니메이션 추가.
2. 결제 검증 (Webhook)
Spring Boot 백엔드 OrderService에 웹훅 페이로드 처리를 위한 로직 개선.
토스에서 전송하는 중첩된 data 객체를 올바르게 파싱 및 추출하여 검증 오류 디버깅 보완.
ngrok을 활용한 로컬 무결성 테스트 완료.
3. 결제 실패 처리 및 안내 고도화 (Fail Page)
백엔드에서 내려오는 다소 불친절한 JSON 예외 문구나 토스의 영문 에러 코드(PAY_PROCESS_CANCELED, REJECT_CARD_COMPANY 등)를 클라이언트 단에서 가로채기.
사용자 친화적인 한국어 멘트(예: "카드사에 의해 결제가 거절되었습니다. 잔액을 확인해주세요.")로 자동 변환하여 표출.
실패 페이지(fail/page.tsx) 역시 성공 페이지 디자인과 완전히 동일한 UI 규격으로 통일해 UX 일관성 상승.
기존에 노출되던 원본 에러 코드를 내부적으로 숨기고, [내 주문 내역], [결제 다시 시도] 투트랙 버튼으로 빠른 문제 해결 유도.

📸 스크린샷
<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 2 43 49 PM" src="https://github.com/user-attachments/assets/7d5bfc8a-3d5d-403c-8f78-a85e592559ad" />
<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 2 43 53 PM" src="https://github.com/user-attachments/assets/e60d7080-5d58-4f7d-93f1-8733a2b8c8f3" />
<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 2 44 46 PM" src="https://github.com/user-attachments/assets/fbc0e8f3-0c5d-4b05-b7ec-88eb25e9afa4" />
<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 2 45 19 PM" src="https://github.com/user-attachments/assets/c6c176eb-8d85-4494-8961-aefe3c000624" />

📌 확인 사항 (리뷰 포인트)
TossPaymentClient에서 파싱하는 Webhook 페이로드 규격이 운영 서버와 동일하게 동작할 것으로 보이는지 확인해 주세요.
CSS 모듈(success.module.css, fail.module.css) 내의 변수들이 글로벌 토큰 디자인과 잘 어우러지는지 살펴봐 주세요.