### PR TITLE
fix: 환불 정책 도메인 참조 임포트 경로 올바르게 수정 #VO-703

### DIFF
--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -10,7 +10,7 @@ import com.venueon.order.application.port.out.RefundSavePort;
 import com.venueon.order.domain.model.Order;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.order.adapter.in.web.dto.*;
-import com.venueon.report.application.port.in.RequestRefundUseCase;
+import com.venueon.order.application.port.in.RequestRefundUseCase;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 🚀 PR 요약
마이페이지 대시보드의 사용성을 개선하고 실데이터 연동을 위한 백엔드 모듈 확장 및 프론트엔드 라우트/용어 최적화를 진행했습니다. 
또한 Order 도메인의 잘못된 패키지 참조(report)를 바로잡아 모듈러 모놀리스 구조의 강결합을 해소했습니다.

## 🛠 주요 작업 사항
### 📍 Frontend 
- **도메인 용어 및 라우트 전면 최적화 (강의 ➔ 이벤트)**: 
  - `mypage/seminars` 경로 ➔ `mypage/events` 로 전면 변경 및 관련 Sidebar 라우팅 링크 수정
  - UI 텍스트 통일: `내 강의 목록` ➔ **`내 이벤트 목록`**, `찜한 강의` ➔ **`찜한 이벤트`**
  - VOD식 탭 '이어서 학습하기'를 라이브/오프라인 행사 맥락의 **'진행 중'**으로 구조 변경
  - 액션 버튼 텍스트(`입장하기` 변경) 및 테이블 '진행 시간' 컬럼 신규 추가
- **대시보드 UI 연동**: `SummaryData` 상태 관리를 통한 `/api/mypage/summary` API 연동 처리
- **디자인 토큰 적용**: `page.module.css` 내 하드코딩된 사이즈/간격 값을 디자인 시스템(`variables.css`) 토큰으로 완전 교체
- **공통 컴포넌트 리팩터링**: `InputField` 컴포넌트 내부에 `variant="search"`일 경우 `placeholder="검색어를 입력하세요"`를 주입하도록 추상화하여 마크업 중복 제거

### 📍 Backend (Hexagonal Architecture)
- **user 모듈 개편**: `VenueOn_목표_아키텍처_v5.md` 문서 내 도메인 분리 원칙에 따라 `com.venueon.user` 패키지 하위로 마이페이지 Aggregate 생성
- **요약 API Skeleton 구축 (`GET /api/mypage/summary`)**:
  - `MyPageController.java` (Adapter Layer 구현)
  - `GetMyPageSummaryUseCase.java` (In-Port 구성)
  - `MyPageService.java` (Application Layer - 초기 프론트 작업용 Mock Data 반환 로직 세팅)
  - `MyPageSummaryResponse.java` (DTO Layer) 
- **`EventStatus` 추가**: 기획 요건에 맞춘 이벤트 생애주기 내 `PREPARING` (준비 중) 상태 열거형 추가
- **의존성 참조 오류 해결 (Order 도메인)**: 
  - `OrderService.java` 내에서 환불 처리 시 신고 도메인(`report`)에 잘못 의존하고 있던 `RequestRefundUseCase` 임포트 경로를 `com.venueon.order.application.port.in` 올바른 주문 패키지로 분리/수정 완료

## 🔗 관련 이슈
- close #VO-703
