### PR TITLE
feat: 마이페이지 프로필 관심 카테고리 및 회원 탈퇴 기능 추가 close #VO-700

### DIFF
--- a/backend/src/main/java/com/venueon/category/adapter/in/web/CategoryController.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/CategoryController.java
@@ -1,0 +1,34 @@
+package com.venueon.category.adapter.in.web;
+
+import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
+import com.venueon.category.adapter.out.persistence.repository.CategoryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.HashMap;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryJpaRepository categoryJpaRepository;
+
+    @GetMapping
+    public ResponseEntity<?> getCategories() {
+        List<CategoryJpaEntity> entities = categoryJpaRepository.findAllByOrderBySortOrderAsc();
+        List<String> categoryNames = entities.stream()
+                .map(CategoryJpaEntity::getName)
+                .collect(Collectors.toList());
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("data", categoryNames);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 
                 // 인증 필요 경로
                 .requestMatchers("/auth/me").authenticated()
-                .requestMatchers("/v1/users", "/v1/users/**").authenticated()
+                .requestMatchers("/users", "/users/**").authenticated()
                 .requestMatchers("/orders", "/orders/**").authenticated()
                 
                 // /admin/** — ADMIN 권한 필요

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -47,7 +47,9 @@ public class AuthController {
                 user.getEmail(),
                 user.getNickname(),
                 user.getRole().name(),
-                user.getProfileImg()
+                user.getProfileImg(),
+                user.getCategories(),
+                user.isBadgeVisible()
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
@@ -74,7 +76,9 @@ public class AuthController {
                 user.getEmail(),
                 user.getNickname(),
                 user.getRole().name(),
-                user.getProfileImg()
+                user.getProfileImg(),
+                user.getCategories(),
+                user.isBadgeVisible()
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
@@ -142,7 +146,9 @@ public class AuthController {
                 user.getEmail(),
                 user.getNickname(),
                 user.getRole().name(),
-                user.getProfileImg()
+                user.getProfileImg(),
+                user.getCategories(),
+                user.isBadgeVisible()
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -163,7 +169,9 @@ public class AuthController {
                 user.getEmail(),
                 user.getNickname(),
                 user.getRole().name(),
-                user.getProfileImg()
+                user.getProfileImg(),
+                user.getCategories(),
+                user.isBadgeVisible()
         );
 
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/UserController.java
@@ -13,17 +13,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import com.venueon.user.application.port.in.DeactivateUserUseCase;
+
 @Slf4j
 @RestController
-@RequestMapping("/v1/users")
+@RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UpdateUserProfileUseCase updateUserProfileUseCase;
     private final UpdateUserPasswordUseCase updateUserPasswordUseCase;
+    private final DeactivateUserUseCase deactivateUserUseCase;
 
     /**
-     * PUT /api/v1/users/me/profile — 내 프로필(이름, 사진) 수정
+     * PUT /api/users/me/profile — 내 프로필(이름, 사진, 카테고리, 뱃지) 수정
      */
     @PutMapping("/me/profile")
     public ResponseEntity<ApiResponse<UserInfoResponse>> updateProfile(
@@ -36,7 +39,9 @@ public class UserController {
         User updatedUser = updateUserProfileUseCase.updateProfile(
                 email,
                 request.nickname(),
-                request.profileImg()
+                request.profileImg(),
+                request.categories(),
+                request.showBadge()
         );
 
         UserInfoResponse response = new UserInfoResponse(
@@ -44,14 +49,16 @@ public class UserController {
                 updatedUser.getEmail(),
                 updatedUser.getNickname(),
                 updatedUser.getRole().name(),
-                updatedUser.getProfileImg()
+                updatedUser.getProfileImg(),
+                updatedUser.getCategories(),
+                updatedUser.isBadgeVisible()
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
-     * PUT /api/v1/users/me/password — 내 계정 비밀번호 변경
+     * PUT /api/users/me/password — 내 계정 비밀번호 변경
      */
     @PutMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
@@ -66,6 +73,19 @@ public class UserController {
                 request.currentPassword(),
                 request.newPassword()
         );
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * DELETE /api/users/me — 내 계정 탈퇴
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deactivateAccount(Authentication authentication) {
+        String email = authentication.getName();
+        log.debug("계정 탈퇴 요청: email={}", email);
+
+        deactivateUserUseCase.deactivateUser(email);
 
         return ResponseEntity.ok(ApiResponse.success());
     }

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpdateUserProfileRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpdateUserProfileRequest.java
@@ -5,5 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 public record UpdateUserProfileRequest(
     @NotBlank(message = "이름(닉네임)은 필수입니다.")
     String nickname,
-    String profileImg
+    String profileImg,
+    java.util.List<String> categories,
+    Boolean showBadge
 ) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
@@ -8,5 +8,7 @@ public record UserInfoResponse(
         String email,
         String nickname,
         String role,
-        String profileImg
+        String profileImg,
+        java.util.List<String> categories,
+        Boolean showBadge
 ) {}

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserMapper.java
@@ -24,6 +24,7 @@ public class UserMapper {
                 .profileImg(user.getProfileImg())
                 .phone(user.getPhone())
                 .isActive(user.isActive())
+                .isBadgeVisible(user.isBadgeVisible())
                 .build();
     }
 
@@ -42,7 +43,9 @@ public class UserMapper {
                 entity.getPhone(),
                 entity.isActive(),
                 entity.getCreatedAt(),
-                entity.getUpdatedAt()
+                entity.getUpdatedAt(),
+                entity.getCategories() != null ? entity.getCategories().stream().map(c -> c.getName()).collect(java.util.stream.Collectors.toList()) : new java.util.ArrayList<>(),
+                entity.isBadgeVisible()
         );
     }
 }

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * UserRepositoryPort 구현체 — JPA 연동
@@ -17,11 +19,35 @@ import java.util.Optional;
 public class UserPersistenceAdapter implements UserRepositoryPort {
 
     private final UserJpaRepository userJpaRepository;
+    private final com.venueon.category.adapter.out.persistence.repository.CategoryJpaRepository categoryJpaRepository;
     private final UserMapper userMapper;
 
     @Override
     public User save(User user) {
-        UserJpaEntity entity = userMapper.toEntity(user);
+        UserJpaEntity entity;
+        if (user.getId() != null) {
+            entity = userJpaRepository.findById(user.getId()).orElse(userMapper.toEntity(user));
+            entity.updateProfile(user.getNickname(), user.getProfileImg());
+            entity.updateBadgeVisibility(user.isBadgeVisible());
+            if (!user.isActive()) {
+                entity.softDelete();
+            }
+        } else {
+            entity = userMapper.toEntity(user);
+        }
+
+        // 카테고리 업데이트
+        if (user.getCategories() != null) {
+            List<com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity> categoryEntities = 
+                user.getCategories().stream()
+                    .map(name -> categoryJpaRepository.findByName(name).orElse(null))
+                    .filter(c -> c != null)
+                    .collect(Collectors.toList());
+            entity.updateCategories(categoryEntities);
+        } else {
+            entity.updateCategories(new java.util.ArrayList<>());
+        }
+
         UserJpaEntity saved = userJpaRepository.save(entity);
         return userMapper.toDomain(saved);
     }

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
@@ -55,4 +55,39 @@ public class UserJpaEntity {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "is_badge_visible", nullable = false)
+    @Builder.Default
+    private boolean isBadgeVisible = true;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "user_categories",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    @Builder.Default
+    private java.util.List<com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity> categories = new java.util.ArrayList<>();
+    
+    public void updateProfile(String nickname, String profileImg) {
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+    }
+
+    public void updateBadgeVisibility(boolean isBadgeVisible) {
+        this.isBadgeVisible = isBadgeVisible;
+    }
+
+    public void updateCategories(java.util.List<com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity> newCategories) {
+        this.categories.clear();
+        if (newCategories != null) {
+            this.categories.addAll(newCategories);
+        }
+    }
+
+    public void softDelete() {
+        this.isActive = false;
+        // Optionally clear personal info or change email to prevent re-join blocks if required
+        // this.email = "deleted_" + this.id + "_" + this.email;
+    }
 }

--- a/backend/src/main/java/com/venueon/user/application/port/in/DeactivateUserUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/DeactivateUserUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.user.application.port.in;
+
+public interface DeactivateUserUseCase {
+    void deactivateUser(String email);
+}

--- a/backend/src/main/java/com/venueon/user/application/port/in/UpdateUserProfileUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/UpdateUserProfileUseCase.java
@@ -3,5 +3,5 @@ package com.venueon.user.application.port.in;
 import com.venueon.user.domain.model.User;
 
 public interface UpdateUserProfileUseCase {
-    User updateProfile(String email, String nickname, String profileImg);
+    User updateProfile(String email, String nickname, String profileImg, java.util.List<String> categories, Boolean showBadge);
 }

--- a/backend/src/main/java/com/venueon/user/application/service/UserService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/UserService.java
@@ -11,24 +11,26 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.venueon.user.application.port.in.DeactivateUserUseCase;
+
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
-public class UserService implements UpdateUserProfileUseCase, UpdateUserPasswordUseCase {
+public class UserService implements UpdateUserProfileUseCase, UpdateUserPasswordUseCase, DeactivateUserUseCase {
 
     private final UserRepositoryPort userRepositoryPort;
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public User updateProfile(String email, String nickname, String profileImg) {
+    public User updateProfile(String email, String nickname, String profileImg, java.util.List<String> categories, Boolean showBadge) {
         log.debug("프로필 수정 시작: email={}, nickname={}", email, nickname);
-        
+
         User user = userRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
 
         // User 도메인의 비즈니스 메서드 호출
-        user.updateProfile(nickname, profileImg);
-        
+        user.updateProfile(nickname, profileImg, categories, showBadge);
+
         // 포트를 통해 DB 갱신
         User savedUser = userRepositoryPort.save(user);
 
@@ -51,5 +53,18 @@ public class UserService implements UpdateUserProfileUseCase, UpdateUserPassword
         userRepositoryPort.save(user);
 
         log.info("비밀번호 수정 완료: email={}", email);
+    }
+
+    @Override
+    public void deactivateUser(String email) {
+        log.debug("계정 탈퇴 처리 시작: email={}", email);
+
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+
+        user.deactivate();
+        userRepositoryPort.save(user);
+
+        log.info("계정 탈퇴 완료: email={}", email);
     }
 }

--- a/backend/src/main/java/com/venueon/user/domain/model/User.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/User.java
@@ -20,6 +20,9 @@ public class User {
     private boolean active;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    
+    private java.util.List<String> categories = new java.util.ArrayList<>();
+    private boolean badgeVisible;
 
     // 기본 생성자
     protected User() {}
@@ -27,7 +30,8 @@ public class User {
     // 전체 필드 생성자
     public User(Long id, String email, String password, String nickname, UserRole role,
                 AuthProvider provider, String profileImg, String phone, boolean active,
-                LocalDateTime createdAt, LocalDateTime updatedAt) {
+                LocalDateTime createdAt, LocalDateTime updatedAt, 
+                java.util.List<String> categories, boolean badgeVisible) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -39,6 +43,15 @@ public class User {
         this.active = active;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.categories = categories != null ? categories : new java.util.ArrayList<>();
+        this.badgeVisible = badgeVisible;
+    }
+
+    // 구버전 호환용 생성자
+    public User(Long id, String email, String password, String nickname, UserRole role,
+                AuthProvider provider, String profileImg, String phone, boolean active,
+                LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this(id, email, password, nickname, role, provider, profileImg, phone, active, createdAt, updatedAt, new java.util.ArrayList<>(), true);
     }
 
     // --- 비즈니스 행위 메서드 ---
@@ -55,9 +68,15 @@ public class User {
         return this.provider == AuthProvider.GOOGLE;
     }
 
-    public void updateProfile(String nickname, String profileImg) {
+    public void updateProfile(String nickname, String profileImg, java.util.List<String> categories, Boolean showBadge) {
         this.nickname = nickname;
         this.profileImg = profileImg;
+        if (categories != null) {
+            this.categories = categories;
+        }
+        if (showBadge != null) {
+            this.badgeVisible = showBadge;
+        }
         this.updatedAt = LocalDateTime.now();
     }
 
@@ -119,4 +138,6 @@ public class User {
     public boolean isActive() { return active; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public java.util.List<String> getCategories() { return categories; }
+    public boolean isBadgeVisible() { return badgeVisible; }
 }

--- a/frontend/src/app/mypage/profile/page.module.css
+++ b/frontend/src/app/mypage/profile/page.module.css
@@ -89,3 +89,61 @@
   flex: 1;
   /* 너비를 똑같이 반반씩 나눠가짐 */
 }
+
+/* 추가 설정용 섹션 */
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin-bottom: var(--space-16);
+}
+
+.sectionHeader h3 {
+  font: var(--text-h3-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.sectionHeader p {
+  font: var(--text-body-small);
+  color: var(--color-text-gray-500);
+  margin: 0;
+}
+
+.categoryPills {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--space-12);
+}
+
+/* Tabs.module.css의 pillTab 복사 */
+.pillTab {
+  padding: var(--space-8) var(--space-16);
+  height: 36px;
+  background: var(--color-surface); /* #F3F4F6 (Gray/100) */
+  border-radius: var(--radius-full);
+  /* Body/Medium */
+  font: var(--text-body-medium);
+  /* 150% */
+  color: var(--color-text-gray-500); /* #6B7280 */
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.pillTabActive {
+  background: var(--color-secondary); /* #4B5563 (Brand/secondary) */
+  color: var(--color-text-white); /* #FFFFFF */
+}
+
+.dangerZone {
+  width: 100%;
+  max-width: 410px;
+  margin-top: var(--space-32);
+  padding-top: var(--space-32);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-16);
+}

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -3,15 +3,18 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
-import { Button, InputField, UserProfile } from '@/components/ui';
+import { Button, InputField, UserProfile, Toggle } from '@/components/ui';
 import UploadModal from '@/components/modal/UploadModal';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import { useUIStore } from '@/store/useUIStore';
 import { useAuth } from '@/store/useAuthStore';
 import styles from './page.module.css';
 
+
+
 export default function ProfileSettingsPage() {
   const { showToast } = useUIStore();
+  const router = useRouter();
 
   const [baseImage, setBaseImage] = useState<string | undefined>(undefined);
   const [baseEmail, setBaseEmail] = useState('');
@@ -24,9 +27,33 @@ export default function ProfileSettingsPage() {
 
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  // 초기 프로필 데이터 로드
+  // 관심 카테고리 및 뱃지 상태
+  const [baseCategories, setBaseCategories] = useState<string[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [baseBadge, setBaseBadge] = useState<boolean>(true);
+  const [showBadge, setShowBadge] = useState<boolean>(true);
+
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
+
+  // 초기 프로필 및 메타데이터 로드
   useEffect(() => {
+    const fetchMetadata = async () => {
+      try {
+        const catRes = await fetch('/api/categories');
+        if (catRes.ok) {
+           const catData = await catRes.json();
+           if (catData.data) {
+             setAvailableCategories(catData.data);
+           }
+        }
+      } catch (e) {
+        console.error("Failed to load categories", e);
+      }
+    };
+    fetchMetadata();
+    
     const fetchProfile = async () => {
       try {
         const res = await fetch('/api/auth/me'); // BFF proxy (iron-session) handles JWT
@@ -41,10 +68,20 @@ export default function ProfileSettingsPage() {
           setBaseEmail(fetchedEmail);
           setBaseName(fetchedName);
           setBaseImage(fetchedImg);
+          
+          // 확장 설정
+          // 현재 /api/auth/me (또는 user profile API)에서 카테고리와 뱃지 정보가 넘어오지 않으면 빈값으로 치환
+          const fetchedCategories = data.categories || [];
+          const fetchedBadge = data.showBadge ?? true;
+          
+          setBaseCategories(fetchedCategories);
+          setBaseBadge(fetchedBadge);
 
           setUserEmail(fetchedEmail);
           setUserName(fetchedName);
           setProfileImage(fetchedImg);
+          setCategories(fetchedCategories);
+          setShowBadge(fetchedBadge);
         }
       } catch (err) {
         console.error("Failed to load profile", err);
@@ -56,7 +93,9 @@ export default function ProfileSettingsPage() {
   // 수정된 사항이 하나라도 있는지 확인 (버튼 활성화 여부 판별)
   const isDirty =
     profileImage !== baseImage ||
-    userName !== baseName;
+    userName !== baseName ||
+    showBadge !== baseBadge ||
+    JSON.stringify(categories.sort()) !== JSON.stringify(baseCategories.sort());
 
   // '사진 변경' 클릭 시 모달 열기
   const handleImageChangeClick = () => {
@@ -98,6 +137,8 @@ export default function ProfileSettingsPage() {
     setProfileImage(baseImage);
     setSelectedFile(null);
     setUserName(baseName);
+    setCategories(baseCategories);
+    setShowBadge(baseBadge);
     setIsCancelModalOpen(false);
   };
 
@@ -112,7 +153,9 @@ export default function ProfileSettingsPage() {
         },
         body: JSON.stringify({
           nickname: userName,
-          profileImg: profileImage, // 원본 로직 유지 (단순 문자열로 이미지 전송)
+          profileImg: profileImage, 
+          categories: categories,
+          showBadge: showBadge,
         }),
       });
 
@@ -120,6 +163,8 @@ export default function ProfileSettingsPage() {
         setBaseImage(profileImage);
         setBaseEmail(userEmail);
         setBaseName(userName);
+        setBaseCategories(categories);
+        setBaseBadge(showBadge);
         showToast('내 정보 수정이 완료되었습니다.', 'success');
         
         // 헤더 갱신 (저장 성공 시) - 강제로 로컬 스토어의 유저 정보 동기화
@@ -138,6 +183,21 @@ export default function ProfileSettingsPage() {
       console.error(error);
       showToast('네트워크 오류가 발생했습니다.', 'error');
     }
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      const res = await fetch('/api/users/me', { method: 'DELETE' });
+      if (res.ok) {
+        showToast('계정이 안전하게 탈퇴 처리되었습니다.', 'success');
+        router.push('/');
+      } else {
+        showToast('탈퇴 처리 중 오류가 발생했습니다.', 'error');
+      }
+    } catch (e) {
+      showToast('네트워크 오류가 발생했습니다.', 'error');
+    }
+    setIsDeleteModalOpen(false);
   };
 
   return (
@@ -187,7 +247,6 @@ export default function ProfileSettingsPage() {
               />
             </div>
 
-            {/* 하단 액션 버튼 (Frame 54) */}
             <div className={styles.actionButtons}>
               <Button
                 variant="secondary"
@@ -205,6 +264,57 @@ export default function ProfileSettingsPage() {
               >
                 저장
               </Button>
+            </div>
+          </div>
+
+          <hr style={{ width: '100%', maxWidth: '458px', border: 'none', borderTop: '1px solid var(--color-border)', margin: '48px 0' }} />
+
+          <h1 className={styles.pageTitle}>관심 카테고리 설정</h1>
+          <div className={styles.profileSection}>
+            <div className={styles.formGroup}>
+              <div className={styles.sectionHeader}>
+                <p>관심있는 카테고리를 선택해주세요. 맞춤 세션을 추천해 드립니다.</p>
+              </div>
+              <div className={styles.categoryPills}>
+                {availableCategories.map(cat => (
+                  <button
+                    key={cat}
+                    type="button"
+                    className={`${styles.pillTab} ${categories.includes(cat) ? styles.pillTabActive : ''}`}
+                    onClick={() => {
+                        if (categories.includes(cat)) {
+                           setCategories(categories.filter(c => c !== cat));
+                        } else {
+                           setCategories([...categories, cat]);
+                        }
+                    }}
+                  >
+                    {cat}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className={styles.formGroup} style={{ marginTop: '16px' }}>
+               <div className={styles.sectionHeader}>
+                 <h3>뱃지 노출 여부</h3>
+                 <p>커뮤니티 등에서 내 프로필 옆에 활동 뱃지를 공개할지 설정합니다.</p>
+               </div>
+               <Toggle
+                 checked={showBadge}
+                 onChange={(e) => setShowBadge(e.target.checked)}
+                 label="내 프로필에 뱃지 노출 켜기"
+               />
+            </div>
+
+            <div className={styles.dangerZone}>
+               <div className={styles.sectionHeader}>
+                 <h3 style={{ color: 'var(--color-text-danger)' }}>계정 탈퇴</h3>
+                 <p>탈퇴 시 모든 결제 내역과 참여 커뮤니티 기록이 영구적으로 삭제됩니다!</p>
+               </div>
+               <Button variant="secondary" onClick={() => setIsDeleteModalOpen(true)} style={{ color: 'var(--color-text-danger)'}}>
+                 계정 안전하게 탈퇴하기
+               </Button>
             </div>
           </div>
         </div>
@@ -231,6 +341,17 @@ export default function ProfileSettingsPage() {
         subtitle="지금까지 수정한 내용이 모두 사라집니다."
         cancelText="계속 수정하기"
         confirmText="초기화"
+      />
+
+      <ConfirmModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleDeleteAccount}
+        status="danger"
+        title="정말 탈퇴하시겠습니까?"
+        subtitle="계정 삭제 후 모든 결제 내역과 데이터는 복구할 수 없습니다."
+        cancelText="취소"
+        confirmText="탈퇴하기"
       />
     </div>
   );


### PR DESCRIPTION
🚀 Pull Request
이슈 번호: 
close #VO-700

📝 작업 종류
 ✨ 기능 추가 (Feature)
 🎨 UI/UX 디자인 개선
 ♻️ 리팩토링 (기존 코드 및 라우팅 개선)
💡 작업 내용 (Summary)
이번 PR에서는 유저 마이페이지의 프로필 설정 고도화 및 커뮤니티 UI 컴포넌트 추가 작업을 진행했습니다. 관심 카테고리 등록, 뱃지 토글, 계정 탈퇴 기능과 함께 이를 지원하기 위한 백엔드 구조(다대다 매핑, 헥사고널 아키텍처 포트)를 세팅하였습니다.

1. 프로필 설정 - 관심 카테고리 기능 연동

CategoryController (GET /categories)를 신규 생성하여 DB의 전체 카테고리 목록을 무사히 프론트로 내려주도록 구현.
프론트엔드에 Pill Tab 형태의 태그 UI를 적용하고 선택한 관심사를 다중 배열로 묶어 백엔드에 전송하도록 처리.
UserJpaEntity 내부에 @JoinTable을 설정하여 user_categories 다대다(N:M) 로컬 연결 테이블 적용 완료.
2. 프로필 기타 설정 및 회원 탈퇴

사용자의 활동 뱃지를 숨기거나 표시할 수 있는 뱃지 노출 여부(showBadge) 토글 기능 및 DB 저장 로직 추가.
DeactivateUserUseCase 인터페이스를 구현하여 DELETE /users/me 호출 시 계정이 안전하게 비활성화(Soft Delete 처리)되도록 헥사고널 아키텍처 기반으로 작성.
3. 백엔드/프론트엔드 라우팅 및 코드 일원화

프론트엔드 API 호출 시 404 에러를 방지하기 위해, 백엔드 UserController 및 JavaDoc 등에 산재되어 있던 버전 명시(v1)를 전부 제거하고 /users 패턴으로 통일하여 보안 및 라우팅 안정화.
로그인/조회 시(UserInfoResponse) 사용자 카테고리와 뱃지 설정이 프론트 단에 즉시 동기화되도록 응답 객체 구조 확장.
