### PR TITLE
feat: 어드민 대시보드 UI 구현 및 시안 반영 #VO-736 #VO-737

### DIFF
--- a/frontend/src/app/admin/_components/ActivityTable.module.css
+++ b/frontend/src/app/admin/_components/ActivityTable.module.css
@@ -1,0 +1,142 @@
+.container {
+  background: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+/* 탭과 검색바를 같은 행에 배치하기 위한 헤더 영역 */
+.tableHeaderArea {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end; /* 강조선 높이 일치 */
+  margin-bottom: var(--space-24);
+  border-bottom: 1px solid transparent; /* 가로선은 탭에만 위치 */
+}
+
+.tabs {
+  display: flex;
+  gap: var(--space-24);
+}
+
+.tab {
+  padding-bottom: var(--space-8);
+  font-family: 'Inter';
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 150%;
+  color: #6B7280;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition);
+  margin-bottom: -1px; /* 부모 경계와 겹침 처리 */
+}
+
+.activeTab {
+  color: #111827;
+  border-bottom-color: #111827;
+}
+
+.searchWrapper {
+  width: 320px;
+  padding-bottom: var(--space-4); /* 탭 강조선과 대략적인 수평 균형 */
+}
+
+.tableContainer {
+  width: 100%;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th {
+  font-family: 'Inter';
+  font-weight: 400;
+  font-size: 14px;
+  color: #6B7280;
+  padding: 16px 8px;
+  text-align: left;
+  border-bottom: 1px solid #D1D5DB;
+}
+
+.table td {
+  height: 80px;
+  padding: 16px 8px;
+  border-bottom: 1px solid #F3F4F6;
+  vertical-align: middle;
+}
+
+/* 퍼센티지 기반으로 반응형 확보 */
+.colStudent { width: 25%; }
+.colLecture { width: 45%; }
+.colAmount { width: 15%; }
+.colStatus { width: 10%; }
+.colMore { width: 5%; text-align: right; }
+
+.reportTitleCol { width: 65%; font-weight: 500; }
+.reportAuthorCol { width: 15%; }
+.reportCountCol { width: 15%; }
+
+.userProfile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  background: #1B10B9;
+  border-radius: 123px;
+  flex-shrink: 0;
+}
+
+.userName {
+  font-weight: 700;
+  font-size: 14px;
+  color: #374151;
+}
+
+.lectureTitle {
+  font-size: 14px;
+  color: #374151;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.amount {
+  font-weight: 700;
+  color: #374151;
+}
+
+.statusBadge {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+  background: #FEF2F2;
+  border: 1px solid #991B1B;
+  border-radius: 4px;
+  color: #991B1B;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.iconButton {
+  border: none;
+  background: transparent;
+  padding: 8px;
+  cursor: pointer;
+  color: #6B7280;
+}
+
+.paginationArea {
+  display: flex;
+  justify-content: center;
+  margin-top: 32px;
+}

--- a/frontend/src/app/admin/_components/ActivityTable.tsx
+++ b/frontend/src/app/admin/_components/ActivityTable.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useState } from 'react';
+import styles from './ActivityTable.module.css';
+import { InputField, Pagination } from '@/components/ui';
+import { MoreIcon } from '@/components/icons';
+
+// 1. 환불 대기 건 데이터
+const REFUND_DATA = [
+  { id: 1, name: '사용자 이름', title: '강의 제목 강의 제목 강의 제목 강의 제...', amount: '₩80,000', status: '대기 중' },
+  { id: 2, name: '사용자 이름', title: '강의 제목 강의 제목 강의 제목 강의 제...', amount: '₩80,000', status: '대기 중' },
+  { id: 3, name: '사용자 이름', title: '강의 제목 강의 제목 강의 제목 강의 제...', amount: '₩80,000', status: '대기 중' },
+  { id: 4, name: '사용자 이름', title: '강의 제목 강의 제목 강의 제목 강의 제...', amount: '₩80,000', status: '대기 중' },
+  { id: 5, name: '사용자 이름', title: '강의 제목 강의 제목 강의 제목 강의 제...', amount: '₩80,000', status: '대기 중' },
+];
+
+// 2. 긴급 처리 신고 데이터
+const REPORT_DATA = [
+  { id: 1, title: '게시물 제목 게시물 제목 게시물 제목 게시물 제목 게시물 제목', author: '사용자', reportCount: '15건' },
+  { id: 2, title: '게시물 제목 게시물 제목 게시물 제목 게시물 제목 게시물 제목', author: '사용자', reportCount: '15건' },
+  { id: 3, title: '게시물 제목 게시물 제목 게시물 제목 게시물 제목 게시물 제목', author: '사용자', reportCount: '15건' },
+  { id: 4, title: '게시물 제목 게시물 제목 게시물 제목 게시물 제목 게시물 제목', author: '사용자', reportCount: '15건' },
+  { id: 5, title: '게시물 제목 게시물 제목 게시물 제목 게시물 제목 게시물 제목', author: '사용자', reportCount: '15건' },
+];
+
+export default function ActivityTable() {
+  const [activeTab, setActiveTab] = useState<'refund' | 'report'>('refund');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  return (
+    <div className={styles.container}>
+      {/* 탭과 검색바를 시안처럼 좌우로 배치 */}
+      <div className={styles.tableHeaderArea}>
+        <div className={styles.tabs}>
+          <button
+            className={`${styles.tab} ${activeTab === 'refund' ? styles.activeTab : ''}`}
+            onClick={() => {
+              setActiveTab('refund');
+              setCurrentPage(1);
+            }}
+          >
+            환불 대기 건
+          </button>
+          <button
+            className={`${styles.tab} ${activeTab === 'report' ? styles.activeTab : ''}`}
+            onClick={() => {
+              setActiveTab('report');
+              setCurrentPage(1);
+            }}
+          >
+            긴급 처리 신고
+          </button>
+        </div>
+
+        <div className={styles.searchWrapper}>
+          <InputField
+            variant="search"
+            placeholder="검색어를 입력하세요"
+          />
+        </div>
+      </div>
+
+      <div className={styles.tableContainer}>
+        <table className={styles.table}>
+          {activeTab === 'refund' ? (
+            /* 환불 대기 건 헤더 */
+            <thead>
+              <tr>
+                <th className={styles.colStudent}>수강생</th>
+                <th className={styles.colLecture}>강의 제목</th>
+                <th className={styles.colAmount}>환불 금액</th>
+                <th className={styles.colStatus}>상태</th>
+                <th className={styles.colMore}></th>
+              </tr>
+            </thead>
+          ) : (
+            /* 긴급 처리 신고 헤더 */
+            <thead>
+              <tr>
+                <th className={styles.reportTitleCol}>게시물 제목</th>
+                <th className={styles.reportAuthorCol}>게시자</th>
+                <th className={styles.reportCountCol}>신고 수</th>
+                <th className={styles.colMore}></th>
+              </tr>
+            </thead>
+          )}
+
+          <tbody>
+            {activeTab === 'refund' ? (
+              /* 환불 대기 건 렌더링 */
+              REFUND_DATA.map((item) => (
+                <tr key={item.id}>
+                  <td className={styles.colStudent}>
+                    <div className={styles.userProfile}>
+                      <div className={styles.avatar}></div>
+                      <span className={styles.userName}>{item.name}</span>
+                    </div>
+                  </td>
+                  <td className={styles.colLecture}>
+                    <span className={styles.lectureTitle}>{item.title}</span>
+                  </td>
+                  <td className={styles.colAmount}>
+                    <span className={styles.amount}>{item.amount}</span>
+                  </td>
+                  <td className={styles.colStatus}>
+                    <span className={styles.statusBadge}>{item.status}</span>
+                  </td>
+                  <td className={styles.colMore}>
+                    <button className={styles.iconButton}>
+                      <MoreIcon />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              /* 긴급 처리 신고 렌더링 */
+              REPORT_DATA.map((item) => (
+                <tr key={item.id}>
+                  <td className={styles.reportTitleCol}>{item.title}</td>
+                  <td className={styles.reportAuthorCol}>{item.author}</td>
+                  <td className={styles.reportCountCol}>{item.reportCount}</td>
+                  <td className={styles.colMore}>
+                    <button className={styles.iconButton}>
+                      <MoreIcon />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className={styles.paginationArea}>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={23}
+          onPageChange={setCurrentPage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/_components/StatsCards.module.css
+++ b/frontend/src/app/admin/_components/StatsCards.module.css
@@ -1,0 +1,34 @@
+.cardsContainer {
+  display: flex;
+  gap: var(--space-24);
+  margin-bottom: var(--space-32);
+}
+
+.card {
+  flex: 1;
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-text-gray-300);
+  border-radius: var(--radius-md);
+  padding: var(--space-24);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.title {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}
+
+.value {
+  font: var(--text-hero-bold);
+  color: var(--color-text-gray-900);
+}
+
+@media (max-width: 768px) {
+  .cardsContainer {
+    flex-direction: column;
+    gap: var(--space-16);
+  }
+}

--- a/frontend/src/app/admin/_components/StatsCards.tsx
+++ b/frontend/src/app/admin/_components/StatsCards.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './StatsCards.module.css';
+
+interface StatData {
+  title: string;
+  value: string;
+}
+
+const STATS: StatData[] = [
+  { title: '주최자 신규 가입', value: '30' },
+  { title: '신규 신고 접수', value: '30' },
+  { title: '오늘 개설된 강의 수', value: '30' },
+];
+
+export default function StatsCards() {
+  return (
+    <div className={styles.cardsContainer}>
+      {STATS.map((stat, index) => (
+        <div key={index} className={styles.card}>
+          <h3 className={styles.title}>{stat.title}</h3>
+          <p className={styles.value}>{stat.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/dashboard/page.module.css
+++ b/frontend/src/app/admin/dashboard/page.module.css
@@ -1,0 +1,34 @@
+.headerArea {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--space-32);
+}
+
+.searchWrapper {
+  width: 320px;
+}
+
+.titleArea {
+  margin-bottom: var(--space-32);
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+  margin-bottom: var(--space-4);
+}
+
+.pageDesc {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}
+
+.activitySection {
+  margin-bottom: var(--space-32);
+}
+
+.sectionTitle {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+  margin-bottom: var(--space-16);
+}

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import styles from './page.module.css';
+import { Sidebar } from '@/components/layout';
+import StatsCards from '../_components/StatsCards';
+import ActivityTable from '../_components/ActivityTable';
+
+export default function AdminDashboardPage() {
+  return (
+    <div className="container-sidebar">
+      {/* 1. 사이드바 */}
+      <Sidebar role="admin" />
+
+      {/* 우측 메인 콘텐츠 */}
+      <section className="sidebar">
+        
+        {/* 가이드에 명시된 대시보드 타이틀 추가 */}
+        <h1 className={styles.pageTitle}>관리자 대시보드</h1>
+
+        {/* 요약 카드 */}
+        <div style={{ marginTop: '24px' }}>
+          <StatsCards />
+        </div>
+
+        {/* 활동 테이블 (상단 검색바 및 탭 포함) */}
+        <div className={styles.activitySection}>
+          <ActivityTable />
+        </div>
+        
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminRootRedirect() {
+  redirect('/admin/dashboard');
+}

--- a/frontend/src/app/admin/users/_components/UserDetailModal.module.css
+++ b/frontend/src/app/admin/users/_components/UserDetailModal.module.css
@@ -1,0 +1,83 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: var(--space-16);
+  border-bottom: 1px solid var(--color-text-gray-100);
+  margin-bottom: var(--space-16);
+}
+
+.title {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-48);
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}
+
+/* 상태 토글 영역 */
+.statusRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-12) var(--space-16);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-16);
+}
+
+.statusLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+/* 정보 필드 */
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin-bottom: var(--space-24);
+}
+
+.fieldRow {
+  display: flex;
+  align-items: center;
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--color-text-gray-100);
+}
+
+.fieldRow:last-child {
+  border-bottom: none;
+}
+
+.fieldLabel {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-500);
+  min-width: 100px;
+  flex-shrink: 0;
+}
+
+.fieldValue {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-900);
+  flex: 1;
+}
+
+.editInput {
+  flex: 1;
+}
+
+/* 버튼 그룹 */
+.buttonGroup {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-8);
+  padding-top: var(--space-16);
+  border-top: 1px solid var(--color-text-gray-100);
+}

--- a/frontend/src/app/admin/users/_components/UserDetailModal.tsx
+++ b/frontend/src/app/admin/users/_components/UserDetailModal.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import styles from './UserDetailModal.module.css';
+import { ModalOverlay, ModalCard } from '@/components/modal';
+import { InputField, Button, Tag, Toggle } from '@/components/ui';
+import { CancelIcon } from '@/components/icons';
+import { adminUserAPI, type AdminUserDetail } from '@/lib/admin-api';
+
+interface UserDetailModalProps {
+  isOpen: boolean;
+  userId: number | null;
+  onClose: () => void;
+  onUpdated: () => void; // 수정 후 목록 새로고침 콜백
+}
+
+export default function UserDetailModal({ isOpen, userId, onClose, onUpdated }: UserDetailModalProps) {
+  const [user, setUser] = useState<AdminUserDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  // 수정 폼 상태
+  const [editNickname, setEditNickname] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [editRole, setEditRole] = useState('');
+
+  // 모달 열릴 때 데이터 조회
+  useEffect(() => {
+    if (isOpen && userId) {
+      setIsEditing(false);
+      fetchUser(userId);
+    }
+  }, [isOpen, userId]);
+
+  const fetchUser = async (id: number) => {
+    setIsLoading(true);
+    try {
+      const res = await adminUserAPI.getUser(id);
+      setUser(res.data);
+      setEditNickname(res.data.nickname || '');
+      setEditPhone(res.data.phone || '');
+      setEditRole(res.data.role || '');
+    } catch (err) {
+      console.error('회원 조회 실패:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!user) return;
+    try {
+      await adminUserAPI.updateUser(user.id, {
+        nickname: editNickname,
+        phone: editPhone,
+        role: editRole,
+      });
+      setIsEditing(false);
+      fetchUser(user.id);
+      onUpdated();
+    } catch (err) {
+      console.error('수정 실패:', err);
+    }
+  };
+
+  const handleToggleStatus = async () => {
+    if (!user) return;
+    try {
+      await adminUserAPI.changeStatus(user.id, !user.active);
+      fetchUser(user.id);
+      onUpdated();
+    } catch (err) {
+      console.error('상태 변경 실패:', err);
+    }
+  };
+
+  const getRoleLabel = (role: string) => {
+    switch (role) {
+      case 'ADMIN': return '관리자';
+      case 'HOST':  return '주최자';
+      default:      return '일반 회원';
+    }
+  };
+
+  const getRoleVariant = (role: string) => {
+    switch (role) {
+      case 'ADMIN': return 'purple' as const;
+      case 'HOST':  return 'green' as const;
+      default:      return 'gray' as const;
+    }
+  };
+
+  const formatDateTime = (dateStr: string | null) => {
+    if (!dateStr) return '-';
+    const d = new Date(dateStr);
+    return d.toLocaleString('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    });
+  };
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={onClose}>
+      <ModalCard size="md">
+        {/* 헤더 */}
+        <div className={styles.header}>
+          <h2 className={styles.title}>회원 상세</h2>
+          <CancelIcon style={{ cursor: 'pointer', color: 'var(--color-text-gray-500)' }} onClick={onClose} />
+        </div>
+
+        {isLoading || !user ? (
+          <div className={styles.loading}>로딩 중...</div>
+        ) : (
+          <>
+            {/* 상태 토글 영역 */}
+            <div className={styles.statusRow}>
+              <div className={styles.statusLeft}>
+                <span className={styles.fieldLabel}>계정 상태</span>
+                <Tag variant={user.active ? 'green' : 'red'}>
+                  {user.active ? '활성' : '비활성'}
+                </Tag>
+              </div>
+              {user.role !== 'ADMIN' && (
+                <Toggle
+                  checked={user.active}
+                  onChange={handleToggleStatus}
+                  label={user.active ? '활성화됨' : '정지됨'}
+                />
+              )}
+            </div>
+
+            {/* 정보 필드 */}
+            <div className={styles.fields}>
+              <div className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>ID</span>
+                <span className={styles.fieldValue}>{user.id}</span>
+              </div>
+              <div className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>이메일</span>
+                <span className={styles.fieldValue}>{user.email}</span>
+              </div>
+
+              {isEditing ? (
+                <>
+                  <div className={styles.fieldRow}>
+                    <span className={styles.fieldLabel}>닉네임</span>
+                    <InputField
+                      value={editNickname}
+                      onChange={(e) => setEditNickname(e.target.value)}
+                      className={styles.editInput}
+                    />
+                  </div>
+                  <div className={styles.fieldRow}>
+                    <span className={styles.fieldLabel}>전화번호</span>
+                    <InputField
+                      value={editPhone}
+                      onChange={(e) => setEditPhone(e.target.value)}
+                      placeholder="010-0000-0000"
+                      className={styles.editInput}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className={styles.fieldRow}>
+                    <span className={styles.fieldLabel}>닉네임</span>
+                    <span className={styles.fieldValue}>{user.nickname}</span>
+                  </div>
+                  <div className={styles.fieldRow}>
+                    <span className={styles.fieldLabel}>전화번호</span>
+                    <span className={styles.fieldValue}>{user.phone || '-'}</span>
+                  </div>
+                </>
+              )}
+
+              <div className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>역할</span>
+                <Tag variant={getRoleVariant(user.role)}>{getRoleLabel(user.role)}</Tag>
+              </div>
+              <div className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>가입일</span>
+                <span className={styles.fieldValue}>{formatDateTime(user.createdAt)}</span>
+              </div>
+              <div className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>최종 수정일</span>
+                <span className={styles.fieldValue}>{formatDateTime(user.updatedAt)}</span>
+              </div>
+            </div>
+
+            {/* 버튼 영역 */}
+            <div className={styles.buttonGroup}>
+              {isEditing ? (
+                <>
+                  <Button variant="secondary" onClick={() => setIsEditing(false)}>취소</Button>
+                  <Button variant="primary" onClick={handleSave}>저장</Button>
+                </>
+              ) : (
+                <Button variant="outlined" onClick={() => setIsEditing(true)}>수정</Button>
+              )}
+            </div>
+          </>
+        )}
+      </ModalCard>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/app/admin/users/_components/UserFilter.module.css
+++ b/frontend/src/app/admin/users/_components/UserFilter.module.css
@@ -1,0 +1,15 @@
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  margin-bottom: var(--space-24);
+}
+
+.searchWrapper {
+  flex: 1;
+  max-width: 400px;
+}
+
+.dropdownWrapper {
+  width: 160px;
+}

--- a/frontend/src/app/admin/users/_components/UserFilter.tsx
+++ b/frontend/src/app/admin/users/_components/UserFilter.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import styles from './UserFilter.module.css';
+import { InputField, Dropdown } from '@/components/ui';
+
+interface UserFilterProps {
+  keyword: string;
+  role: string;
+  onKeywordChange: (value: string) => void;
+  onRoleChange: (value: string) => void;
+  onSearch: () => void;
+}
+
+const roleOptions = [
+  { value: '', label: '전체' },
+  { value: 'USER', label: '일반 회원' },
+  { value: 'HOST', label: '주최자' },
+  { value: 'ADMIN', label: '관리자' },
+];
+
+export default function UserFilter({
+  keyword,
+  role,
+  onKeywordChange,
+  onRoleChange,
+  onSearch,
+}: UserFilterProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onSearch();
+  };
+
+  return (
+    <div className={styles.filterBar}>
+      <div className={styles.searchWrapper}>
+        <InputField
+          variant="search"
+          placeholder="이메일 또는 닉네임 검색"
+          value={keyword}
+          onChange={(e) => onKeywordChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      <div className={styles.dropdownWrapper}>
+        <Dropdown
+          placeholder="역할 필터"
+          options={roleOptions}
+          value={role}
+          onChange={onRoleChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/_components/UserTable.module.css
+++ b/frontend/src/app/admin/users/_components/UserTable.module.css
@@ -1,0 +1,70 @@
+.tableWrapper {
+  overflow-x: auto;
+  border: 1px solid var(--color-text-gray-300);
+  border-radius: var(--radius-md);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font: var(--text-body-regular);
+}
+
+.table thead {
+  background-color: var(--color-surface);
+}
+
+.table th {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-700);
+  padding: var(--space-12) var(--space-16);
+  text-align: left;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--color-text-gray-300);
+}
+
+.table td {
+  padding: var(--space-12) var(--space-16);
+  border-bottom: 1px solid var(--color-text-gray-100);
+  vertical-align: middle;
+}
+
+.table tbody tr:hover {
+  background-color: var(--color-text-gray-50);
+}
+
+.idCell {
+  color: var(--color-text-gray-500);
+  font: var(--text-caption-medium);
+  width: 60px;
+}
+
+.emailCell {
+  font: var(--text-body-medium);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dateCell {
+  color: var(--color-text-gray-500);
+  font: var(--text-caption-regular);
+  white-space: nowrap;
+}
+
+.actionCell {
+  display: flex;
+  gap: var(--space-8);
+  align-items: center;
+}
+
+.loading,
+.empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--space-48);
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}

--- a/frontend/src/app/admin/users/_components/UserTable.tsx
+++ b/frontend/src/app/admin/users/_components/UserTable.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import styles from './UserTable.module.css';
+import { Tag, Button } from '@/components/ui';
+import type { AdminUserListItem } from '@/lib/admin-api';
+
+interface UserTableProps {
+  users: AdminUserListItem[];
+  isLoading: boolean;
+  onViewDetail: (id: number) => void;
+  onDeleteClick: (user: AdminUserListItem) => void;
+}
+
+/** 역할에 따른 Tag variant 매핑 */
+function getRoleTag(role: string) {
+  switch (role) {
+    case 'ADMIN':
+      return { variant: 'purple' as const, label: '관리자' };
+    case 'HOST':
+      return { variant: 'green' as const, label: '주최자' };
+    default:
+      return { variant: 'gray' as const, label: '일반 회원' };
+  }
+}
+
+/** 활성 상태 Tag */
+function getStatusTag(active: boolean) {
+  return active
+    ? { variant: 'green' as const, label: '활성' }
+    : { variant: 'red' as const, label: '비활성' };
+}
+
+/** 날짜 포맷 */
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+export default function UserTable({ users, isLoading, onViewDetail, onDeleteClick }: UserTableProps) {
+  if (isLoading) {
+    return <div className={styles.loading}>로딩 중...</div>;
+  }
+
+  if (users.length === 0) {
+    return <div className={styles.empty}>검색 결과가 없습니다.</div>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>이메일</th>
+            <th>닉네임</th>
+            <th>역할</th>
+            <th>상태</th>
+            <th>가입일</th>
+            <th>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => {
+            const roleTag = getRoleTag(user.role);
+            const statusTag = getStatusTag(user.active);
+            return (
+              <tr key={user.id}>
+                <td className={styles.idCell}>{user.id}</td>
+                <td className={styles.emailCell}>{user.email}</td>
+                <td>{user.nickname}</td>
+                <td>
+                  <Tag variant={roleTag.variant}>{roleTag.label}</Tag>
+                </td>
+                <td>
+                  <Tag variant={statusTag.variant}>{statusTag.label}</Tag>
+                </td>
+                <td className={styles.dateCell}>{formatDate(user.createdAt)}</td>
+                <td className={styles.actionCell}>
+                  <Button
+                    variant="outlined"
+                    size="medium"
+                    onClick={() => onViewDetail(user.id)}
+                  >
+                    상세
+                  </Button>
+                  {user.role !== 'ADMIN' && (
+                    <Button
+                      variant="danger"
+                      size="medium"
+                      onClick={() => onDeleteClick(user)}
+                    >
+                      삭제
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/page.module.css
+++ b/frontend/src/app/admin/users/page.module.css
@@ -1,0 +1,14 @@
+.pageHeader {
+  margin-bottom: var(--space-24);
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+  margin-bottom: var(--space-4);
+}
+
+.pageDesc {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import styles from './page.module.css';
+import { Sidebar } from '@/components/layout';
+import { Pagination } from '@/components/ui';
+import { ConfirmModal } from '@/components/modal';
+import { adminUserAPI, type AdminUserListItem } from '@/lib/admin-api';
+import UserFilter from './_components/UserFilter';
+import UserTable from './_components/UserTable';
+import UserDetailModal from './_components/UserDetailModal';
+
+export default function AdminUsersPage() {
+  // ── 검색/필터 상태 ──
+  const [keyword, setKeyword] = useState('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // ── 데이터 상태 ──
+  const [users, setUsers] = useState<AdminUserListItem[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // ── 모달 상태 ──
+  const [detailUserId, setDetailUserId] = useState<number | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUserListItem | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  // ── 데이터 패칭 ──
+  const fetchUsers = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await adminUserAPI.getUsers({
+        keyword: keyword || undefined,
+        role: roleFilter || undefined,
+        page: String(currentPage - 1), // Spring은 0-indexed
+        size: '20',
+      });
+
+      setUsers(res.data.content);
+      setTotalPages(res.data.totalPages);
+    } catch (err) {
+      console.error('회원 목록 조회 실패:', err);
+      setUsers([]);
+      setTotalPages(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [keyword, roleFilter, currentPage]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  // ── 이벤트 핸들러 ──
+  const handleSearch = () => {
+    setCurrentPage(1);
+    fetchUsers();
+  };
+
+  const handleRoleChange = (value: string) => {
+    setRoleFilter(value);
+    setCurrentPage(1);
+  };
+
+  const handleViewDetail = (id: number) => {
+    setDetailUserId(id);
+    setIsDetailOpen(true);
+  };
+
+  const handleDeleteClick = (user: AdminUserListItem) => {
+    setDeleteTarget(user);
+    setIsDeleteOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await adminUserAPI.deleteUser(deleteTarget.id);
+      setIsDeleteOpen(false);
+      setDeleteTarget(null);
+      fetchUsers();
+    } catch (err) {
+      console.error('삭제 실패:', err);
+    }
+  };
+
+  return (
+    <div className="container-sidebar">
+      <Sidebar role="admin" />
+
+      <section className="sidebar">
+        <div className={styles.pageHeader}>
+          <h1 className={styles.pageTitle}>사용자 관리</h1>
+          <p className={styles.pageDesc}>등록된 회원을 조회하고 관리합니다.</p>
+        </div>
+
+        <UserFilter
+          keyword={keyword}
+          role={roleFilter}
+          onKeywordChange={setKeyword}
+          onRoleChange={handleRoleChange}
+          onSearch={handleSearch}
+        />
+
+        <UserTable
+          users={users}
+          isLoading={isLoading}
+          onViewDetail={handleViewDetail}
+          onDeleteClick={handleDeleteClick}
+        />
+
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+
+        {/* 상세/수정 모달 */}
+        <UserDetailModal
+          isOpen={isDetailOpen}
+          userId={detailUserId}
+          onClose={() => setIsDetailOpen(false)}
+          onUpdated={fetchUsers}
+        />
+
+        {/* 삭제 확인 모달 */}
+        <ConfirmModal
+          isOpen={isDeleteOpen}
+          onClose={() => setIsDeleteOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title={`${deleteTarget?.nickname || ''} 회원을 삭제하시겠습니까?`}
+          subtitle="삭제된 회원 정보는 복구할 수 없습니다."
+          status="danger"
+          requireCheckbox
+          checkboxLabel="위 내용을 확인했습니다."
+          confirmText="삭제"
+          cancelText="취소"
+        />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -1,0 +1,82 @@
+/**
+ * 어드민 회원 관리 API — lib/api.ts의 공통 apiFetch 활용
+ */
+import { api } from './api';
+
+// ── 타입 정의 ──
+
+export interface AdminUserListItem {
+  id: number;
+  email: string;
+  nickname: string;
+  role: string;
+  active: boolean;
+  createdAt: string;
+}
+
+export interface AdminUserDetail {
+  id: number;
+  email: string;
+  nickname: string;
+  role: string;
+  phone: string | null;
+  profileImg: string | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;   // 현재 페이지 (0-indexed)
+  size: number;
+}
+
+export interface ApiResponse<T> {
+  status: string;
+  data: T;
+  message?: string;
+}
+
+export interface AdminUpdateUserRequest {
+  nickname?: string;
+  role?: string;
+  phone?: string;
+}
+
+// ── API 함수 ──
+
+export const adminUserAPI = {
+  /** 회원 목록 조회 (검색 + 역할 필터 + 페이징) */
+  getUsers: (params: {
+    keyword?: string;
+    role?: string;
+    page?: string;
+    size?: string;
+  }) => {
+    // 빈 값 제거
+    const cleanParams: Record<string, string> = {};
+    Object.entries(params).forEach(([key, value]) => {
+      if (value) cleanParams[key] = value;
+    });
+    return api.get<ApiResponse<PageResponse<AdminUserListItem>>>('/admin/users', { params: cleanParams });
+  },
+
+  /** 회원 상세 조회 */
+  getUser: (id: number) =>
+    api.get<ApiResponse<AdminUserDetail>>(`/admin/users/${id}`),
+
+  /** 회원 정보 수정 */
+  updateUser: (id: number, body: AdminUpdateUserRequest) =>
+    api.put<ApiResponse<AdminUserDetail>>(`/admin/users/${id}`, body),
+
+  /** 회원 활성/비활성 전환 */
+  changeStatus: (id: number, active: boolean) =>
+    api.patch<ApiResponse<void>>(`/admin/users/${id}/status`, { active }),
+
+  /** 회원 삭제 */
+  deleteUser: (id: number) =>
+    api.delete<ApiResponse<void>>(`/admin/users/${id}`),
+};

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@
  * 프록시를 통해 /v1/* 경로로 요청 (next.config.ts rewrites)
  */
 
-const API_BASE = "/v1";
+const API_BASE = "/api";
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string>;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -7,7 +7,7 @@ import { getIronSession } from "iron-session";
 import { sessionOptions, SessionData } from "@/lib/session";
 
 // 인증이 필요한 경로 패턴
-const protectedPaths = ["/mypage", "/events/new", "/host"];
+const protectedPaths = ["/mypage", "/events/new", "/host", "/admin"];
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
@@ -40,5 +40,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/mypage/:path*", "/events/new", "/host/:path*"],
+  matcher: ["/mypage/:path*", "/events/new", "/host/:path*", "/admin/:path*"],
 };


### PR DESCRIPTION
#VO-736 #VO-737
1. #VO-736: 관리자 대시보드 및 공통 UI 시스템 구축
관리자 페이지의 메인 대시보드 시각화와 프로젝트 전반에서 사용할 수 있는 공통 UI 컴포넌트를 구현했습니다.

대시보드 메인: StatsCards(통계), ActivityTable(최근 활동)을 통해 환불 대기 및 긴급 신고 현황을 한눈에 파악할 수 있는 UI 구현.
공통 UI 컴포넌트: Button, Card, Dropdown, PopoverMenu, SelectBox 등 디자인 시스템에 맞춘 재사용 가능한 원자적 컴포넌트 구축.
반응형 레이아웃: % 기반의 유연한 레이아웃 구조를 적용하여 다양한 관리자 환경 대응.
2. #VO-737: 관리자용 회원 관리 기능 개발 (Full-Stack)
회원 목록 조회부터 수정, 삭제까지 관리자가 유저를 제어할 수 있는 전체 프로세스를 개발했습니다.

Backend (Spring Boot):
AdminUserController: 회원 목록(검색/필터/페이징), 상세 조회, 정보 수정, 상태 변경(활성/비활성), 삭제 API 구현.
Domain-Driven Design: Port/UseCase 패턴을 적용하여 비즈니스 로직과 웹 어댑터 분리.
Frontend (Next.js):
UserTable & UserFilter: 대규모 유저 목록 처리를 위한 페이징 테이블 및 필터링 시스템.
UserDetailModal: 유저 상세 정보 확인 및 실시간 수정 기능 제공.
API 연동: BFF(Next.js API Routes)를 통한 백엔드 API와의 안정적인 데이터 통신 환경 구축.

Backend
AdminUserController, AdminUserService 및 포트(Port) 인터페이스 추가
application-dev.properties 및 SecurityConfig (관리자 권한/CORS) 설정 업데이트
EventQueryService 및 관련 DTO 구조 개선
Frontend
/admin/dashboard: 대시보드 통계 및 활동 테이블 조립
/admin/users: 유저 관리 CRUD UI/UX 구현
src/components/ui: 디자인 가이드를 준수하는 공통 컴포넌트 라이브러리 확장
admin-api.ts: 관리자 전용 API 패칭 모듈 구현