### PR TITLE
fix: 구글 로그인 버튼 개인화 UI 잘림 현상 수정

### DIFF
--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.module.css
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.module.css
@@ -47,12 +47,3 @@
   display: flex;
   justify-content: center;
 }
-
-/* Google 렌더 버튼이 width 100%를 차지하도록 */
-.googleButton > div {
-  width: 100% !important;
-}
-
-.googleButton iframe {
-  width: 100% !important;
-}

--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
@@ -78,7 +78,6 @@ function GoogleLoginButtonContent({ position = "bottom", redirectTo }: GoogleLog
         text: "continue_with",
         shape: "rectangular",
         logo_alignment: "left",
-        width: googleButtonRef.current.offsetWidth,
         locale: "ko",
       });
     }


### PR DESCRIPTION
## Description
- 구글 로그인 위젯의 개인화된 텍스트(Continue as OOO)가 일정 길이 이상일 때 iframe 너비 강제 고정으로 인해 글씨가 잘리는 현상 수정
- iframe의 CSS 강제 100% 제거 및 JS의 파라미터 `width`를 제거하여 구글 스크립트가 능동적으로 가로 사이즈를 책정하도록 개선