### PR TITLE
fix: lib/api 경로 수정- 필요없는 /v1 rewrite  방식  제거 후 API 경로 규칙 통일

### DIFF
--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -104,8 +104,8 @@ export default function ProfileSettingsPage() {
   // 저장(확인) 클릭 - 실제 백엔드 연동 부분
   const handleSave = async () => {
     try {
-      // 프론트 Proxy 경로 (자동으로 /v1/users/me/profile 로 치환되며, 헤더에 토큰 자동 포함됨)
-      const res = await fetch('/api/v1/users/me/profile', {
+      // BFF 프록시 경로 (Route Handler가 /api 제거 후 백엔드로 전달, JWT 자동 포함)
+      const res = await fetch('/api/users/me/profile', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/app/mypage/security/page.tsx
+++ b/frontend/src/app/mypage/security/page.tsx
@@ -43,7 +43,7 @@ export default function SecuritySettingsPage() {
     }
     
     try {
-      const res = await fetch('/api/v1/users/me/password', {
+      const res = await fetch('/api/users/me/password', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,9 @@
 /**
  * API 유틸리티 — 백엔드 API 호출 공통 함수
- * 프록시를 통해 /v1/* 경로로 요청 (next.config.ts rewrites)
+ * /api/* 경로로 요청 → Route Handler([...path])가 JWT 주입 후 백엔드로 프록시
  */
 
-const API_BASE = "/v1";
+const API_BASE = "/api";
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string>;


### PR DESCRIPTION
close VO-815

## 🔧 fix: 프론트엔드 API 경로 규칙 통일 (`/v1` → `/api`)

### 📌 변경 이유

#### 우리 팀의 설계 규칙 (API 스펙 v5.1)
> **규칙:** 모든 백엔드 경로에 `/api` 미포함 (프론트엔드 BFF에서만 `/api/` 접두사 사용)

즉, 설계 의도는 다음과 같습니다:

| 계층 | 경로 예시 | 설명 |
|---|---|---|
| **백엔드 (Spring)** | `GET /host/seminars` | `/api` 없이 직접 경로 |
| **프론트엔드 (Next.js)** | `GET /api/host/seminars` | `/api/` 접두사를 붙여서 요청 |
| **Route Handler (BFF)** | `/api` 제거 → `/host/seminars` | JWT 주입 후 백엔드로 프록시 |

#### 문제: `/v1` rewrite가 설계와 다르게 사용되고 있었음

기존에 `lib/api.ts`가 `API_BASE = "/v1"`을 사용하고, `next.config.ts`의 rewrite로 `/v1/:path*` → `백엔드/:path*`로 전달하고 있었습니다.

```
❌ 기존 (설계와 다름)
프론트 → /v1/auth/login → next.config rewrite → http://localhost:8080/auth/login

✅ 설계 의도
프론트 → /api/auth/login → Route Handler (JWT 주입) → http://localhost:8080/auth/login
```

**문제점:**
1. `/v1` rewrite 방식은 단순 URL 치환만 하므로 **JWT가 주입되지 않음**
2. 이미 `app/api/[...path]/route.ts` (catch-all Route Handler)가 존재하며, 이 핸들러가 iron-session에서 JWT를 꺼내 `Authorization` 헤더에 주입하는 BFF 역할을 수행함
3. 설계 문서와 실제 코드가 불일치

#### `host-api.ts`는 왜 있었나?

`host-api.ts`는 `API_BASE = "/api"`를 사용하여 Route Handler를 경유하도록 만든 파일이었습니다.
호스트 API는 인증(JWT)이 필요하기 때문에 `/v1` rewrite가 아닌 `/api` Route Handler를 써야 했고,
그래서 별도 파일로 분리된 것입니다.

하지만 **`api.ts`도 `/api`를 사용하도록 수정하면 두 파일이 완전히 동일해지므로**,
굳이 분리할 필요가 없어집니다.

---

### 📝 변경 내용

#### 1. `frontend/src/lib/api.ts` — API_BASE 수정

```diff
- * 프록시를 통해 /v1/* 경로로 요청 (next.config.ts rewrites)
+ * /api/* 경로로 요청 → Route Handler([...path])가 JWT 주입 후 백엔드로 프록시

- const API_BASE = "/v1";
+ const API_BASE = "/api";
```

#### 2. `frontend/src/app/mypage/profile/page.tsx` — 이중 접두사 수정

```diff
- // 프론트 Proxy 경로 (자동으로 /v1/users/me/profile 로 치환되며, 헤더에 토큰 자동 포함됨)
- const res = await fetch('/api/v1/users/me/profile', {
+ // BFF 프록시 경로 (Route Handler가 /api 제거 후 백엔드로 전달, JWT 자동 포함)
+ const res = await fetch('/api/users/me/profile', {
```

> `/api/v1/...`은 Route Handler가 `/api`를 벗긴 뒤 `/v1/users/me/profile`로 백엔드에 요청하게 되어 404 에러가 발생합니다.

#### 3. `frontend/src/app/mypage/security/page.tsx` — 이중 접두사 수정

```diff
- const res = await fetch('/api/v1/users/me/password', {
+ const res = await fetch('/api/users/me/password', {
```

---

### ✅ 요약

- 프론트엔드의 모든 API 요청이 **`/api/` 접두사 하나로 통일**됩니다
- `next.config.ts`의 `/v1` rewrite는 이미 제거된 상태 (이미지 rewrite만 유지)
- 모든 요청이 `app/api/[...path]/route.ts`를 경유하므로 **JWT 자동 주입이 보장**됩니다

### 🔜 후속 작업 (선택)

- [ ] `host-api.ts` 삭제 및 `api.ts`로 통합 (동일한 역할)
- [ ] `host/page.tsx`, `host/seminars/page.tsx`에서 `import { hostApi }` → `import { api }` 변경
