### PR TITLE
feat: 게시글 및 댓글 좋아요 기능 추가

### DIFF
--- a/backend/src/main/java/com/venueon/comment/adapter/in/web/CommentController.java
+++ b/backend/src/main/java/com/venueon/comment/adapter/in/web/CommentController.java
@@ -1,5 +1,6 @@
 package com.venueon.comment.adapter.in.web;
 
+import com.venueon.comment.application.port.in.CommentLikeUseCase;
 import com.venueon.comment.application.port.in.CreateCommentUseCase;
 import com.venueon.comment.application.port.in.GetCommentQuery;
 import com.venueon.comment.application.port.in.dto.CommentResponse;
@@ -21,6 +22,7 @@ public class CommentController {
 
     private final CreateCommentUseCase createCommentUseCase;
     private final GetCommentQuery getCommentQuery;
+    private final CommentLikeUseCase commentLikeUseCase;
 
     /**
      * 댓글 등록 API
@@ -47,5 +49,21 @@ public class CommentController {
     public ResponseEntity<List<CommentResponse>> getComments(@RequestParam Long postId) {
         List<CommentResponse> responses = getCommentQuery.getCommentsByPostId(postId);
         return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 댓글 좋아요 토글
+     * POST /comments/{id}/like
+     */
+    @PostMapping("/{id}/like")
+    public ResponseEntity<Void> toggleLike(@PathVariable Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String email = ((UserDetails) authentication.getPrincipal()).getUsername();
+        commentLikeUseCase.toggleLike(id, email);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/venueon/comment/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/comment/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -1,7 +1,9 @@
 package com.venueon.comment.adapter.out.persistence;
 
 import com.venueon.comment.adapter.out.persistence.entity.CommentJpaEntity;
+import com.venueon.comment.adapter.out.persistence.entity.CommentLikeJpaEntity;
 import com.venueon.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import com.venueon.comment.adapter.out.persistence.repository.CommentLikeJpaRepository;
 import com.venueon.comment.application.port.out.CommentRepositoryPort;
 import com.venueon.comment.domain.model.Comment;
 import com.venueon.post.adapter.out.persistence.entity.PostJpaEntity;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 public class CommentPersistenceAdapter implements CommentRepositoryPort {
 
     private final CommentJpaRepository commentJpaRepository;
+    private final CommentLikeJpaRepository commentLikeJpaRepository;
     private final PostJpaRepository postJpaRepository;
     private final UserJpaRepository userJpaRepository;
 
@@ -43,6 +46,7 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
                 .author(author)
                 .parent(parent)
                 .content(comment.getContent())
+                .likeCount(comment.getLikeCount())
                 .build();
 
         CommentJpaEntity saved = commentJpaRepository.save(entity);
@@ -67,6 +71,30 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
         return commentJpaRepository.countByPostId(postId);
     }
 
+    @Override
+    public boolean existsLike(Long commentId, Long userId) {
+        return commentLikeJpaRepository.existsByCommentIdAndUserId(commentId, userId);
+    }
+
+    @Override
+    public void saveLike(Long commentId, Long userId) {
+        CommentJpaEntity comment = commentJpaRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found: " + commentId));
+        UserJpaEntity user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        CommentLikeJpaEntity like = CommentLikeJpaEntity.builder()
+                .comment(comment)
+                .user(user)
+                .build();
+        commentLikeJpaRepository.save(like);
+    }
+
+    @Override
+    public void deleteLike(Long commentId, Long userId) {
+        commentLikeJpaRepository.deleteByCommentIdAndUserId(commentId, userId);
+    }
+
     private Comment mapToDomain(CommentJpaEntity entity) {
         return Comment.builder()
                 .id(entity.getId())
@@ -75,6 +103,7 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
                 .authorNickname(entity.getAuthor().getNickname())
                 .parentId(entity.getParent() != null ? entity.getParent().getId() : null)
                 .content(entity.getContent())
+                .likeCount(entity.getLikeCount())
                 .createdAt(entity.getCreatedAt())
                 .build();
     }

--- a/backend/src/main/java/com/venueon/comment/adapter/out/persistence/entity/CommentLikeJpaEntity.java
+++ b/backend/src/main/java/com/venueon/comment/adapter/out/persistence/entity/CommentLikeJpaEntity.java
@@ -1,0 +1,35 @@
+package com.venueon.comment.adapter.out.persistence.entity;
+
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment_likes", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"comment_id", "user_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CommentLikeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private CommentJpaEntity comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/venueon/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
+++ b/backend/src/main/java/com/venueon/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.venueon.comment.adapter.out.persistence.repository;
+
+import com.venueon.comment.adapter.out.persistence.entity.CommentLikeJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeJpaRepository extends JpaRepository<CommentLikeJpaEntity, Long> {
+    boolean existsByCommentIdAndUserId(Long commentId, Long userId);
+    void deleteByCommentIdAndUserId(Long commentId, Long userId);
+}

--- a/backend/src/main/java/com/venueon/comment/application/port/in/CommentLikeUseCase.java
+++ b/backend/src/main/java/com/venueon/comment/application/port/in/CommentLikeUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.comment.application.port.in;
+
+public interface CommentLikeUseCase {
+    void toggleLike(Long commentId, String email);
+}

--- a/backend/src/main/java/com/venueon/comment/application/port/in/dto/CommentResponse.java
+++ b/backend/src/main/java/com/venueon/comment/application/port/in/dto/CommentResponse.java
@@ -12,6 +12,7 @@ public record CommentResponse(
     String authorNickname,
     String content,
     Long parentId,
+    int likeCount,
     LocalDateTime createdAt
 ) {
 }

--- a/backend/src/main/java/com/venueon/comment/application/port/out/CommentRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/comment/application/port/out/CommentRepositoryPort.java
@@ -12,4 +12,8 @@ public interface CommentRepositoryPort {
     Optional<Comment> findById(Long id);
     List<Comment> findByPostId(Long postId);
     long countByPostId(Long postId);
+
+    boolean existsLike(Long commentId, Long userId);
+    void saveLike(Long commentId, Long userId);
+    void deleteLike(Long commentId, Long userId);
 }

--- a/backend/src/main/java/com/venueon/comment/application/service/CommentCommandService.java
+++ b/backend/src/main/java/com/venueon/comment/application/service/CommentCommandService.java
@@ -1,6 +1,7 @@
 package com.venueon.comment.application.service;
 
 import com.venueon.common.annotation.UseCase;
+import com.venueon.comment.application.port.in.CommentLikeUseCase;
 import com.venueon.comment.application.port.in.CreateCommentUseCase;
 import com.venueon.comment.application.port.in.dto.CommentResponse;
 import com.venueon.comment.application.port.in.dto.CreateCommentRequest;
@@ -13,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-public class CommentCommandService implements CreateCommentUseCase {
+@Transactional
+public class CommentCommandService implements CreateCommentUseCase, CommentLikeUseCase {
 
     private final CommentRepositoryPort commentRepositoryPort;
     private final UserRepositoryPort userRepositoryPort;
@@ -40,7 +42,27 @@ public class CommentCommandService implements CreateCommentUseCase {
                 saved.getAuthorNickname(),
                 saved.getContent(),
                 saved.getParentId(),
+                saved.getLikeCount(),
                 saved.getCreatedAt()
         );
+    }
+
+    @Override
+    public void toggleLike(Long commentId, String email) {
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
+        
+        Comment comment = commentRepositoryPort.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found with id: " + commentId));
+
+        if (commentRepositoryPort.existsLike(commentId, user.getId())) {
+            commentRepositoryPort.deleteLike(commentId, user.getId());
+            comment.decrementLikeCount();
+        } else {
+            commentRepositoryPort.saveLike(commentId, user.getId());
+            comment.incrementLikeCount();
+        }
+
+        commentRepositoryPort.save(comment);
     }
 }

--- a/backend/src/main/java/com/venueon/comment/application/service/CommentQueryService.java
+++ b/backend/src/main/java/com/venueon/comment/application/service/CommentQueryService.java
@@ -28,6 +28,7 @@ public class CommentQueryService implements GetCommentQuery {
                         comment.getAuthorNickname(),
                         comment.getContent(),
                         comment.getParentId(),
+                        comment.getLikeCount(),
                         comment.getCreatedAt()
                 ))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/venueon/comment/domain/model/Comment.java
+++ b/backend/src/main/java/com/venueon/comment/domain/model/Comment.java
@@ -19,6 +19,7 @@ public class Comment {
     private String authorNickname; // UI 표현용
     private Long parentId;  // 대댓글 시 부모 댓글 ID
     private String content;
+    private int likeCount;
     private LocalDateTime createdAt;
 
     // --- 비즈니스 행위 ---
@@ -28,5 +29,15 @@ public class Comment {
 
     public boolean isOwnedBy(Long userId) {
         return this.authorId != null && this.authorId.equals(userId);
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
     }
 }

--- a/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
+++ b/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
@@ -2,6 +2,7 @@ package com.venueon.post.adapter.in.web;
 
 import com.venueon.post.application.port.in.CreatePostUseCase;
 import com.venueon.post.application.port.in.GetPostQuery;
+import com.venueon.post.application.port.in.PostLikeUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
 import com.venueon.post.application.port.in.dto.CreatePostResponse;
 import com.venueon.post.application.port.in.dto.PostListResponse;
@@ -25,6 +26,7 @@ public class PostController {
 
     private final CreatePostUseCase createPostUseCase;
     private final GetPostQuery getPostQuery;
+    private final PostLikeUseCase postLikeUseCase;
 
     /**
      * 1단계: 게시글 등록
@@ -36,7 +38,8 @@ public class PostController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = "admin@venueon.com"; // 기본값 (비회원 익명작성용)
 
-        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal())) {
             email = ((UserDetails) authentication.getPrincipal()).getUsername();
         }
 
@@ -48,17 +51,33 @@ public class PostController {
      * 2단계 + 3단계: 특정 커뮤니티의 게시글 목록 조회 (페이징 + 타입 필터)
      *
      * 사용 예시:
-     *   GET /posts?communityId=1                           → 전체 목록
-     *   GET /posts?communityId=1&type=NOTICE               → 공지사항만
-     *   GET /posts?communityId=1&page=0&size=10&sort=createdAt,desc
+     * GET /posts?communityId=1 → 전체 목록
+     * GET /posts?communityId=1&type=NOTICE → 공지사항만
+     * GET /posts?communityId=1&page=0&size=10&sort=createdAt,desc
      */
     @GetMapping
     public ResponseEntity<Page<PostListResponse>> getPostList(
             @RequestParam Long communityId,
             @RequestParam(required = false) PostType type,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-    ) {
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<PostListResponse> posts = getPostQuery.getPostsByCommunityId(communityId, type, pageable);
         return ResponseEntity.ok(posts);
+    }
+
+    /**
+     * 게시글 좋아요 토글
+     * POST /posts/{id}/like
+     */
+    @PostMapping("/{id}/like")
+    public ResponseEntity<Void> toggleLike(@PathVariable Long id) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String email = ((UserDetails) authentication.getPrincipal()).getUsername();
+        postLikeUseCase.toggleLike(id, email);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
@@ -3,7 +3,9 @@ package com.venueon.post.adapter.out.persistence;
 import com.venueon.community.adapter.out.persistence.entity.CommunityJpaEntity;
 import com.venueon.community.adapter.out.persistence.repository.CommunityJpaRepository;
 import com.venueon.post.adapter.out.persistence.entity.PostJpaEntity;
+import com.venueon.post.adapter.out.persistence.entity.PostLikeJpaEntity;
 import com.venueon.post.adapter.out.persistence.repository.PostJpaRepository;
+import com.venueon.post.adapter.out.persistence.repository.PostLikeJpaRepository;
 import com.venueon.post.application.port.out.PostRepositoryPort;
 import com.venueon.post.domain.model.Post;
 import com.venueon.post.domain.model.PostType;
@@ -14,20 +16,24 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class PostPersistenceAdapter implements PostRepositoryPort {
 
     private final PostJpaRepository postJpaRepository;
+    private final PostLikeJpaRepository postLikeJpaRepository;
     private final CommunityJpaRepository communityJpaRepository;
-    private final UserJpaRepository userJpaRepository;
+    private final UserJpaRepository userRepository;
 
     @Override
     public Post save(Post post) {
         CommunityJpaEntity community = communityJpaRepository.findById(post.getCommunityId())
-                .orElseThrow(() -> new IllegalArgumentException("Community not found with id: " + post.getCommunityId()));
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Community not found with id: " + post.getCommunityId()));
 
-        UserJpaEntity author = userJpaRepository.findById(post.getAuthorId())
+        UserJpaEntity author = userRepository.findById(post.getAuthorId())
                 .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + post.getAuthorId()));
 
         PostJpaEntity postEntity = PostJpaEntity.builder()
@@ -37,13 +43,35 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
                 .content(post.getContent())
                 .type(post.getType())
                 .build();
-                
+
         if (post.getId() != null) {
-            // update handling logic 
+            PostJpaEntity existing = postJpaRepository.findById(post.getId()).orElse(null);
+            if (existing != null) {
+                postEntity = PostJpaEntity.builder()
+                        .id(post.getId())
+                        .community(existing.getCommunity())
+                        .author(existing.getAuthor())
+                        .title(post.getTitle())
+                        .content(post.getContent())
+                        .type(post.getType())
+                        .viewCount(post.getViewCount())
+                        .commentCount(post.getCommentCount())
+                        .likeCount(post.getLikeCount())
+                        .isHidden(existing.isHidden())
+                        .isPinned(post.isPinned())
+                        .isNotice(post.isNotice())
+                        .createdAt(existing.getCreatedAt())
+                        .build();
+            }
         }
 
         PostJpaEntity savedPost = postJpaRepository.save(postEntity);
         return mapToDomain(savedPost);
+    }
+
+    @Override
+    public Optional<Post> findById(Long id) {
+        return postJpaRepository.findById(id).map(this::mapToDomain);
     }
 
     @Override
@@ -58,6 +86,30 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
                 .map(this::mapToDomain);
     }
 
+    @Override
+    public boolean existsLike(Long postId, Long userId) {
+        return postLikeJpaRepository.existsByPostIdAndUserId(postId, userId);
+    }
+
+    @Override
+    public void saveLike(Long postId, Long userId) {
+        PostJpaEntity post = postJpaRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+        UserJpaEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        PostLikeJpaEntity like = PostLikeJpaEntity.builder()
+                .post(post)
+                .user(user)
+                .build();
+        postLikeJpaRepository.save(like);
+    }
+
+    @Override
+    public void deleteLike(Long postId, Long userId) {
+        postLikeJpaRepository.deleteByPostIdAndUserId(postId, userId);
+    }
+
     private Post mapToDomain(PostJpaEntity entity) {
         return Post.builder()
                 .id(entity.getId())
@@ -68,6 +120,11 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
                 .title(entity.getTitle())
                 .content(entity.getContent())
                 .type(entity.getType())
+                .viewCount(entity.getViewCount())
+                .commentCount(entity.getCommentCount())
+                .likeCount(entity.getLikeCount())
+                .isPinned(entity.isPinned())
+                .isNotice(entity.isNotice())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostBookmarkJpaEntity.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostBookmarkJpaEntity.java
@@ -1,6 +1,5 @@
-package com.venueon.comment.adapter.out.persistence.entity;
+package com.venueon.post.adapter.out.persistence.entity;
 
-import com.venueon.post.adapter.out.persistence.entity.PostJpaEntity;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,12 +8,14 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "comments")
+@Table(name = "post_bookmarks", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"post_id", "user_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class CommentJpaEntity {
+public class PostBookmarkJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,23 +26,8 @@ public class CommentJpaEntity {
     private PostJpaEntity post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    private UserJpaEntity author;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private CommentJpaEntity parent;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String content;
-
-    @Column(name = "like_count")
-    @Builder.Default
-    private int likeCount = 0;
-
-    @Column(name = "is_hidden", nullable = false)
-    @Builder.Default
-    private boolean isHidden = false;
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostJpaEntity.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostJpaEntity.java
@@ -49,9 +49,21 @@ public class PostJpaEntity {
     @Builder.Default
     private int commentCount = 0;
 
+    @Column(name = "like_count")
+    @Builder.Default
+    private int likeCount = 0;
+
     @Column(name = "is_hidden", nullable = false)
     @Builder.Default
     private boolean isHidden = false;
+
+    @Column(name = "is_pinned", nullable = false)
+    @Builder.Default
+    private boolean isPinned = false;
+
+    @Column(name = "is_notice", nullable = false)
+    @Builder.Default
+    private boolean isNotice = false;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostLikeJpaEntity.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/entity/PostLikeJpaEntity.java
@@ -1,6 +1,5 @@
-package com.venueon.comment.adapter.out.persistence.entity;
+package com.venueon.post.adapter.out.persistence.entity;
 
-import com.venueon.post.adapter.out.persistence.entity.PostJpaEntity;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,12 +8,14 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "comments")
+@Table(name = "post_likes", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"post_id", "user_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class CommentJpaEntity {
+public class PostLikeJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,23 +26,8 @@ public class CommentJpaEntity {
     private PostJpaEntity post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    private UserJpaEntity author;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private CommentJpaEntity parent;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String content;
-
-    @Column(name = "like_count")
-    @Builder.Default
-    private int likeCount = 0;
-
-    @Column(name = "is_hidden", nullable = false)
-    @Builder.Default
-    private boolean isHidden = false;
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostLikeJpaRepository.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostLikeJpaRepository.java
@@ -1,0 +1,14 @@
+package com.venueon.post.adapter.out.persistence.repository;
+
+import com.venueon.post.adapter.out.persistence.entity.PostLikeJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeJpaRepository extends JpaRepository<PostLikeJpaEntity, Long> {
+    Optional<PostLikeJpaEntity> findByPostIdAndUserId(Long postId, Long userId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+    void deleteByPostIdAndUserId(Long postId, Long userId);
+}

--- a/backend/src/main/java/com/venueon/post/application/port/in/PostLikeUseCase.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/PostLikeUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.post.application.port.in;
+
+public interface PostLikeUseCase {
+    void toggleLike(Long postId, String email);
+}

--- a/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
@@ -9,13 +9,13 @@ import java.time.LocalDateTime;
  * 본문(content)은 목록에서 필요 없으므로 제외하여 데이터 전송량을 줄입니다.
  */
 public record PostListResponse(
-        Long id,
-        String title,
-        PostType type,
-        String authorNickname,
-        String content,
-        int viewCount,
-        int commentCount,
-        LocalDateTime createdAt
-) {
+                Long id,
+                String title,
+                PostType type,
+                String authorNickname,
+                String content,
+                int viewCount,
+                int commentCount,
+                int likeCount,
+                LocalDateTime createdAt) {
 }

--- a/backend/src/main/java/com/venueon/post/application/port/out/PostRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/post/application/port/out/PostRepositoryPort.java
@@ -5,8 +5,20 @@ import com.venueon.post.domain.model.PostType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface PostRepositoryPort {
     Post save(Post post);
+
+    Optional<Post> findById(Long id);
+
     Page<Post> findByCommunityId(Long communityId, Pageable pageable);
+
     Page<Post> findByCommunityIdAndType(Long communityId, PostType type, Pageable pageable);
+
+    boolean existsLike(Long postId, Long userId);
+
+    void saveLike(Long postId, Long userId);
+
+    void deleteLike(Long postId, Long userId);
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
@@ -2,6 +2,7 @@ package com.venueon.post.application.service;
 
 import com.venueon.common.annotation.UseCase;
 import com.venueon.post.application.port.in.CreatePostUseCase;
+import com.venueon.post.application.port.in.PostLikeUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
 import com.venueon.post.application.port.in.dto.CreatePostResponse;
 import com.venueon.post.application.port.out.PostRepositoryPort;
@@ -13,31 +14,50 @@ import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-public class PostCommandService implements CreatePostUseCase {
+public class PostCommandService implements CreatePostUseCase, PostLikeUseCase {
 
-    private final PostRepositoryPort postRepositoryPort;
-    private final UserRepositoryPort userRepositoryPort;
+        private final PostRepositoryPort postRepositoryPort;
+        private final UserRepositoryPort userRepositoryPort;
 
-    @Override
-    @Transactional
-    public CreatePostResponse createPost(CreatePostRequest request, String email) {
-        User author = userRepositoryPort.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
+        @Override
+        @Transactional
+        public CreatePostResponse createPost(CreatePostRequest request, String email) {
+                User author = userRepositoryPort.findByEmail(email)
+                                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
 
-        Post post = Post.builder()
-                .communityId(request.communityId())
-                .authorId(author.getId())
-                .title(request.title())
-                .content(request.content())
-                .type(request.type())
-                .build();
+                Post post = Post.builder()
+                                .communityId(request.communityId())
+                                .authorId(author.getId())
+                                .title(request.title())
+                                .content(request.content())
+                                .type(request.type())
+                                .build();
 
-        Post savedPost = postRepositoryPort.save(post);
+                Post savedPost = postRepositoryPort.save(post);
 
-        return new CreatePostResponse(
-                savedPost.getId(),
-                savedPost.getTitle(),
-                savedPost.getCreatedAt()
-        );
-    }
+                return new CreatePostResponse(
+                                savedPost.getId(),
+                                savedPost.getTitle(),
+                                savedPost.getCreatedAt());
+        }
+
+        @Override
+        @Transactional
+        public void toggleLike(Long postId, String email) {
+                User user = userRepositoryPort.findByEmail(email)
+                                .orElseThrow(() -> new IllegalArgumentException("User not found: " + email));
+
+                Post post = postRepositoryPort.findById(postId)
+                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+
+                if (postRepositoryPort.existsLike(postId, user.getId())) {
+                        postRepositoryPort.deleteLike(postId, user.getId());
+                        post.decrementLikeCount();
+                } else {
+                        postRepositoryPort.saveLike(postId, user.getId());
+                        post.incrementLikeCount();
+                }
+
+                postRepositoryPort.save(post);
+        }
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
@@ -34,9 +34,9 @@ public class PostQueryService implements GetPostQuery {
                 post.getType(),
                 post.getAuthorNickname(),
                 post.getContent(),
-                0, // viewCount (가설 추가)
-                0, // commentCount (가설 추가)
-                post.getCreatedAt()
-        ));
+                post.getViewCount(),
+                post.getCommentCount(),
+                post.getLikeCount(),
+                post.getCreatedAt()));
     }
 }

--- a/backend/src/main/java/com/venueon/post/domain/model/Post.java
+++ b/backend/src/main/java/com/venueon/post/domain/model/Post.java
@@ -21,6 +21,9 @@ public class Post {
     private PostType type;
     private int viewCount;
     private int commentCount;
+    private int likeCount;
+    private boolean isPinned;
+    private boolean isNotice;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -43,5 +46,23 @@ public class Post {
         if (this.commentCount > 0) {
             this.commentCount--;
         }
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void togglePin() {
+        this.isPinned = !this.isPinned;
+    }
+
+    public void setNotice(boolean isNotice) {
+        this.isNotice = isNotice;
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@tosspayments/tosspayments-sdk": "^2.6.0",
         "date-fns": "^4.1.0",
         "iron-session": "^8.0.4",
-        "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4343,15 +4342,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,6 @@
     "@tosspayments/tosspayments-sdk": "^2.6.0",
     "date-fns": "^4.1.0",
     "iron-session": "^8.0.4",
-    "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/frontend/src/app/community/components/CommunityCommentItem.module.css
+++ b/frontend/src/app/community/components/CommunityCommentItem.module.css
@@ -69,3 +69,53 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* --------- 댓글 하단 (좋아요 + 답글) --------- */
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 4px;
+}
+
+.likeButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  color: #6B7280;
+}
+
+.likeButton:hover {
+  background-color: #F3F4F6;
+}
+
+.likeCount {
+  font-size: 12px;
+  color: #9CA3AF;
+}
+
+.activeLikeCount {
+  font-size: 12px;
+  color: #EF4444;
+  font-weight: 500;
+}
+
+.replyButton {
+  font-size: 12px;
+  color: #6B7280;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.replyButton:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/app/community/components/CommunityCommentItem.tsx
+++ b/frontend/src/app/community/components/CommunityCommentItem.tsx
@@ -19,6 +19,10 @@ export interface CommunityCommentItemProps {
   menuItems?: PopoverMenuItem[];
   /** 더보기 메뉴 항목 선택 시 콜백 */
   onMenuSelect?: (value: string) => void;
+  /** 좋아요 수 */
+  likeCount?: number;
+  /** 좋아요 클릭 시 콜백 */
+  onLike?: () => void;
 }
 
 export default function CommunityCommentItem({
@@ -28,6 +32,8 @@ export default function CommunityCommentItem({
   avatarUrl,
   menuItems,
   onMenuSelect,
+  likeCount = 0,
+  onLike,
 }: CommunityCommentItemProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -66,6 +72,32 @@ export default function CommunityCommentItem({
       </div>
 
       <p className={styles.content}>{content}</p>
+
+      <div className={styles.footer}>
+        <button 
+          className={styles.likeButton} 
+          onClick={(e) => {
+            e.stopPropagation();
+            onLike?.();
+          }}
+          type="button"
+        >
+          <svg 
+            width="14" 
+            height="14" 
+            viewBox="0 0 24 24" 
+            fill={likeCount > 0 ? "#EF4444" : "none"} 
+            stroke={likeCount > 0 ? "#EF4444" : "#9CA3AF"} 
+            strokeWidth="2" 
+            strokeLinecap="round" 
+            strokeLinejoin="round"
+          >
+            <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+          </svg>
+          <span className={likeCount > 0 ? styles.activeLikeCount : styles.likeCount}>{likeCount}</span>
+        </button>
+        <button className={styles.replyButton} type="button">답글 달기</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -88,6 +88,50 @@
   font-size: 20px;
   cursor: pointer;
   color: #9CA3AF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+
+.optionButton:hover {
+  background-color: #F3F4F6;
+}
+
+.detailActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.likeButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background-color: #F9FAFB;
+  border: 1px solid #E5E7EB;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 14px;
+  color: #4B5563;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.likeButton:hover {
+  background-color: #F3F4F6;
+  border-color: #D1D5DB;
+}
+
+.likeButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.activeHeart {
+  color: #EF4444;
 }
 
 .bodySection {

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -26,6 +26,7 @@ interface CommentResponse {
   authorNickname: string;
   content: string;
   parentId: number | null;
+  likeCount: number;
   createdAt: string;
 }
 
@@ -79,8 +80,8 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   };
 
-  const fetchComments = async (postId: number) => {
-    setIsCommentsLoading(true);
+  const fetchComments = async (postId: number, silent = false) => {
+    if (!silent) setIsCommentsLoading(true);
     try {
       const response = await fetch(`/api/comments?postId=${postId}`);
       if (!response.ok) throw new Error('댓글을 불러오는데 실패했습니다.');
@@ -89,7 +90,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
     } catch (error) {
       console.error(error);
     } finally {
-      setIsCommentsLoading(false);
+      if (!silent) setIsCommentsLoading(false);
     }
   };
 
@@ -144,6 +145,29 @@ export default function CommunityPostContainer({ communityId }: Props) {
       showToast('좋아요 처리 실패', 'error');
     } finally {
       setIsLikeSubmitting(false);
+    }
+  };
+
+  const handleCommentLikeToggle = async (commentId: number) => {
+    try {
+      const response = await fetch(`/api/comments/${commentId}/like`, {
+        method: 'POST',
+      });
+
+      if (response.status === 401) {
+        showToast('로그인이 필요합니다.', 'error');
+        return;
+      }
+
+      if (!response.ok) throw new Error('댓글 좋아요 실패');
+
+      // 댓글 목록만 새로고침 (로딩 표시 없이 데이터만 갱신)
+      if (selectedPostId) {
+        fetchComments(selectedPostId, true);
+      }
+    } catch (error) {
+      console.error(error);
+      showToast('좋아요 처리 실패', 'error');
     }
   };
 
@@ -281,6 +305,8 @@ export default function CommunityPostContainer({ communityId }: Props) {
                     username={comment.authorNickname}
                     date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                     content={comment.content}
+                    likeCount={comment.likeCount}
+                    onLike={() => handleCommentLikeToggle(comment.id)}
                     menuItems={[{ value: 'report', label: '신고하기' }]}
                   />
                 ))

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -15,6 +15,7 @@ interface PostListResponse {
   content: string;
   viewCount: number;
   commentCount: number;
+  likeCount: number;
   createdAt: string;
 }
 
@@ -45,23 +46,24 @@ export default function CommunityPostContainer({ communityId }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
-  
+
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [isCommentsLoading, setIsCommentsLoading] = useState(false);
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
+  const [isLikeSubmitting, setIsLikeSubmitting] = useState(false);
 
-  const fetchPosts = async () => {
-    setIsLoading(true);
+  const fetchPosts = async (silent = false) => {
+    if (!silent) setIsLoading(true);
     try {
       const response = await fetch(
         `/api/posts?communityId=${communityId}&page=${currentPage - 1}&size=10`
       );
-      
+
       if (!response.ok) {
         throw new Error('데이터를 불러오는데 실패했습니다.');
       }
-      
+
       const data: PageData = await response.json();
       setPosts(data.content);
       setTotalPages(data.totalPages === 0 ? 1 : data.totalPages);
@@ -73,7 +75,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
       console.error(error);
       showToast('게시물 불러오기 실패', 'error', '네트워크 오류가 발생했습니다.');
     } finally {
-        setIsLoading(false);
+      if (!silent) setIsLoading(false);
     }
   };
 
@@ -119,6 +121,32 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   };
 
+  const handleLikeToggle = async () => {
+    if (!selectedPostId || isLikeSubmitting) return;
+
+    setIsLikeSubmitting(true);
+    try {
+      const response = await fetch(`/api/posts/${selectedPostId}/like`, {
+        method: 'POST',
+      });
+
+      if (response.status === 401) {
+        showToast('로그인이 필요합니다.', 'error');
+        return;
+      }
+
+      if (!response.ok) throw new Error('좋아요 처리 실패');
+
+      // 게시글 목록 새로고침 (로딩 표시 없이 데이터만 갱신)
+      fetchPosts(true);
+    } catch (error) {
+      console.error(error);
+      showToast('좋아요 처리 실패', 'error');
+    } finally {
+      setIsLikeSubmitting(false);
+    }
+  };
+
   useEffect(() => {
     fetchPosts();
   }, [communityId, currentPage]);
@@ -133,27 +161,27 @@ export default function CommunityPostContainer({ communityId }: Props) {
 
   return (
     <div className={styles.container}>
-      
+
       {/* 1. 좌측: 리스트 영역 (너비 고정) */}
       <div className={styles.leftSidebar}>
         <div className={styles.searchRow}>
-            <div className={styles.searchInputWrapper}>
-                <InputField variant="search" placeholder="검색어를 입력하세요" />
-            </div>
-            <Button variant="primary" onClick={() => window.location.href = `/community/${communityId}/write`}>
-                글쓰기
-            </Button>
+          <div className={styles.searchInputWrapper}>
+            <InputField variant="search" placeholder="검색어를 입력하세요" />
+          </div>
+          <Button variant="primary" onClick={() => window.location.href = `/community/${communityId}/write`}>
+            글쓰기
+          </Button>
         </div>
 
         <div className={styles.postList}>
           {isLoading ? (
-              <div className={styles.loadingOrEmpty}>
-                  데이터를 불러오는 중입니다...
-              </div>
+            <div className={styles.loadingOrEmpty}>
+              데이터를 불러오는 중입니다...
+            </div>
           ) : posts.length === 0 ? (
-              <div className={styles.loadingOrEmpty}>
-                  게시글이 없습니다.
-              </div>
+            <div className={styles.loadingOrEmpty}>
+              게시글이 없습니다.
+            </div>
           ) : (
             posts.map(post => (
               <CommunityPostItem
@@ -171,79 +199,99 @@ export default function CommunityPostContainer({ communityId }: Props) {
         {/* 좌측 리스트 페이징 영역 */}
         {totalPages > 1 && (
           <div className={styles.paginationWrapper}>
-             <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
           </div>
         )}
       </div>
 
       {/* 2. 우측: 디테일 영역 (나머지 공간 전부 차지) */}
       <div className={styles.rightDetail}>
-          {selectedPost ? (
-              <>
-                {/* 2-1. 상세 상단 헤더 */}
-                <div className={styles.detailHeader}>
-                    <div>
-                        <h2 className={styles.detailTitle}>
-                            {selectedPost.title}
-                        </h2>
-                        <div className={styles.detailMeta}>
-                            <span>{new Date(selectedPost.createdAt).toLocaleDateString()} / {new Date(selectedPost.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-                        </div>
-                    </div>
-                    {/* 옵션 버튼 (점 3개 아이콘 더미) */}
-                    <button className={styles.optionButton}>
-                        •••
-                    </button>
+        {selectedPost ? (
+          <>
+            {/* 2-1. 상세 상단 헤더 */}
+            <div className={styles.detailHeader}>
+              <div>
+                <h2 className={styles.detailTitle}>
+                  {selectedPost.title}
+                </h2>
+                <div className={styles.detailMeta}>
+                  <span>{new Date(selectedPost.createdAt).toLocaleDateString()} / {new Date(selectedPost.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
                 </div>
-
-                {/* 2-2. 작성자 및 본문 영역 */}
-                <div className={styles.bodySection}>
-                    <div className={styles.authorWrapper}>
-                        <UserProfile name={selectedPost.authorNickname} size="medium" />
-                    </div>
-                    <div className={styles.contentWrapper}>
-                        {selectedPost.content?.split('\n').map((line, index) => (
-                            <React.Fragment key={index}>
-                                {line}
-                                <br />
-                            </React.Fragment>
-                        ))}
-                    </div>
-                </div>
-
-                {/* 2-3. 댓글 입력 영역 */}
-                <div className={styles.commentInputWrapper}>
-                   <CommentInput 
-                     onSubmit={handleCommentSubmit} 
-                     disabled={isCommentSubmitting}
-                     placeholder={isCommentSubmitting ? "등록 중..." : "댓글을 입력하세요.."}
-                   />
-                </div>
-
-                {/* 2-4. 댓글 리스트 영역 */}
-                <div className={styles.commentList}>
-                     {isCommentsLoading ? (
-                        <div className={styles.commentStatus}>댓글을 불러오는 중...</div>
-                     ) : comments.length === 0 ? (
-                        <div className={styles.commentStatus}>첫 번째 댓글을 남겨보세요!</div>
-                     ) : (
-                        comments.map(comment => (
-                          <CommunityCommentItem
-                             key={comment.id}
-                             username={comment.authorNickname}
-                             date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                             content={comment.content}
-                             menuItems={[{ value: 'report', label: '신고하기' }]}
-                          />
-                        ))
-                     )}
-                </div>
-              </>
-          ) : (
-              <div className={styles.emptyDetail}>
-                  선택된 게시물이 없습니다.
               </div>
-          )}
+              <div className={styles.detailActions}>
+                <button
+                  className={styles.likeButton}
+                  onClick={handleLikeToggle}
+                  disabled={isLikeSubmitting}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill={selectedPost.likeCount > 0 ? "#EF4444" : "none"}
+                    stroke={selectedPost.likeCount > 0 ? "#EF4444" : "currentColor"}
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+                  </svg>
+                  <span>{selectedPost.likeCount}</span>
+                </button>
+                <button className={styles.optionButton}>
+                  •••
+                </button>
+              </div>
+            </div>
+
+            {/* 2-2. 작성자 및 본문 영역 */}
+            <div className={styles.bodySection}>
+              <div className={styles.authorWrapper}>
+                <UserProfile name={selectedPost.authorNickname} size="medium" />
+              </div>
+              <div className={styles.contentWrapper}>
+                {selectedPost.content?.split('\n').map((line, index) => (
+                  <React.Fragment key={index}>
+                    {line}
+                    <br />
+                  </React.Fragment>
+                ))}
+              </div>
+            </div>
+
+            {/* 2-3. 댓글 입력 영역 */}
+            <div className={styles.commentInputWrapper}>
+              <CommentInput
+                onSubmit={handleCommentSubmit}
+                disabled={isCommentSubmitting}
+                placeholder={isCommentSubmitting ? "등록 중..." : "댓글을 입력하세요.."}
+              />
+            </div>
+
+            {/* 2-4. 댓글 리스트 영역 */}
+            <div className={styles.commentList}>
+              {isCommentsLoading ? (
+                <div className={styles.commentStatus}>댓글을 불러오는 중...</div>
+              ) : comments.length === 0 ? (
+                <div className={styles.commentStatus}>첫 번째 댓글을 남겨보세요!</div>
+              ) : (
+                comments.map(comment => (
+                  <CommunityCommentItem
+                    key={comment.id}
+                    username={comment.authorNickname}
+                    date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    content={comment.content}
+                    menuItems={[{ value: 'report', label: '신고하기' }]}
+                  />
+                ))
+              )}
+            </div>
+          </>
+        ) : (
+          <div className={styles.emptyDetail}>
+            선택된 게시물이 없습니다.
+          </div>
+        )}
       </div>
 
     </div>

--- a/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
+++ b/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { MoreVertical } from 'lucide-react';
 import styles from './EventActionMenu.module.css';
 import { PopoverMenu } from '@/components/ui';
 import { ConfirmModal } from '@/components/modal';
@@ -43,7 +42,7 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
         method: 'DELETE',
       });
       if (!res.ok) throw new Error('이벤트 삭제에 실패했습니다.');
-      
+
       showToast('이벤트가 성공적으로 삭제되었습니다.', 'success');
       router.push('/');
       router.refresh();
@@ -57,7 +56,20 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
   return (
     <div className={styles.wrapper}>
       <button className={styles.triggerButton} onClick={() => setMenuOpen(!menuOpen)}>
-        <MoreVertical size={20} />
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="1" />
+          <circle cx="12" cy="5" r="1" />
+          <circle cx="12" cy="19" r="1" />
+        </svg>
       </button>
 
       {menuOpen && (

--- a/frontend/src/app/events/new/_components/EventForm.tsx
+++ b/frontend/src/app/events/new/_components/EventForm.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { FileUp, X } from 'lucide-react';
 import { Button, InputField, TextareaField, SelectBox } from '@/components/ui';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import styles from './EventForm.module.css';
@@ -102,16 +101,16 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     let droppedFile: File | null = null;
-    
+
     if (e.dataTransfer.items) {
       const item = Array.from(e.dataTransfer.items).find(i => i.kind === 'file');
       if (item) droppedFile = item.getAsFile();
     } else if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       droppedFile = e.dataTransfer.files[0];
     }
-    
+
     if (droppedFile) {
       handleFileUpload(droppedFile);
     } else {
@@ -123,7 +122,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     setLoading(true);
     try {
       const isOnline = formData.isOnlineStr === 'true';
-      
+
       // 날짜 파싱 (임시로 시작일 10시, 종료일 18시 셋팅)
       let startDateStr = new Date().toISOString();
       let endDateStr = new Date().toISOString();
@@ -163,7 +162,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       }
 
       if (!res.ok) throw new Error(`이벤트 ${mode === 'create' ? '생성' : '수정'} 실패`);
-      
+
       const resData = await res.json();
       const targetId = mode === 'create' ? resData.data.id : eventId;
 
@@ -194,11 +193,11 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       <div className={styles.formGroup}>
         <label className={styles.label}>강의 제목</label>
-        <input 
-          type="text" 
+        <input
+          type="text"
           name="title"
-          className={styles.titleInput} 
-          placeholder="제목을 입력하세요." 
+          className={styles.titleInput}
+          placeholder="제목을 입력하세요."
           value={formData.title}
           onChange={handleChange}
         />
@@ -211,7 +210,10 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             <img src={previewUrl} alt="미리보기" className={styles.previewImage} />
             {uploading && <div className={styles.uploadingOverlay}>업로드 중...</div>}
             <button className={styles.removeImageBtn} onClick={handleRemoveImage} type="button">
-              <X size={16} />
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
             </button>
           </div>
         ) : (
@@ -223,7 +225,11 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setIsDragOver(false); }}
             onDrop={(e) => { e.preventDefault(); e.stopPropagation(); setIsDragOver(false); handleDrop(e); }}
           >
-            <FileUp size={32} className={styles.uploadIcon} />
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={styles.uploadIcon}>
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="17 8 12 3 7 8"></polyline>
+              <line x1="12" y1="3" x2="12" y2="15"></line>
+            </svg>
             <p>{isDragOver ? '여기에 놓으세요' : '클릭하거나 파일을 여기로 끌어다 놓으세요'}</p>
           </div>
         )}
@@ -245,9 +251,9 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           <label className={styles.label}>강의 정보</label>
           <span className={styles.charCount}>{formData.description.length}/300</span>
         </div>
-        <textarea 
+        <textarea
           name="description"
-          className={styles.textarea} 
+          className={styles.textarea}
           placeholder="강의 정보를 입력하세요."
           maxLength={300}
           value={formData.description}
@@ -260,22 +266,22 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           <label className={styles.label}>총 가격</label>
           <div className={styles.priceInputWrapper}>
             <span className={styles.currencyIcon}>₩</span>
-            <input 
-              type="number" 
+            <input
+              type="number"
               name="price"
-              className={styles.priceInput} 
+              className={styles.priceInput}
               value={formData.price}
               onChange={handleChange}
             />
           </div>
         </div>
-        
+
         <div className={styles.formGroup}>
           <label className={styles.label}>날짜</label>
-          <input 
-            type="date" 
+          <input
+            type="date"
             name="date"
-            className={styles.dateInput} 
+            className={styles.dateInput}
             value={formData.date}
             onChange={handleChange}
           />
@@ -283,7 +289,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
         <div className={styles.formGroup}>
           <label className={styles.label}>온라인/오프라인</label>
-          <select 
+          <select
             name="isOnlineStr"
             className={styles.selectInput}
             value={formData.isOnlineStr}
@@ -298,11 +304,11 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       <div className={styles.formGroup}>
         <label className={styles.label}>장소</label>
-        <input 
-          type="text" 
+        <input
+          type="text"
           name="location"
-          className={styles.standardInput} 
-          placeholder="오프라인 강의일 경우 주소를 입력해주세요." 
+          className={styles.standardInput}
+          placeholder="오프라인 강의일 경우 주소를 입력해주세요."
           value={formData.location}
           onChange={handleChange}
           disabled={formData.isOnlineStr === 'true'}
@@ -325,23 +331,23 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtonsRow}>
-            <button 
-              className={styles.draftBtn} 
+            <button
+              className={styles.draftBtn}
               disabled={true}
               title="마이페이지 기능이 추가되면 지원될 예정입니다."
             >
               임시 저장
             </button>
-            <button 
-              className={styles.publishBtn} 
+            <button
+              className={styles.publishBtn}
               onClick={() => handleSubmit(false)}
               disabled={loading}
             >
               {loading ? (mode === 'create' ? '게시 중...' : '수정 중...') : (mode === 'create' ? '게시하기' : '수정하기')}
             </button>
           </div>
-          <button 
-            className={styles.cancelBtn} 
+          <button
+            className={styles.cancelBtn}
             onClick={() => setIsExitModalOpen(true)}
             disabled={loading}
           >
@@ -350,7 +356,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         </div>
       </div>
 
-      <ConfirmModal 
+      <ConfirmModal
         isOpen={isExitModalOpen}
         onClose={() => setIsExitModalOpen(false)}
         onConfirm={() => {


### PR DESCRIPTION
1. 게시글 & 댓글 좋아요 기능 (백엔드)

헥사고날 아키텍처 준수: 도메인 객체(Post, Comment)에 좋아요 비즈니스 로직을 추가하고, 각각의 영속성 어댑터와 포트(UseCase)를 구현했습니다.
데이터 무결성: 좋아요 추가/삭제 시 DB 엔티티의 like_count 컬럼이 원자적으로 증감하도록 비즈니스 로직을 구축했습니다.
토글 방식 API: 별도의 추가/삭제 요청 없이 하나의 엔드포인트(POST /.../like)로 상태 전환이 가능하도록 구현했습니다.

2. 커뮤니티 UI 연동 및 최적화 (프론트엔드)

하트 아이콘 연동: 게시물 상세 및 댓글 리스트에 하트 아이콘과 좋아요 숫자를 실시간으로 시각화했습니다.
사용자 경험(UX) 개선: 좋아요 클릭 시 목록 전체가 아닌 데이터만 갱신하는 Silent Refresh 방식을 적용하여 화면 깜빡임 현상을 완전히 제거했습니다.
빌드 안정화: lucide-react 라이브러리 의존성을 제거하고 인라인 SVG로 아이콘을 교체하여 빌드 오류를 해결했습니다.

VO-648 VO-649