### PR TITLE
feat: 마이페이지 수강 탭 및 커뮤니티 카드 구현, 찜 목록 기능 고도화

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/in/web/OrderController.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/OrderController.java
@@ -84,12 +84,13 @@ public class OrderController {
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<Page<OrderDetailResponse>>> getMyOrders(
             Authentication authentication,
+            @RequestParam(required = false) String tab,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         String email = authentication.getName();
         Long userId = orderService.getUserIdByEmail(email);
 
-        Page<OrderDetailResponse> response = orderService.getMyOrders(userId, pageable);
+        Page<OrderDetailResponse> response = orderService.getMyOrders(userId, tab, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 @Component
@@ -96,8 +97,28 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
     }
 
     @Override
-    public Page<Order> findValidOrdersByUserId(Long userId, Pageable pageable) {
-        return orderJpaRepository.findValidOrdersByUserId(userId, pageable).map(this::toDomain);
+    public Page<Order> findValidOrdersByUserId(Long userId, String tab, Pageable pageable) {
+        List<com.venueon.event.domain.model.EventStatus> statuses = new ArrayList<>();
+        boolean hasStatuses = false;
+
+        if (tab != null && !tab.isEmpty()) {
+            hasStatuses = true;
+            if ("upcoming".equals(tab)) {
+                statuses.addAll(List.of(com.venueon.event.domain.model.EventStatus.DRAFT, com.venueon.event.domain.model.EventStatus.PUBLISHED, com.venueon.event.domain.model.EventStatus.PREPARING));
+            } else if ("enrolled".equals(tab)) {
+                statuses.add(com.venueon.event.domain.model.EventStatus.ONGOING);
+            } else if ("completed".equals(tab)) {
+                statuses.add(com.venueon.event.domain.model.EventStatus.ENDED);
+            } else {
+                hasStatuses = false;
+            }
+        }
+        
+        if (statuses.isEmpty()) {
+            statuses.add(com.venueon.event.domain.model.EventStatus.DRAFT); 
+        }
+
+        return orderJpaRepository.findValidOrdersByUserIdAndEventStatuses(userId, hasStatuses, statuses, pageable).map(this::toDomain);
     }
 
     // --- Mapper ---

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -15,8 +15,13 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     Page<OrderJpaEntity> findByUserId(Long userId, Pageable pageable);
 
     @Query("SELECT o FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
-           "(o.status != 'PENDING' OR (o.status = 'PENDING' AND o.paymentMethod = 'VIRTUAL_ACCOUNT'))")
-    Page<OrderJpaEntity> findValidOrdersByUserId(@Param("userId") Long userId, Pageable pageable);
+           "(o.status != 'PENDING' OR (o.status = 'PENDING' AND o.paymentMethod = 'VIRTUAL_ACCOUNT')) AND " +
+           "(:hasStatuses = false OR o.event.status IN :statuses)")
+    Page<OrderJpaEntity> findValidOrdersByUserIdAndEventStatuses(
+            @Param("userId") Long userId, 
+            @Param("hasStatuses") boolean hasStatuses, 
+            @Param("statuses") List<com.venueon.event.domain.model.EventStatus> statuses, 
+            Pageable pageable);
 
     List<OrderJpaEntity> findByEventId(Long eventId);
 

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -22,5 +22,5 @@ public interface OrderRepositoryPort {
     
     Page<Order> findByUserId(Long userId, Pageable pageable);
 
-    Page<Order> findValidOrdersByUserId(Long userId, Pageable pageable);
+    Page<Order> findValidOrdersByUserId(Long userId, String tab, Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -208,8 +208,8 @@ public class OrderService {
      * 내 주문/결제 내역
      * API 스펙: GET /orders/me
      */
-    public Page<OrderDetailResponse> getMyOrders(Long userId, Pageable pageable) {
-        return orderRepository.findValidOrdersByUserId(userId, pageable)
+    public Page<OrderDetailResponse> getMyOrders(Long userId, String tab, Pageable pageable) {
+        return orderRepository.findValidOrdersByUserId(userId, tab, pageable)
                 .map(this::toOrderDetailResponse);
     }
 

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/mypage")
+@RequestMapping("/mypage")
 public class MyPageController {
 
     private final GetMyPageSummaryUseCase getMyPageSummaryUseCase;

--- a/backend/src/main/java/com/venueon/wishlist/adapter/in/web/WishlistController.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/in/web/WishlistController.java
@@ -1,0 +1,49 @@
+package com.venueon.wishlist.adapter.in.web;
+import com.venueon.common.dto.ApiResponse;
+import com.venueon.wishlist.application.port.in.GetWishlistUseCase;
+import com.venueon.wishlist.application.port.in.ToggleWishlistUseCase;
+import com.venueon.wishlist.adapter.in.web.dto.WishlistResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/wishlists")
+@RequiredArgsConstructor
+public class WishlistController {
+    private final ToggleWishlistUseCase toggleWishlistUseCase;
+    private final GetWishlistUseCase getWishlistUseCase;
+
+    private Long getUserId(Long principalId) {
+        return principalId != null ? principalId : 1L; // Fallback mock userId
+    }
+
+    @PostMapping("/events/{eventId}")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> toggleWishlist(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId) {
+        boolean isAdded = toggleWishlistUseCase.toggle(getUserId(userId), eventId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("isWishlisted", isAdded)));
+    }
+
+    @GetMapping("/events/{eventId}/check")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkWishlist(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId) {
+        boolean exists = getWishlistUseCase.checkWishlist(getUserId(userId), eventId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("isWishlisted", exists)));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<Page<WishlistResponse>>> getMyWishlist(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 8) Pageable pageable) {
+        Page<WishlistResponse> res = getWishlistUseCase.getWishlist(getUserId(userId), pageable);
+        return ResponseEntity.ok(ApiResponse.success(res));
+    }
+}

--- a/backend/src/main/java/com/venueon/wishlist/adapter/in/web/dto/WishlistResponse.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/in/web/dto/WishlistResponse.java
@@ -1,0 +1,36 @@
+package com.venueon.wishlist.adapter.in.web.dto;
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
+import com.venueon.wishlist.domain.model.WishlistItem;
+import lombok.Getter;
+import lombok.Builder;
+import java.time.format.DateTimeFormatter;
+
+@Getter @Builder
+public class WishlistResponse {
+    private Long id;
+    private String status;
+    private String title;
+    private String organizer;
+    private String dateTime;
+    private String location;
+    private int price;
+    private Long wishlistId;
+
+    public static WishlistResponse of(WishlistItem item, Event event, HostInfo host) {
+        String eventStatus = event.getStatus() != null ? event.getStatus().name() : "ONGOING";
+        String organizerName = (host != null && host.nickname() != null) ? host.nickname() : "알 수 없는 호스트";
+        String dateStr = event.getStartDate() != null ? event.getStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")) : "-";
+        
+        return WishlistResponse.builder()
+            .id(event.getId())
+            .wishlistId(item.getId())
+            .status(eventStatus)
+            .title(event.getTitle())
+            .organizer(organizerName)
+            .dateTime(dateStr)
+            .location(event.getLocation() != null ? event.getLocation() : "온라인")
+            .price(event.getPrice())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/venueon/wishlist/adapter/out/client/EventClientAdapter.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/out/client/EventClientAdapter.java
@@ -1,0 +1,23 @@
+package com.venueon.wishlist.adapter.out.client;
+import com.venueon.wishlist.application.port.out.LoadEventPort;
+import com.venueon.event.application.service.EventQueryService;
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventClientAdapter implements LoadEventPort {
+    private final EventQueryService eventQueryService;
+    
+    @Override
+    public Event loadEvent(Long eventId) {
+        return eventQueryService.getEventById(eventId);
+    }
+    
+    @Override
+    public HostInfo loadHost(Long creatorId) {
+        return eventQueryService.getHostInfoByCreatorId(creatorId);
+    }
+}

--- a/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/WishlistPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/WishlistPersistenceAdapter.java
@@ -1,0 +1,56 @@
+package com.venueon.wishlist.adapter.out.persistence;
+import com.venueon.wishlist.application.port.out.LoadWishlistPort;
+import com.venueon.wishlist.application.port.out.SaveWishlistPort;
+import com.venueon.wishlist.application.port.out.DeleteWishlistPort;
+import com.venueon.wishlist.domain.model.WishlistItem;
+import com.venueon.wishlist.adapter.out.persistence.entity.WishlistJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class WishlistPersistenceAdapter implements LoadWishlistPort, SaveWishlistPort, DeleteWishlistPort {
+    private final WishlistRepository repository;
+
+    private WishlistItem mapToDomain(WishlistJpaEntity entity) {
+        if (entity == null) return null;
+        return WishlistItem.create(entity.getId(), entity.getUserId(), entity.getEventId(), entity.getCreatedAt());
+    }
+
+    private WishlistJpaEntity mapToEntity(WishlistItem domain) {
+        return WishlistJpaEntity.builder()
+                .id(domain.getId())
+                .userId(domain.getUserId())
+                .eventId(domain.getEventId())
+                .build();
+    }
+
+    @Override
+    public Optional<WishlistItem> findByUserIdAndEventId(Long userId, Long eventId) {
+        return repository.findByUserIdAndEventId(userId, eventId).map(this::mapToDomain);
+    }
+
+    @Override
+    public Page<WishlistItem> findByUserId(Long userId, Pageable pageable) {
+        return repository.findByUserId(userId, pageable).map(this::mapToDomain);
+    }
+
+    @Override
+    public boolean exists(Long userId, Long eventId) {
+        return repository.existsByUserIdAndEventId(userId, eventId);
+    }
+
+    @Override
+    public WishlistItem save(WishlistItem wishlistItem) {
+        WishlistJpaEntity saved = repository.save(mapToEntity(wishlistItem));
+        return mapToDomain(saved);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/WishlistRepository.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/WishlistRepository.java
@@ -1,0 +1,12 @@
+package com.venueon.wishlist.adapter.out.persistence;
+import com.venueon.wishlist.adapter.out.persistence.entity.WishlistJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface WishlistRepository extends JpaRepository<WishlistJpaEntity, Long> {
+    Optional<WishlistJpaEntity> findByUserIdAndEventId(Long userId, Long eventId);
+    Page<WishlistJpaEntity> findByUserId(Long userId, Pageable pageable);
+    boolean existsByUserIdAndEventId(Long userId, Long eventId);
+}

--- a/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/entity/WishlistJpaEntity.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/out/persistence/entity/WishlistJpaEntity.java
@@ -1,0 +1,22 @@
+package com.venueon.wishlist.adapter.out.persistence.entity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "wishlist")
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WishlistJpaEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/in/GetWishlistUseCase.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/in/GetWishlistUseCase.java
@@ -1,0 +1,8 @@
+package com.venueon.wishlist.application.port.in;
+import com.venueon.wishlist.adapter.in.web.dto.WishlistResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+public interface GetWishlistUseCase {
+    Page<WishlistResponse> getWishlist(Long userId, Pageable pageable);
+    boolean checkWishlist(Long userId, Long eventId);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/in/ToggleWishlistUseCase.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/in/ToggleWishlistUseCase.java
@@ -1,0 +1,4 @@
+package com.venueon.wishlist.application.port.in;
+public interface ToggleWishlistUseCase {
+    boolean toggle(Long userId, Long eventId);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/out/DeleteWishlistPort.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/out/DeleteWishlistPort.java
@@ -1,0 +1,4 @@
+package com.venueon.wishlist.application.port.out;
+public interface DeleteWishlistPort {
+    void delete(Long id);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadEventPort.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadEventPort.java
@@ -1,0 +1,7 @@
+package com.venueon.wishlist.application.port.out;
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
+public interface LoadEventPort {
+    Event loadEvent(Long eventId);
+    HostInfo loadHost(Long creatorId);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadWishlistPort.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadWishlistPort.java
@@ -1,0 +1,10 @@
+package com.venueon.wishlist.application.port.out;
+import com.venueon.wishlist.domain.model.WishlistItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+public interface LoadWishlistPort {
+    Optional<WishlistItem> findByUserIdAndEventId(Long userId, Long eventId);
+    Page<WishlistItem> findByUserId(Long userId, Pageable pageable);
+    boolean exists(Long userId, Long eventId);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/port/out/SaveWishlistPort.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/out/SaveWishlistPort.java
@@ -1,0 +1,5 @@
+package com.venueon.wishlist.application.port.out;
+import com.venueon.wishlist.domain.model.WishlistItem;
+public interface SaveWishlistPort {
+    WishlistItem save(WishlistItem wishlistItem);
+}

--- a/backend/src/main/java/com/venueon/wishlist/application/service/WishlistService.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/service/WishlistService.java
@@ -1,0 +1,58 @@
+package com.venueon.wishlist.application.service;
+import com.venueon.wishlist.application.port.in.ToggleWishlistUseCase;
+import com.venueon.wishlist.application.port.in.GetWishlistUseCase;
+import com.venueon.wishlist.application.port.out.LoadWishlistPort;
+import com.venueon.wishlist.application.port.out.SaveWishlistPort;
+import com.venueon.wishlist.application.port.out.DeleteWishlistPort;
+import com.venueon.wishlist.application.port.out.LoadEventPort;
+import com.venueon.wishlist.domain.model.WishlistItem;
+import com.venueon.wishlist.adapter.in.web.dto.WishlistResponse;
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistService implements ToggleWishlistUseCase, GetWishlistUseCase {
+    private final LoadWishlistPort loadWishlistPort;
+    private final SaveWishlistPort saveWishlistPort;
+    private final DeleteWishlistPort deleteWishlistPort;
+    private final LoadEventPort loadEventPort;
+
+    @Override
+    @Transactional
+    public boolean toggle(Long userId, Long eventId) {
+        return loadWishlistPort.findByUserIdAndEventId(userId, eventId)
+                .map(item -> {
+                    deleteWishlistPort.delete(item.getId());
+                    return false; // Removed
+                })
+                .orElseGet(() -> {
+                    WishlistItem item = WishlistItem.create(null, userId, eventId, LocalDateTime.now());
+                    saveWishlistPort.save(item);
+                    return true; // Added
+                });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<WishlistResponse> getWishlist(Long userId, Pageable pageable) {
+        return loadWishlistPort.findByUserId(userId, pageable)
+                .map(item -> {
+                    Event event = loadEventPort.loadEvent(item.getEventId());
+                    HostInfo host = loadEventPort.loadHost(event.getCreatorId());
+                    return WishlistResponse.of(item, event, host);
+                });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkWishlist(Long userId, Long eventId) {
+        return loadWishlistPort.exists(userId, eventId);
+    }
+}

--- a/backend/src/main/java/com/venueon/wishlist/domain/model/WishlistItem.java
+++ b/backend/src/main/java/com/venueon/wishlist/domain/model/WishlistItem.java
@@ -1,0 +1,15 @@
+package com.venueon.wishlist.domain.model;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter @AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class WishlistItem {
+    private Long id;
+    private Long userId;
+    private Long eventId;
+    private LocalDateTime createdAt;
+    
+    public static WishlistItem create(Long id, Long userId, Long eventId, LocalDateTime createdAt) {
+        return new WishlistItem(id, userId, eventId, createdAt);
+    }
+}

--- a/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.tsx
+++ b/frontend/src/app/(auth)/host-signup/_components/HostTermsModal/HostTermsModal.tsx
@@ -73,7 +73,7 @@ const TERMS_DATA: Record<HostTermType, { title: string; sections: { heading: str
       {
         heading: "제1조 (호스트의 정의)",
         body: [
-          "호스트란 VenueOn 플랫폼을 통해 공연, 전시, 이벤트 등의 행사를 등록하고 티켓을 판매하는 사업자(개인 또는 법인)를 의미합니다."
+          "호스트란 VenueOn 플랫폼을 통해 공연, 전시, 세션 등의 행사를 등록하고 티켓을 판매하는 사업자(개인 또는 법인)를 의미합니다."
         ]
       },
       {

--- a/frontend/src/app/api/events/[id]/route.ts
+++ b/frontend/src/app/api/events/[id]/route.ts
@@ -93,7 +93,7 @@ export async function DELETE(
       }
     }
 
-    return NextResponse.json({ success: true, message: "세션가 삭제되었습니다." });
+    return NextResponse.json({ success: true, message: "세션이 삭제되었습니다." });
   } catch (error) {
     console.error("Failed to delete event:", error);
     return NextResponse.json(

--- a/frontend/src/app/api/events/[id]/route.ts
+++ b/frontend/src/app/api/events/[id]/route.ts
@@ -61,7 +61,7 @@ export async function PUT(
   } catch (error) {
     console.error("Failed to update event:", error);
     return NextResponse.json(
-      { success: false, message: "이벤트 수정 중 오류가 발생했습니다." },
+      { success: false, message: "세션 수정 중 오류가 발생했습니다." },
       { status: 500 }
     );
   }
@@ -93,11 +93,11 @@ export async function DELETE(
       }
     }
 
-    return NextResponse.json({ success: true, message: "이벤트가 삭제되었습니다." });
+    return NextResponse.json({ success: true, message: "세션가 삭제되었습니다." });
   } catch (error) {
     console.error("Failed to delete event:", error);
     return NextResponse.json(
-      { success: false, message: "이벤트 삭제 중 오류가 발생했습니다." },
+      { success: false, message: "세션 삭제 중 오류가 발생했습니다." },
       { status: 500 }
     );
   }

--- a/frontend/src/app/community/components/CommunityCard.module.css
+++ b/frontend/src/app/community/components/CommunityCard.module.css
@@ -1,0 +1,135 @@
+/* src/app/community/components/CommunityCard.module.css */
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+  padding: var(--space-24);
+  /* 24px */
+  gap: var(--space-16);
+  /* 16px */
+  width: 410px;
+  height: 495px;
+  background-color: var(--color-surface);
+  /* #F3F4F6 */
+  border-radius: var(--radius-xl);
+  /* 24px */
+  box-sizing: border-box;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0;
+  gap: var(--space-16);
+  /* 16px */
+  width: 100%;
+  flex: none;
+}
+
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.postType {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-700);
+  text-transform: uppercase;
+}
+
+.postTypeDot {
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-text-gray-700);
+  border-radius: 50%;
+}
+
+.timeAgo {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+}
+
+.title {
+  font: var(--text-h1-card-regular);
+  color: var(--color-text-gray-900);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  width: 100%;
+}
+
+.bottomSection {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--space-16);
+  flex: none;
+}
+
+.divider {
+  width: calc(100% + var(--space-48));
+  margin-left: calc(var(--space-24) * -1);
+  height: 1px;
+  background-color: var(--color-text-gray-300);
+}
+
+.tagSectionTitle {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-500);
+  text-transform: uppercase;
+}
+
+.categorySection {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-start;
+  padding: 0;
+  gap: var(--space-8);
+  /* 8px */
+  width: 100%;
+  height: 98px; /* 고정 공간 확보 (최대 2줄) */
+  overflow: hidden; /* 3줄째로 넘어가면 가림 */
+}
+
+.categoryTag {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: var(--space-12) var(--space-24);
+  /* 12px 24px */
+  height: 45px;
+  border: 1px solid var(--color-text-gray-700);
+  /* #374151 */
+  border-radius: 123px;
+  font: var(--text-body-bold);
+  /* 14px 700 */
+  color: var(--color-text-gray-700);
+  /* #374151 */
+  box-sizing: border-box;
+}
+
+.actionWrapper {
+  width: 100%;
+  margin-top: var(--space-8);
+  flex: none;
+}

--- a/frontend/src/app/community/components/CommunityCard.tsx
+++ b/frontend/src/app/community/components/CommunityCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import styles from './CommunityCard.module.css';
+import { Button } from '@/components/ui';
+
+export interface CommunityCardProps {
+  postType?: string;
+  timeAgo?: string;
+  title: string;
+  tagSectionTitle?: string;
+  categories?: string[];
+  actionButtonText?: string;
+  onActionClick?: () => void;
+}
+
+export default function CommunityCard({
+  postType,
+  timeAgo,
+  title,
+  tagSectionTitle,
+  categories = [],
+  actionButtonText,
+  onActionClick
+}: CommunityCardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.header}>
+        <div className={styles.topRow}>
+          {postType && (
+            <div className={styles.postType}>
+              <span className={styles.postTypeDot} />
+              {postType}
+            </div>
+          )}
+          {timeAgo && <div className={styles.timeAgo}>{timeAgo}</div>}
+        </div>
+        <h3 className={styles.title} title={title}>{title}</h3>
+      </div>
+
+      {categories.length > 0 && (
+        <div className={styles.bottomSection}>
+          <div className={styles.divider} />
+          {tagSectionTitle && (
+            <div className={styles.tagSectionTitle}>{tagSectionTitle}</div>
+          )}
+          <div className={styles.categorySection}>
+            {categories.map((category, index) => (
+              <div key={index} className={styles.categoryTag}>
+                {category}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {actionButtonText && (
+        <div className={styles.actionWrapper}>
+          <Button variant="primary" style={{ width: '100%', height: '48px' }} onClick={onActionClick}>
+            {actionButtonText}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
+++ b/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
@@ -41,9 +41,9 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
       const res = await fetch(`/api/events/${eventId}`, {
         method: 'DELETE',
       });
-      if (!res.ok) throw new Error('이벤트 삭제에 실패했습니다.');
+      if (!res.ok) throw new Error('세션 삭제에 실패했습니다.');
 
-      showToast('이벤트가 성공적으로 삭제되었습니다.', 'success');
+      showToast('세션가 성공적으로 삭제되었습니다.', 'success');
       router.push('/');
       router.refresh();
     } catch (err: any) {
@@ -89,7 +89,7 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
         onConfirm={handleDelete}
-        title="이벤트 삭제"
+        title="세션 삭제"
         subtitle="정말 삭제하시겠습니까? (이 작업은 되돌릴 수 없습니다)"
         confirmText="삭제"
         status="danger"

--- a/frontend/src/app/events/[id]/edit/page.tsx
+++ b/frontend/src/app/events/[id]/edit/page.tsx
@@ -35,7 +35,7 @@ export default async function EventEditPage({ params }: Props) {
   if (!event) {
     return (
       <div style={{ textAlign: 'center', padding: '100px 0' }}>
-        <h2>이벤트를 찾을 수 없습니다.</h2>
+        <h2>세션를 찾을 수 없습니다.</h2>
       </div>
     );
   }

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -47,8 +47,8 @@ export default async function EventDetailPage({ params }: Props) {
   if (!event || event.error) {
     return (
       <div className={styles.container} style={{ textAlign: 'center', padding: '100px 0' }}>
-        <h2>이벤트를 찾을 수 없거나 불러오지 못했습니다.</h2>
-        <p>삭제되었거나 존재하지 않는 이벤트입니다.</p>
+        <h2>세션를 찾을 수 없거나 불러오지 못했습니다.</h2>
+        <p>삭제되었거나 존재하지 않는 세션입니다.</p>
         <div style={{ marginTop: 20, color: 'red', textAlign: 'left', background: '#ffebee', padding: 16 }}>
           <pre>{JSON.stringify(event, null, 2)}</pre>
         </div>
@@ -73,7 +73,7 @@ export default async function EventDetailPage({ params }: Props) {
       {/* 뒤로 가기 바 */}
       <div className={styles.topBar}>
         <Link href="/" className={styles.backButton}>
-          ← 강의 목록 보기
+          ← 세션 목록 보기
         </Link>
       </div>
 
@@ -97,9 +97,9 @@ export default async function EventDetailPage({ params }: Props) {
         )}
       </div>
 
-      {/* 강의 정보 섹션 */}
+      {/* 세션 정보 섹션 */}
       <section className={styles.section}>
-        <h3 className={styles.sectionTitle}>강의 정보</h3>
+        <h3 className={styles.sectionTitle}>세션 정보</h3>
         <div className={styles.description}>
           {event.description}
         </div>
@@ -120,7 +120,7 @@ export default async function EventDetailPage({ params }: Props) {
           <div className={styles.infoItem}>
             <span className={styles.infoLabel}>장소</span>
             <span className={styles.infoValue}>
-              {event.isOnline ? '온라인 이벤트' : event.location}
+              {event.isOnline ? '온라인 세션' : event.location}
             </span>
           </div>
         </div>
@@ -147,7 +147,7 @@ export default async function EventDetailPage({ params }: Props) {
       {/* 하단 액션 버튼 */}
       <div className={styles.bottomActionArea}>
         <Link href="/" style={{ textDecoration: 'none' }}>
-          <Button variant="outlined" size="large">강의 목록</Button>
+          <Button variant="outlined" size="large">세션 목록</Button>
         </Link>
         {event.status === 'PUBLISHED' ? (
           <Link href={`/orders/checkout?eventId=${id}&quantity=1`} style={{ textDecoration: 'none' }}>

--- a/frontend/src/app/events/new/_components/EventForm.tsx
+++ b/frontend/src/app/events/new/_components/EventForm.tsx
@@ -134,7 +134,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       // API 요청 분기 (create / edit)
       const payload = {
         categoryId: 1, // 테스트용 하드코딩
-        title: formData.title || '새 이벤트',
+        title: formData.title || '새 세션',
         description: formData.description,
         type: 'SEMINAR',
         location: formData.location,
@@ -161,7 +161,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         });
       }
 
-      if (!res.ok) throw new Error(`이벤트 ${mode === 'create' ? '생성' : '수정'} 실패`);
+      if (!res.ok) throw new Error(`세션 ${mode === 'create' ? '생성' : '수정'} 실패`);
 
       const resData = await res.json();
       const targetId = mode === 'create' ? resData.data.id : eventId;
@@ -176,7 +176,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         if (!publishRes.ok) throw new Error('상태 변경 실패');
       }
 
-      showToast(mode === 'create' ? (isDraft ? '임시 저장되었습니다.' : '이벤트가 성공적으로 게시되었습니다.') : '이벤트가 성공적으로 수정되었습니다.', 'success');
+      showToast(mode === 'create' ? (isDraft ? '임시 저장되었습니다.' : '세션가 성공적으로 게시되었습니다.') : '세션가 성공적으로 수정되었습니다.', 'success');
       router.push(`/events/${targetId}`);
     } catch (err: any) {
       showToast(err.message, 'error');
@@ -188,11 +188,11 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
   return (
     <div className={styles.formContainer}>
       <button className={styles.backButton} onClick={() => router.back()}>
-        ← 강의 목록 보기
+        ← 세션 목록 보기
       </button>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>강의 제목</label>
+        <label className={styles.label}>세션 제목</label>
         <input
           type="text"
           name="title"
@@ -204,7 +204,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       </div>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>강의 이미지</label>
+        <label className={styles.label}>세션 이미지</label>
         {previewUrl ? (
           <div className={styles.previewWrapper}>
             <img src={previewUrl} alt="미리보기" className={styles.previewImage} />
@@ -248,13 +248,13 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       <div className={styles.formGroup}>
         <div className={styles.labelRow}>
-          <label className={styles.label}>강의 정보</label>
+          <label className={styles.label}>세션 정보</label>
           <span className={styles.charCount}>{formData.description.length}/300</span>
         </div>
         <textarea
           name="description"
           className={styles.textarea}
-          placeholder="강의 정보를 입력하세요."
+          placeholder="세션 정보를 입력하세요."
           maxLength={300}
           value={formData.description}
           onChange={handleChange}
@@ -308,7 +308,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           type="text"
           name="location"
           className={styles.standardInput}
-          placeholder="오프라인 강의일 경우 주소를 입력해주세요."
+          placeholder="오프라인 세션일 경우 주소를 입력해주세요."
           value={formData.location}
           onChange={handleChange}
           disabled={formData.isOnlineStr === 'true'}
@@ -363,7 +363,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           setIsExitModalOpen(false);
           router.back();
         }}
-        title="강의 작성을 중단하시겠습니까?"
+        title="세션 작성을 중단하시겠습니까?"
         subtitle="지금 나가면 입력한 정보가 저장되지 않고 모두 삭제됩니다. 작성을 취소하시겠습니까?"
         status="danger"
         cancelText="계속 작성하기"

--- a/frontend/src/app/events/page.tsx
+++ b/frontend/src/app/events/page.tsx
@@ -98,7 +98,7 @@ export default function EventsPage() {
           </div>
         </section>
 
-        {/* 이벤트 카드 리스트 */}
+        {/* 세션 카드 리스트 */}
         <section className={styles.content}>
           {loading ? (
             <div>Loading...</div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,9 +5,9 @@ import Footer from "@/components/layout/Footer";
 import Toast from "@/components/ui/Toast";
 
 export const metadata: Metadata = {
-  title: "VenueOn — 이벤트 중계 플랫폼",
+  title: "VenueOn — 세션 중계 플랫폼",
   description:
-    "유료·무료 이벤트를 탐색하고, 티켓을 구매하고, 커뮤니티에 참여하세요.",
+    "유료·무료 세션를 탐색하고, 티켓을 구매하고, 커뮤니티에 참여하세요.",
 };
 
 export default function RootLayout({

--- a/frontend/src/app/mypage/community/page.module.css
+++ b/frontend/src/app/mypage/community/page.module.css
@@ -1,0 +1,26 @@
+/* src/app/mypage/community/page.module.css */
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-32);
+  width: 100%;
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+}
+
+.listSection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-24);
+  width: 100%;
+}
+
+.searchBar {
+  width: 410px;
+}

--- a/frontend/src/app/mypage/community/page.tsx
+++ b/frontend/src/app/mypage/community/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useState } from 'react';
+import Sidebar from '@/components/layout/Sidebar';
+import { CardGrid, Pagination, InputField, Tabs } from '@/components/ui';
+import CommunityCard from '@/app/community/components/CommunityCard';
+import styles from './page.module.css';
+
+const TAB_OPTIONS = [
+  { value: 'participating', label: '참여 중' },
+  { value: 'community_bookmark', label: '커뮤니티 북마크' },
+  { value: 'my_post', label: '내가 쓴 게시물' },
+  { value: 'post_bookmark', label: '게시물 북마크' },
+];
+
+const MOCK_COMMUNITIES = [
+  {
+    id: 1,
+    postType: "프로젝트 모집",
+    timeAgo: "방금 전",
+    title: "함께 사이드 프로젝트 완성할 프론트엔드 개발자 찾습니다 👀",
+    tagSectionTitle: "모집 파트",
+    categories: ['UI/UX 디자이너', 'PM (기획)', '프론트엔드', '백엔드']
+  },
+  {
+    id: 2,
+    postType: "스터디 모집",
+    timeAgo: "2시간 전",
+    title: "Next.js 14 앱 라우터 뽀개기 스터디 모집",
+    tagSectionTitle: "관심 분야",
+    categories: ['프론트엔드', 'Next.js', 'React']
+  },
+  {
+    id: 3,
+    postType: "네트워킹",
+    timeAgo: "1일 전",
+    title: "판교 직장인 IT 네트워킹 및 정보 공유 모임",
+    tagSectionTitle: "모임 특징",
+    categories: ['오프라인', '친목', '정보공유']
+  },
+  {
+    id: 4,
+    postType: "코드 리뷰",
+    timeAgo: "2일 전",
+    title: "서로 코드리뷰 해주면서 상부상조할 백엔드 개발자 분 모셔요",
+    tagSectionTitle: "사용 기술",
+    categories: ['Java', 'Spring Boot', 'MySQL']
+  }
+];
+
+export default function MyCommunityPage() {
+  const [activeTab, setActiveTab] = useState('participating');
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = 1; // 목업용
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="container-sidebar">
+      <Sidebar role="user" />
+      <div className="sidebar-content">
+        <div className={styles.content}>
+          {/* 페이지 타이틀 */}
+          <h1 className={styles.pageTitle}>내 커뮤니티</h1>
+
+          <div className={styles.listSection}>
+            <Tabs
+              variant="line"
+              options={TAB_OPTIONS}
+              activeValue={activeTab}
+              onChange={handleTabChange}
+            />
+
+            <InputField
+              variant="search"
+              className={styles.searchBar}
+            />
+
+            <CardGrid layout="2-cols">
+              {MOCK_COMMUNITIES.map((community) => (
+                <CommunityCard
+                  key={community.id}
+                  postType={community.postType}
+                  timeAgo={community.timeAgo}
+                  title={community.title}
+                  tagSectionTitle={community.tagSectionTitle}
+                  categories={community.categories}
+                />
+              ))}
+            </CardGrid>
+
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -20,9 +20,9 @@ interface LectureItem {
 const ITEMS_PER_PAGE = 8; // 2열 × 4줄
 
 const TAB_OPTIONS = [
-  { value: 'upcoming', label: '수강 예정' },
-  { value: 'enrolled', label: '수강 중' },
-  { value: 'completed', label: '수강 완료' },
+  { value: 'upcoming', label: '진행 전' },
+  { value: 'enrolled', label: '진행 중' },
+  { value: 'completed', label: '종료' },
 ];
 
 export default function MyPage() {
@@ -31,6 +31,7 @@ export default function MyPage() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const [lectures, setLectures] = useState<LectureItem[]>([]);
+  const [wishlistSet, setWishlistSet] = useState<Set<number>>(new Set());
   const [totalPages, setTotalPages] = useState(1);
   const [loading, setLoading] = useState(false);
 
@@ -39,8 +40,7 @@ export default function MyPage() {
     setLoading(true);
     try {
       const res = await fetch(
-        `/api/orders/me?page=${page - 1}&size=${ITEMS_PER_PAGE}`
-        // 백엔드 tab 필터링 미구현으로 우선 모두 가져옴
+        `/api/orders/me?tab=${tab}&page=${page - 1}&size=${ITEMS_PER_PAGE}`
       );
       if (res.ok) {
         const json = await res.json();
@@ -52,7 +52,7 @@ export default function MyPage() {
             orderId: item.orderId,
             eventId: item.eventId,
             title: item.eventTitle,
-            status: item.eventStatus || item.status, // 주문 상태 대신 이벤트(강의) 상태를 카드에 매핑
+            status: item.eventStatus || item.status, // 주문 상태 대신 세션(세션) 상태를 카드에 매핑
             organizer: item.organizer || "알 수 없는 호스트",
           dateTime: item.eventStartDate ? new Date(item.eventStartDate).toLocaleString('ko-KR', {
             year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'
@@ -62,6 +62,20 @@ export default function MyPage() {
         }));
         setLectures(mappedLectures);
         setTotalPages(data.totalPages || 1);
+
+        // Fetch wishlist IDs
+        try {
+          const wlRes = await fetch('/api/wishlists/me?size=100');
+          if (wlRes.ok) {
+            const wlData = await wlRes.json();
+            if (wlData.data && wlData.data.content) {
+              const ids = new Set<number>(wlData.data.content.map((item: any) => item.id));
+              setWishlistSet(ids);
+            }
+          }
+        } catch (e) {
+          // ignore
+        }
       } else {
         setLectures([]);
         setTotalPages(1);
@@ -96,7 +110,7 @@ export default function MyPage() {
       <div className="sidebar-content">
         <div className={styles.content}>
           {/* 페이지 타이틀 */}
-          <h1 className={styles.pageTitle}>내 강의 목록</h1>
+          <h1 className={styles.pageTitle}>내 세션 목록</h1>
 
           {/* 탭 + 카드 + 페이지네이션 */}
           <div className={styles.listSection}>
@@ -118,19 +132,32 @@ export default function MyPage() {
                   key={lecture.orderId}
                   status={lecture.status}
                   title={lecture.title}
+                  eventId={lecture.eventId}
+                  isWishlistedProp={wishlistSet.has(lecture.eventId)}
                   organizer={lecture.organizer}
                   dateTime={lecture.dateTime}
                   location={lecture.location}
                   price={lecture.price}
-                  actionButtonText="스터디룸 입장"
-                  onActionClick={() => router.push(`/events/${lecture.eventId}`)}
+                  actionButtonText={
+                    activeTab === 'completed' ? '리뷰 작성하기' :
+                    activeTab === 'enrolled' ? '입장하기' :
+                    '상세 보기'
+                  }
+                  onActionClick={() => {
+                    if (activeTab === 'completed') {
+                      // 리뷰 쓰기 모달 혹은 페이지 라우팅 코드로 수정 필요 (임시 라우팅)
+                      router.push(`/community`); 
+                    } else {
+                      router.push(`/events/${lecture.eventId}`);
+                    }
+                  }}
                 />
               ))}
             </CardGrid>
 
             {!loading && lectures.length === 0 && (
               <p style={{ color: 'var(--color-text-gray-500)', textAlign: 'center', width: '100%', padding: 'var(--space-48) 0' }}>
-                해당 탭에 강의가 없습니다.
+                해당 탭에 세션이 없습니다.
               </p>
             )}
 

--- a/frontend/src/app/mypage/orders/components/RefundModal.tsx
+++ b/frontend/src/app/mypage/orders/components/RefundModal.tsx
@@ -84,7 +84,7 @@ export default function RefundModal({
         {/* 유의사항 동의 체크박스 (표준 Styling) */}
         <div className={styles.checkboxContainer}>
           <Checkbox 
-            label="[필수] 환불 시 이벤트 참여가 취소되며, 처리 후에는 복구할 수 없습니다."
+            label="[필수] 환불 시 세션 참여가 취소되며, 처리 후에는 복구할 수 없습니다."
             checked={isConfirmed}
             onChange={(e) => setIsConfirmed(e.target.checked)}
           />

--- a/frontend/src/app/mypage/orders/page.tsx
+++ b/frontend/src/app/mypage/orders/page.tsx
@@ -95,7 +95,7 @@ export default function OrdersPage() {
             ) : (
               <Table columns="1fr 100px 140px 100px 100px">
                 <TableHeader>
-                  <TableCell header>강의명</TableCell>
+                  <TableCell header>세션명</TableCell>
                   <TableCell header>결제 일시</TableCell>
                   <TableCell header>결제 금액</TableCell>
                   <TableCell header>상태</TableCell>

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -52,11 +52,11 @@ export default function MyPageDashboard() {
           {/* 요약 박스 (3개 가로 배치) */}
           <div className={styles.summaryContainer}>
             <div className={styles.summaryBox}>
-              <span className={styles.summaryTitle}>참여 중인 이벤트</span>
+              <span className={styles.summaryTitle}>참여 중인 세션</span>
               <span className={styles.summaryContent}>{summaryData.ongoingCourseCount}개</span>
             </div>
             <div className={styles.summaryBox}>
-              <span className={styles.summaryTitle}>리뷰를 기다리는 이벤트</span>
+              <span className={styles.summaryTitle}>리뷰를 기다리는 세션</span>
               <span className={styles.summaryContent}>{summaryData.pendingReviewCount}개</span>
             </div>
             <div className={styles.summaryBox}>

--- a/frontend/src/app/mypage/wishlist/page.tsx
+++ b/frontend/src/app/mypage/wishlist/page.tsx
@@ -6,26 +6,34 @@ import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Pagination, InputField } from '@/components/ui';
 import styles from '../events/page.module.css';
 
-// 관심 목록용 임시 데이터
-const mockWishlistLectures = Array.from({ length: 12 }, (_, i) => ({
-  id: i + 1,
-  status: i % 2 === 0 ? '모집 중' : '진행 중',
-  title: `찜한 강의 ${i + 1} — 정말 듣고 싶은 클래스`,
-  organizer: '최고의 강사진',
-  dateTime: '2026.05.01 ~ 2026.06.30',
-  location: '온라인',
-  price: 45000,
-}));
-
-const ITEMS_PER_PAGE = 8;
-
 export default function WishlistPage() {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
+  const [lectures, setLectures] = useState<any[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const ITEMS_PER_PAGE = 8;
+  const [loading, setLoading] = useState(false);
 
-  const totalPages = Math.ceil(mockWishlistLectures.length / ITEMS_PER_PAGE) || 1;
-  const startIdx = (currentPage - 1) * ITEMS_PER_PAGE;
-  const currentLectures = mockWishlistLectures.slice(startIdx, startIdx + ITEMS_PER_PAGE);
+  React.useEffect(() => {
+    async function fetchWishlist() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/wishlists/me?page=${currentPage - 1}&size=${ITEMS_PER_PAGE}`);
+        if (res.ok) {
+          const json = await res.json();
+          setLectures(json.data.content || []);
+          setTotalPages(json.data.totalPages || 1);
+        } else {
+          setLectures([]);
+        }
+      } catch (err) {
+        console.error('Failed to fetch wishlist', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchWishlist();
+  }, [currentPage]);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -47,22 +55,30 @@ export default function WishlistPage() {
             />
 
             <CardGrid layout="2-cols">
-              {currentLectures.map((lecture) => (
+              {lectures.map((lecture) => (
                 <Card
-                  key={lecture.id}
+                  key={lecture.wishlistId}
+                  eventId={lecture.id}
+                  isWishlistedProp={true}
                   status={lecture.status}
                   title={lecture.title}
                   organizer={lecture.organizer}
                   dateTime={lecture.dateTime}
                   location={lecture.location}
                   price={lecture.price}
-                  actionButtonText="자세히 보기"
-                  onActionClick={() => router.push(`/events`)}
+                  actionButtonText="장바구니 담기"
+                  onActionClick={() => router.push(`/events/${lecture.id}`)}
                 />
               ))}
             </CardGrid>
 
-            {mockWishlistLectures.length > 0 && (
+            {!loading && lectures.length === 0 && (
+              <p style={{ color: 'var(--color-text-gray-500)', textAlign: 'center', width: '100%', padding: 'var(--space-48) 0' }}>
+                아직 찜한 세션이 없습니다.
+              </p>
+            )}
+
+            {lectures.length > 0 && (
               <Pagination
                 currentPage={currentPage}
                 totalPages={totalPages}

--- a/frontend/src/app/orders/checkout/success/page.tsx
+++ b/frontend/src/app/orders/checkout/success/page.tsx
@@ -98,7 +98,7 @@ function CheckoutSuccessContent() {
           <h1 className={successStyles.title}>수강 신청 완료!</h1>
           <p className={successStyles.subtitle}>
             교육 프로그램 등록이 완료되었습니다.<br />
-            상세 내역은 내 강의 목록에서 확인하실 수 있습니다.
+            상세 내역은 내 세션 목록에서 확인하실 수 있습니다.
           </p>
         </div>
 
@@ -109,8 +109,8 @@ function CheckoutSuccessContent() {
               <p className={successStyles.cardValue}>#{paymentInfo.orderId}</p>
             </div>
             <div className={successStyles.cardRow}>
-              <p className={successStyles.cardLabel}>강의명</p>
-              <p className={successStyles.cardValue}>{paymentInfo.orderName || 'VenueOn 강의'}</p>
+              <p className={successStyles.cardLabel}>세션명</p>
+              <p className={successStyles.cardValue}>{paymentInfo.orderName || 'VenueOn 세션'}</p>
             </div>
             <div className={successStyles.cardRow}>
               <p className={successStyles.cardLabel}>결제 금액</p>
@@ -126,7 +126,7 @@ function CheckoutSuccessContent() {
             style={{ flex: 1, backgroundColor: '#FFFFFF', borderColor: 'var(--color-gray-200, #E5E7EB)' }}
             onClick={() => window.location.href = '/mypage/orders'}
           >
-            내 강의 목록
+            내 세션 목록
           </Button>
           <Button
             variant="primary"

--- a/frontend/src/app/orders/refund/page.tsx
+++ b/frontend/src/app/orders/refund/page.tsx
@@ -6,9 +6,9 @@ import styles from './refund.module.css';
 // 취소 사유 선택지
 const CANCEL_REASONS = [
   '일정이 변경되어 참석이 어렵습니다.',
-  '다른 강의를 수강하고 싶습니다.',
+  '다른 세션를 수강하고 싶습니다.',
   '단순 변심입니다.',
-  '강의 내용이 기대와 달랐습니다.',
+  '세션 내용이 기대와 달랐습니다.',
   '직접 입력',
 ];
 
@@ -130,7 +130,7 @@ export default function RefundPage() {
       <div className={styles.headerSection}>
         <h1 className={styles.title}>내 수강 내역</h1>
         <p className={styles.subtitle}>
-          수강 신청한 강의 목록입니다. 결제 완료 상태의 강의만 취소가 가능합니다.
+          수강 신청한 세션 목록입니다. 결제 완료 상태의 세션만 취소가 가능합니다.
         </p>
       </div>
 
@@ -138,7 +138,7 @@ export default function RefundPage() {
       {orders.length === 0 ? (
         <div className={styles.emptyState}>
           <div className={styles.emptyIcon}>📋</div>
-          <p>아직 수강 신청한 강의가 없습니다.</p>
+          <p>아직 수강 신청한 세션가 없습니다.</p>
         </div>
       ) : (
         <div className={styles.orderList}>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
 import { Card, CardGrid, InputField, Tabs, Pagination } from '@/components/ui';
 import { format } from 'date-fns';
@@ -25,7 +25,9 @@ interface EventData {
 }
 
 export default function Home() {
+  const router = useRouter();
   const [events, setEvents] = useState<EventData[]>([]);
+  const [wishlistSet, setWishlistSet] = useState<Set<number>>(new Set());
   const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -54,6 +56,20 @@ export default function Home() {
       if (resData.success) {
         setEvents(resData.data.content);
         setTotalPages(resData.data.totalPages);
+        
+        // Wishlist도 동시에 조회 (비로그인이거나 에러시 조용히 넘어감)
+        try {
+          const wlRes = await fetch('/api/wishlists/me?size=100');
+          if (wlRes.ok) {
+            const wlData = await wlRes.json();
+            if (wlData.data && wlData.data.content) {
+              const ids = new Set<number>(wlData.data.content.map((item: any) => item.id));
+              setWishlistSet(ids);
+            }
+          }
+        } catch (e) {
+          // ignore error (e.g. not logged in)
+        }
       } else {
         console.error('Failed to fetch events:', resData.message);
       }
@@ -117,18 +133,24 @@ export default function Home() {
           </div>
         </section>
 
-        {/* 이벤트 카드 리스트 */}
+        {/* 세션 카드 리스트 */}
         <section className={styles.content}>
           {loading ? (
             <div>Loading...</div>
           ) : events.length === 0 ? (
-            <div style={{ textAlign: 'center', padding: '100px 0' }}>등록된 강의가 없습니다.</div>
+            <div style={{ textAlign: 'center', padding: '100px 0' }}>등록된 세션가 없습니다.</div>
           ) : (
             <CardGrid layout="3-cols">
               {events.map((event) => (
-                <Link href={`/events/${event.id}`} key={event.id} style={{ textDecoration: 'none', color: 'inherit' }}>
+                <div 
+                  key={event.id} 
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => router.push(`/events/${event.id}`)}
+                >
                   <Card
                     title={event.title}
+                    eventId={event.id}
+                    isWishlistedProp={wishlistSet.has(event.id)}
                     imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
                     organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 시 실제 이름으로 변경
                     dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
@@ -136,7 +158,7 @@ export default function Home() {
                     price={event.price}
                     status={event.status}
                   />
-                </Link>
+                </div>
               ))}
             </CardGrid>
           )}

--- a/frontend/src/app/sidebar-test/page.tsx
+++ b/frontend/src/app/sidebar-test/page.tsx
@@ -40,14 +40,14 @@ export default function SidebarTestPage() {
       {/* Role: User */}
       <div>
         <h2 style={{ fontSize: 'var(--font-size-h2---bold)', fontWeight: 700, marginBottom: '20px' }}>
-          단일 유저 (Role = 'user') - '내 강의 목록' 선택 상태
+          단일 유저 (Role = 'user') - '내 세션 목록' 선택 상태
         </h2>
         <div style={wrapperStyle}>
           {/* 테스트 환경에서는 주소가 없으므로, fakePathname으로 임의의 활성 탭을 강제 지정합니다 */}
           <Sidebar role="user" fakePathname="/events" />
           <div style={{ flex: 1, padding: '40px', background: '#fff', borderRadius: '12px', minHeight: '400px' }}>
             <h3 style={{ fontSize: '20px', fontWeight: 'bold' }}>우측 메인 컨텐츠 영역</h3>
-            <p style={{ marginTop: '10px', color: '#666' }}>내 강의 목록 상세 테이블이 렌더링되는 공간입니다.</p>
+            <p style={{ marginTop: '10px', color: '#666' }}>내 세션 목록 상세 테이블이 렌더링되는 공간입니다.</p>
           </div>
         </div>
       </div>

--- a/frontend/src/app/ui-test/page.tsx
+++ b/frontend/src/app/ui-test/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Button, Checkbox, Toggle, Radio, SelectBox, Pagination, UserProfile, Logo, Tag, Card, CardGrid, Tabs, InputField, TextareaField, Dropdown, UploadField, CommentInput } from '@/components/ui';
 import CommunityPostItem from '@/app/community/components/CommunityPostItem';
 import CommunityCommentItem from '@/app/community/components/CommunityCommentItem';
+import CommunityCard from '@/app/community/components/CommunityCard';
 import { ConfirmModal, InputModal, UploadModal, PaymentModal } from '@/components/modal';
 import { useUIStore } from '@/store/useUIStore';
 
@@ -377,8 +378,8 @@ export default function UITestPage() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '410px' }}>
 
           <TextareaField
-            label="강의 소개"
-            placeholder="강의에 대한 상세한 소개를 입력해주세요."
+            label="세션 소개"
+            placeholder="세션에 대한 상세한 소개를 입력해주세요."
             showCount={true}
           />
 
@@ -446,6 +447,20 @@ export default function UITestPage() {
       <div style={sectionStyle}>
         <h2 style={titleStyle}>17. Community Components</h2>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+
+          {/* CommunityCard */}
+          <div>
+            <p style={{ marginBottom: '12px', color: '#6B7280' }}>CommunityCard (커뮤니티 리스트 카드)</p>
+            <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
+              <CommunityCard
+                postType="프로젝트 모집"
+                timeAgo="방금 전"
+                title="함께 사이드 프로젝트 완성할 프론트엔드 개발자 찾습니다 👀"
+                tagSectionTitle="모집 파트"
+                categories={['UI/UX 디자이너', 'PM (기획)', '프론트엔드', '백엔드']}
+              />
+            </div>
+          </div>
 
           {/* CommunityPostItem */}
           <div>
@@ -576,7 +591,7 @@ export default function UITestPage() {
           userName: '홍길동',
           statusText: '대기 중',
           date2: '2026-04-16',
-          reasonDetail: '해당 강의의 사업자 번호가 존재하지 않는 번호입니다. 확인 부탁드립니다.'
+          reasonDetail: '해당 세션의 사업자 번호가 존재하지 않는 번호입니다. 확인 부탁드립니다.'
         }}
         onConfirm={() => setIsInputAdminOpen(false)}
       />

--- a/frontend/src/components/icons/WishlistIcon.tsx
+++ b/frontend/src/components/icons/WishlistIcon.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-export default function WishlistIcon(props: React.SVGProps<SVGSVGElement>) {
+export default function WishlistIcon({ fill = "none", stroke = "currentColor", ...props }: React.SVGProps<SVGSVGElement>) {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <path d="M7.5 4C4.46244 4 2 6.46245 2 9.5C2 15 8.5 20 12 21.1631C15.5 20 22 15 22 9.5C22 6.46245 19.5375 4 16.5 4C14.6399 4 12.9954 4.92345 12 6.3369C11.0046 4.92345 9.36015 4 7.5 4Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill={fill} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M7.5 4C4.46244 4 2 6.46245 2 9.5C2 15 8.5 20 12 21.1631C15.5 20 22 15 22 9.5C22 6.46245 19.5375 4 16.5 4C14.6399 4 12.9954 4.92345 12 6.3369C11.0046 4.92345 9.36015 4 7.5 4Z" stroke={stroke} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   );
 }

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
         <div className={styles.colLinks}>
           <h4 className={styles.colTitle}>서비스</h4>
           <ul className={styles.linkList}>
-            <li><Link href="/events" className={styles.linkItem}>이벤트 탐색</Link></li>
+            <li><Link href="/events" className={styles.linkItem}>세션 탐색</Link></li>
             <li><Link href="/host/dashboard" className={styles.linkItem}>주최자 센터</Link></li>
           </ul>
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -33,7 +33,7 @@ export default function Header({
   const displayUserName = user?.nickname || userName;
   const displayUserImage = user?.profileImg || userImageUrl;
 
-  // /mypage 경로일 때는 항상 'myPage' 해더(강의 목록 + 프로필)를 보여주도록 강제
+  // /mypage 경로일 때는 항상 'myPage' 해더(세션 목록 + 프로필)를 보여주도록 강제
   const isMyPage = pathname?.startsWith('/mypage');
   const status = propStatus || (isMyPage ? 'myPage' : (user ? 'signedIn' : 'public'));
 
@@ -69,7 +69,7 @@ export default function Header({
       if (status === 'signedIn') {
         return (
           <div className={styles.actionGroup}>
-            <Link href="/mypage"><Button variant="outlined" size="medium">내 강의실</Button></Link>
+            <Link href="/mypage"><Button variant="outlined" size="medium">마이페이지</Button></Link>
             <Link href="/mypage/profile">
               <UserProfile name={displayUserName} imageUrl={displayUserImage} size="large" />
             </Link>
@@ -80,7 +80,7 @@ export default function Header({
       if (status === 'myPage') {
         return (
           <div className={styles.actionGroup}>
-            <Link href="/"><Button variant="outlined" size="medium">강의 목록</Button></Link>
+            <Link href="/"><Button variant="outlined" size="medium">세션 목록</Button></Link>
             <Link href="/mypage/profile">
               <UserProfile name={displayUserName} imageUrl={displayUserImage} size="large" />
             </Link>
@@ -103,7 +103,7 @@ export default function Header({
         return (
           <div className={styles.actionGroup}>
             <Link href="/host/dashboard">
-              <Button variant="outlined" size="medium">내 강의실</Button>
+              <Button variant="outlined" size="medium">마이페이지</Button>
             </Link>
             <Link href="/mypage/profile">
               <UserProfile name={displayUserName} imageUrl={displayUserImage} size="large" />
@@ -128,7 +128,7 @@ export default function Header({
       return (
         <div className={styles.actionGroup}>
           <Link href="/host/dashboard">
-            <Button variant="outlined" size="medium">내 강의실</Button>
+            <Button variant="outlined" size="medium">마이페이지</Button>
           </Link>
           <Link href="/mypage/profile">
             <UserProfile name={user?.nickname || '호스트'} size="large" />
@@ -141,7 +141,7 @@ export default function Header({
     // 기본: USER
     return (
       <div className={styles.actionGroup}>
-        <Link href="/mypage"><Button variant="outlined" size="medium">내 강의실</Button></Link>
+        <Link href="/mypage"><Button variant="outlined" size="medium">마이페이지</Button></Link>
         <Link href="/mypage/profile">
           <UserProfile name={user?.nickname || '사용자'} size="large" />
         </Link>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -95,7 +95,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
           { label: '대시보드', href: '/admin/dashboard', icon: DashboardIcon },
           { label: '사용자 관리', href: '/admin/users', icon: ProfileIcon },
           { label: '시스템 설정', href: '/admin/settings', icon: SettingIcon },
-          { label: '세션 관리', href: '/admin/seminars', icon: SeminarSettingIcon },
+          { label: '세션 관리', href: '/admin/events', icon: SeminarSettingIcon },
           { label: '커뮤니티 관리', href: '/admin/community', icon: CommunityIcon },
           { label: '신고 관리', href: '/admin/reports', icon: ReportIcon },
           { label: '환불 모니터링', href: '/admin/refunds', icon: DelayedRefundIcon },
@@ -104,7 +104,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
       case 'host':
         return [
           { label: '대시보드', href: '/host/dashboard', icon: DashboardIcon },
-          { label: '내 이벤트 목록', href: '/host/events', icon: SeminarIcon },
+          { label: '내 세션 목록', href: '/host/events', icon: SeminarIcon },
           { label: '프로필 설정', href: '/host/profile', icon: ProfileIcon },
           { label: '로그아웃', href: '/logout', icon: LogoutIcon },
         ];
@@ -112,9 +112,10 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
       default:
         return [
           { label: '대시보드', href: '/mypage', icon: DashboardIcon },
-          { label: '내 이벤트 목록', href: '/mypage/events', icon: SeminarIcon },
+          { label: '내 세션 목록', href: '/mypage/events', icon: SeminarIcon },
           { label: '결제 내역', href: '/mypage/orders', icon: OrderIcon },
           { label: '찜 목록', href: '/mypage/wishlist', icon: WishlistIcon },
+          { label: '내 커뮤니티', href: '/mypage/community', icon: CommunityIcon },
           { label: '프로필 설정', href: '/mypage/profile', icon: ProfileIcon },
           { label: '계정 보안', href: '/mypage/security', icon: SecurityIcon },
           { label: '로그아웃', href: '/logout', icon: LogoutIcon },

--- a/frontend/src/components/ui/Card.module.css
+++ b/frontend/src/components/ui/Card.module.css
@@ -30,6 +30,39 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-8);
+  width: 100%;
+}
+
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.wishlistButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-gray-300); /* 비활성: 기본 회색(단색) */
+  transition: color 0.2s ease;
+}
+
+.wishlistButton:hover {
+  color: #F9A8D4; /* hover: 가장 옅은 핑크 */
+}
+
+.wishlistButton.active {
+  color: #F472B6; /* active: 찐한 연분홍색 */
+}
+
+.wishlistIcon {
+  width: 24px;
+  height: 24px;
 }
 
 .title {

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import styles from './Card.module.css';
 import { Tag, Button, StatusTag } from '@/components/ui';
-import { CompanyIcon, CalendarIcon, LocationIcon } from '@/components/icons';
+import { CompanyIcon, CalendarIcon, LocationIcon, WishlistIcon } from '@/components/icons';
 
 export interface CardProps {
   status?: '게시 전' | '모집 중' | '준비 중' | '진행 중' | '종료' | string;
@@ -17,6 +17,8 @@ export interface CardProps {
   price: string | number;
   actionButtonText?: string;
   onActionClick?: () => void;
+  eventId?: number;
+  isWishlistedProp?: boolean;
 }
 
 export default function Card({
@@ -29,9 +31,18 @@ export default function Card({
   location,
   price,
   actionButtonText,
-  onActionClick
+  onActionClick,
+  eventId,
+  isWishlistedProp = false
 }: CardProps) {
 
+
+  const [isWishlisted, setIsWishlisted] = React.useState(isWishlistedProp);
+
+  // 초기에 전달된 관심 여부가 있으면 바로 반영되도록 효과 추가
+  React.useEffect(() => {
+    setIsWishlisted(isWishlistedProp);
+  }, [isWishlistedProp]);
 
   // 숫자일 경우 ₩ 포맷 변환, 문자열일 경우 그대로 렌더링 (단, 0일 경우 '무료'로 표시)
   const formattedPrice = price === 0 
@@ -43,11 +54,37 @@ export default function Card({
   return (
     <div className={styles.card}>
       <div className={styles.header}>
-        {tagText ? (
-          <Tag variant="gray">{tagText}</Tag>
-        ) : status ? (
-          <StatusTag domain="course" status={status} />
-        ) : null}
+        <div className={styles.topRow}>
+          {tagText ? (
+            <Tag variant="gray">{tagText}</Tag>
+          ) : status ? (
+            <StatusTag domain="course" status={status} />
+          ) : <div />}
+          <button type="button" 
+                  className={`${styles.wishlistButton} ${isWishlisted ? styles.active : ''}`} 
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    
+                    // Optimistic update
+                    const nextState = !isWishlisted;
+                    setIsWishlisted(nextState);
+                    
+                    if (eventId) {
+                      try {
+                        const res = await fetch(`/api/wishlists/events/${eventId}`, { method: 'POST' });
+                        if (!res.ok) {
+                          // Revert on error
+                          setIsWishlisted(!nextState);
+                        }
+                      } catch (err) {
+                        setIsWishlisted(!nextState);
+                      }
+                    }
+                  }}>
+            <WishlistIcon className={styles.wishlistIcon} fill="currentColor" stroke="transparent" />
+          </button>
+        </div>
         <h3 className={styles.title} title={title}>{title}</h3>
       </div>
 

--- a/frontend/src/components/ui/CardGrid.module.css
+++ b/frontend/src/components/ui/CardGrid.module.css
@@ -14,7 +14,7 @@
   max-width: 100%;
 }
 
-/* 3열 레이아웃 (ex: 메인 강의 목록 페이지) */
+/* 3열 레이아웃 (ex: 메인 세션 목록 페이지) */
 .threeCols {
   grid-template-columns: repeat(3, 1fr);
   max-width: 100%;

--- a/frontend/src/components/ui/StatusTag.tsx
+++ b/frontend/src/components/ui/StatusTag.tsx
@@ -25,7 +25,7 @@ const REPORT_MAP: Record<string, { variant: 'red' | 'purple' | 'green' | 'gray',
   '숨김 처리됨': { variant: 'purple', label: '숨김 처리됨' },
 };
 
-// 2. 강의 상태 뱃지 (강의 카드 사용)
+// 2. 세션 상태 뱃지 (세션 카드 사용)
 const COURSE_MAP: Record<string, { variant: 'red' | 'purple' | 'green' | 'gray', label: string }> = {
   'DRAFT': { variant: 'gray', label: '게시 전' },
   '게시 전': { variant: 'gray', label: '게시 전' },

--- a/frontend/src/components/ui/UploadField.tsx
+++ b/frontend/src/components/ui/UploadField.tsx
@@ -16,7 +16,7 @@ export default function UploadField({ label, onFileSelect, className = '', ...pr
   const [fileName, setFileName] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // 드래그 앤 드롭 이벤트 핸들러
+  // 드래그 앤 드롭 세션 핸들러
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(true);
@@ -36,7 +36,7 @@ export default function UploadField({ label, onFileSelect, className = '', ...pr
     }
   };
 
-  // 탐색기 창 선택 이벤트 핸들러
+  // 탐색기 창 선택 세션 핸들러
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];


### PR DESCRIPTION
## 💬 작업 내용
해당 PR은 티켓 번호 **VO-689, VO-690, VO-691, VO-692**의 작업 내역을 포함합니다.
마이페이지 상의 위시리스트(찜 목록), 수강 탭 필터링 고도화, 그리고 커뮤니티 관련 컴포넌트 추가 작업을 진행했습니다.
1. **커뮤니티 UI 컴포넌트 구현**
   - 커뮤니티 전용 리스트 아이템 UI인 `CommunityCard` 컴포넌트 신규 작성 (`CommunityCard.tsx`, `CommunityCard.module.css`)
   - 마이페이지 내 커뮤니티 탭 레이아웃 및 렌더링 파일에 연동 (`mypage/community`)
2. **찜하기(Wishlist) 기능 E2E 구현**
   - 백엔드 헥사고날 아키텍처 기반 `Wishlist` 도메인 / 어댑터 / API 통합 구축
   - 카드 컴포넌트 하트(찜) 클릭 시 DB 연동 로직 추가 및 낙관적 업데이트(Optimistic UI) 렌더링 반영
   - 랜딩 페이지 및 내 수강 목록 페이지에서 새로고침 시에도 찜 상태(`isWishlisted`) 유지되도록 API 병렬 조회(`GET /wishlists/me`) 동기화 추가
3. **수강 목록(내 세션) 탭 필터링 및 DB 쿼리 연동 적용**
   - 프론트엔드의 화면 탭핑에 맞춰 몽땅 불러오던 방식에서 실제 백엔드 결제/주문 DB 데이터 필터링으로 최적화 연동
   - 백엔드 `OrderJpaRepository` 내에 `eventStatus`(게시 전, 모집 중, 진행 중, 종료 등) 다중 조건 리스트(`IN (...)`)를 받아 필터링하는 쿼리(`.findValidOrdersByUserIdAndEventStatuses()`) 신규 추가
   - 프론트엔드 탭 변경 파라미터(`?tab=upcoming` 등) 매핑으로 페이지네이션 버그 원천 해결
4. **UX 개선 및 디자인 카드 디테일 조정**
   - Hydration 에러 사전 차단 (Card 내 중첩된 a태그 래퍼 제거 및 `onClick` router 기반으로 교체)
   - 탭 종류에 따라 알맞은 액션 버튼의 텍스트가 노출되도록 분기 처리 로직 삽입 
     - 진행 전 ➔ `상세 보기`
     - 진행 중 ➔ `입장하기`
     - 종료 ➔ `리뷰 작성하기` (임시로 커뮤니티 페이지 라우팅)
   - 마이페이지/찜 목록 페이지의 기본 버튼을 `장바구니 담기`로 명칭 변경
## 🔗 연관된 이슈
- close #VO-689
- close #VO-690
- close #VO-691
- close #VO-692
## 🧪 테스트 방법
1. 찜하기 클릭 후 브라우저 새로고침을 해도 하트 아이콘 유지되는 지 동기화 확인
2. 내 수강 목록에서 진행 전/진행 중/종료 탭 이동 시 알맞은 세션만 페이지 단위로 필터링되어 나타나는 지 점검
3. 수강 목록에 뜬 카드 버튼 텍스트가 탭 성격에 맞춰(상세 보기 / 입장하기 / 리뷰 작성하기) 잘 바뀌었는지 점검
4. 추가된 커뮤니티 페이지 뷰에서 `CommunityCard` UI 정상 노출 및 레이아웃 깨짐 없는 점검