### PR TITLE
feat: 이벤트 관리 및 세션 단위 구매/결제 연동 완료 (VO-627)

### DIFF
--- a/backend/backend_error.log
+++ b/backend/backend_error.log
@@ -1,0 +1,82 @@
+
+> Task :compileJava
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:3: error: cannot find symbol
+import com.venueon.common.annotation.LoginUser;
+                                    ^
+  symbol:   class LoginUser
+  location: package com.venueon.common.annotation
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:4: error: package com.venueon.common.response does not exist
+import com.venueon.common.response.ApiResponse;
+                                  ^
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:24: error: cannot find symbol
+    public ApiResponse<SessionResponse> createSession(
+           ^
+  symbol:   class ApiResponse
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:49: error: cannot find symbol
+    public ApiResponse<SessionResponse> updateSession(
+           ^
+  symbol:   class ApiResponse
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:76: error: cannot find symbol
+    public ApiResponse<Void> deleteSession(
+           ^
+  symbol:   class ApiResponse
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:86: error: cannot find symbol
+    public ApiResponse<Void> reorderSessions(
+           ^
+  symbol:   class ApiResponse
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/SessionController.java:3: error: package com.venueon.common.response does not exist
+import com.venueon.common.response.ApiResponse;
+                                  ^
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/SessionController.java:22: error: cannot find symbol
+    public ApiResponse<List<SessionResponse>> getSessionsByEventId(@PathVariable Long eventId) {
+           ^
+  symbol:   class ApiResponse
+  location: class SessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:26: error: cannot find symbol
+            @LoginUser Long hostId,
+             ^
+  symbol:   class LoginUser
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:52: error: cannot find symbol
+            @LoginUser Long hostId,
+             ^
+  symbol:   class LoginUser
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:79: error: cannot find symbol
+            @LoginUser Long hostId) {
+             ^
+  symbol:   class LoginUser
+  location: class HostSessionController
+/home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:88: error: cannot find symbol
+            @LoginUser Long hostId,
+             ^
+  symbol:   class LoginUser
+  location: class HostSessionController
+12 errors
+
+> Task :compileJava FAILED
+
+[Incubating] Problems report is available at: file:///home/young/workspace/team3-jangane-venueon/backend/build/reports/problems/problems-report.html
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':compileJava'.
+> Compilation failed; see the compiler output below.
+  /home/young/workspace/team3-jangane-venueon/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java:3: error: cannot find symbol
+  import com.venueon.common.annotation.LoginUser;
+                                      ^
+    symbol:   class LoginUser
+    location: package com.venueon.common.annotation
+  12 errors
+
+* Try:
+> Check your code and dependencies to fix the compilation error(s)
+> Run with --scan to get full insights from a Build Scan (powered by Develocity).
+
+BUILD FAILED in 13s
+1 actionable task: 1 executed

--- a/backend/backend_test.log
+++ b/backend/backend_test.log
@@ -1,0 +1,2129 @@
+> Task :compileJava UP-TO-DATE
+> Task :processResources UP-TO-DATE
+> Task :classes UP-TO-DATE
+> Task :resolveMainClassName UP-TO-DATE
+
+> Task :bootRun
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+
+ :: Spring Boot ::                (v4.0.1)
+
+2026-04-08T16:05:38.818+09:00  INFO 182719 --- [venueon-backend] [           main] com.venueon.VenueOnApplication           : Starting VenueOnApplication using Java 21.0.10 with PID 182719 (/home/young/workspace/team3-jangane-venueon/backend/build/classes/java/main started by young in /home/young/workspace/team3-jangane-venueon/backend)
+2026-04-08T16:05:38.824+09:00 DEBUG 182719 --- [venueon-backend] [           main] com.venueon.VenueOnApplication           : Running with Spring Boot v4.0.1, Spring v7.0.2
+2026-04-08T16:05:38.825+09:00  INFO 182719 --- [venueon-backend] [           main] com.venueon.VenueOnApplication           : The following 1 profile is active: "dev"
+2026-04-08T16:05:40.377+09:00  INFO 182719 --- [venueon-backend] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-04-08T16:05:40.498+09:00  INFO 182719 --- [venueon-backend] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 109 ms. Found 14 JPA repository interfaces.
+2026-04-08T16:05:41.241+09:00  INFO 182719 --- [venueon-backend] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat initialized with port 8080 (http)
+2026-04-08T16:05:41.275+09:00  INFO 182719 --- [venueon-backend] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2026-04-08T16:05:41.276+09:00  INFO 182719 --- [venueon-backend] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/11.0.15]
+2026-04-08T16:05:41.336+09:00  INFO 182719 --- [venueon-backend] [           main] b.w.c.s.WebApplicationContextInitializer : Root WebApplicationContext: initialization completed in 2441 ms
+2026-04-08T16:05:41.616+09:00  INFO 182719 --- [venueon-backend] [           main] org.hibernate.orm.jpa                    : HHH008540: Processing PersistenceUnitInfo [name: default]
+2026-04-08T16:05:41.677+09:00  INFO 182719 --- [venueon-backend] [           main] org.hibernate.orm.core                   : HHH000001: Hibernate ORM core version 7.2.0.Final
+2026-04-08T16:05:42.197+09:00  INFO 182719 --- [venueon-backend] [           main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
+2026-04-08T16:05:42.231+09:00  INFO 182719 --- [venueon-backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2026-04-08T16:05:42.397+09:00  INFO 182719 --- [venueon-backend] [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@30333941
+2026-04-08T16:05:42.399+09:00  INFO 182719 --- [venueon-backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
+2026-04-08T16:05:42.432+09:00  WARN 182719 --- [venueon-backend] [           main] org.hibernate.orm.deprecation            : HHH90000025: PostgreSQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2026-04-08T16:05:42.460+09:00  INFO 182719 --- [venueon-backend] [           main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
+	Database JDBC URL [jdbc:postgresql://localhost:5432/venueon_dev]
+	Database driver: PostgreSQL JDBC Driver
+	Database dialect: PostgreSQLDialect
+	Database version: 15.17
+	Default catalog/schema: venueon_dev/public
+	Autocommit mode: undefined/unknown
+	Isolation level: READ_COMMITTED [default READ_COMMITTED]
+	JDBC fetch size: none
+	Pool: DataSourceConnectionProvider
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2026-04-08T16:05:41.036+09:00  INFO 182719 --- [venueon-backend] [           main] org.hibernate.orm.core                   : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2026-04-08T16:05:41.062+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    set client_min_messages = WARNING
+Hibernate: 
+    set client_min_messages = WARNING
+2026-04-08T16:05:41.064+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comment_likes 
+       drop constraint if exists FK3wa5u7bs1p1o9hmavtgdgk1go
+Hibernate: 
+    alter table if exists comment_likes 
+       drop constraint if exists FK3wa5u7bs1p1o9hmavtgdgk1go
+2026-04-08T16:05:41.066+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comment_likes 
+       drop constraint if exists FK6h3lbneryl5pyb9ykaju7werx
+Hibernate: 
+    alter table if exists comment_likes 
+       drop constraint if exists FK6h3lbneryl5pyb9ykaju7werx
+2026-04-08T16:05:41.067+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       drop constraint if exists FKn2na60ukhs76ibtpt9burkm27
+Hibernate: 
+    alter table if exists comments 
+       drop constraint if exists FKn2na60ukhs76ibtpt9burkm27
+2026-04-08T16:05:41.068+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       drop constraint if exists FKlri30okf66phtcgbe5pok7cc0
+Hibernate: 
+    alter table if exists comments 
+       drop constraint if exists FKlri30okf66phtcgbe5pok7cc0
+2026-04-08T16:05:41.068+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       drop constraint if exists FKh4c7lvsc298whoyd4w9ta25cr
+Hibernate: 
+    alter table if exists comments 
+       drop constraint if exists FKh4c7lvsc298whoyd4w9ta25cr
+2026-04-08T16:05:41.069+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists communities 
+       drop constraint if exists FKehds1lhi1y9a8rweslp1esncn
+Hibernate: 
+    alter table if exists communities 
+       drop constraint if exists FKehds1lhi1y9a8rweslp1esncn
+2026-04-08T16:05:41.070+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists communities 
+       drop constraint if exists FKhi7jr3il90nrhisu3htfl4ks
+Hibernate: 
+    alter table if exists communities 
+       drop constraint if exists FKhi7jr3il90nrhisu3htfl4ks
+2026-04-08T16:05:41.071+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists community_members 
+       drop constraint if exists FKqn9g17tqcwnoy41o2am9fnlep
+Hibernate: 
+    alter table if exists community_members 
+       drop constraint if exists FKqn9g17tqcwnoy41o2am9fnlep
+2026-04-08T16:05:41.072+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists community_members 
+       drop constraint if exists FKme7k1stbnwi6cpmm8a6sgcikn
+Hibernate: 
+    alter table if exists community_members 
+       drop constraint if exists FKme7k1stbnwi6cpmm8a6sgcikn
+2026-04-08T16:05:41.073+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists event_sessions 
+       drop constraint if exists FK4j89lx7pd3n6ugkg9bcmgpu5j
+Hibernate: 
+    alter table if exists event_sessions 
+       drop constraint if exists FK4j89lx7pd3n6ugkg9bcmgpu5j
+2026-04-08T16:05:41.074+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists events 
+       drop constraint if exists FKo6mla8j1p5bokt4dxrlmgwc28
+Hibernate: 
+    alter table if exists events 
+       drop constraint if exists FKo6mla8j1p5bokt4dxrlmgwc28
+2026-04-08T16:05:41.076+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists events 
+       drop constraint if exists FK7ljm71n1057envlomdxcni5hs
+Hibernate: 
+    alter table if exists events 
+       drop constraint if exists FK7ljm71n1057envlomdxcni5hs
+2026-04-08T16:05:41.077+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists host_profiles 
+       drop constraint if exists FKmoas5i4ry1m9mwgbgb1jdrhli
+Hibernate: 
+    alter table if exists host_profiles 
+       drop constraint if exists FKmoas5i4ry1m9mwgbgb1jdrhli
+2026-04-08T16:05:41.078+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists orders 
+       drop constraint if exists FK43g2yroy6l7lfomw37wajkqrn
+Hibernate: 
+    alter table if exists orders 
+       drop constraint if exists FK43g2yroy6l7lfomw37wajkqrn
+2026-04-08T16:05:41.079+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists orders 
+       drop constraint if exists FK32ql8ubntj5uh44ph9659tiih
+Hibernate: 
+    alter table if exists orders 
+       drop constraint if exists FK32ql8ubntj5uh44ph9659tiih
+2026-04-08T16:05:41.080+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_bookmarks 
+       drop constraint if exists FKclpw1l6wrci96rfj0dtt3bfah
+Hibernate: 
+    alter table if exists post_bookmarks 
+       drop constraint if exists FKclpw1l6wrci96rfj0dtt3bfah
+2026-04-08T16:05:41.082+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_bookmarks 
+       drop constraint if exists FK9b5c09u5arho7ei76d78bn7ww
+Hibernate: 
+    alter table if exists post_bookmarks 
+       drop constraint if exists FK9b5c09u5arho7ei76d78bn7ww
+2026-04-08T16:05:41.082+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_likes 
+       drop constraint if exists FKa5wxsgl4doibhbed9gm7ikie2
+Hibernate: 
+    alter table if exists post_likes 
+       drop constraint if exists FKa5wxsgl4doibhbed9gm7ikie2
+2026-04-08T16:05:41.083+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_likes 
+       drop constraint if exists FKkgau5n0nlewg6o9lr4yibqgxj
+Hibernate: 
+    alter table if exists post_likes 
+       drop constraint if exists FKkgau5n0nlewg6o9lr4yibqgxj
+2026-04-08T16:05:41.084+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists posts 
+       drop constraint if exists FK6xvn0811tkyo3nfjk2xvqx6ns
+Hibernate: 
+    alter table if exists posts 
+       drop constraint if exists FK6xvn0811tkyo3nfjk2xvqx6ns
+2026-04-08T16:05:41.086+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists posts 
+       drop constraint if exists FK7rk45ficmsfhe8n1dojvqt6ui
+Hibernate: 
+    alter table if exists posts 
+       drop constraint if exists FK7rk45ficmsfhe8n1dojvqt6ui
+2026-04-08T16:05:41.086+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists refunds 
+       drop constraint if exists FKsk9rqm7f6y8b1g0qob018hdm7
+Hibernate: 
+    alter table if exists refunds 
+       drop constraint if exists FKsk9rqm7f6y8b1g0qob018hdm7
+2026-04-08T16:05:41.087+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists refunds 
+       drop constraint if exists FKrtxief4co3k1lfklj7n05m8mo
+Hibernate: 
+    alter table if exists refunds 
+       drop constraint if exists FKrtxief4co3k1lfklj7n05m8mo
+2026-04-08T16:05:41.089+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists reports 
+       drop constraint if exists FKd3qiw2om5d2oh5xb7fbdcq225
+Hibernate: 
+    alter table if exists reports 
+       drop constraint if exists FKd3qiw2om5d2oh5xb7fbdcq225
+2026-04-08T16:05:41.090+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists categories cascade
+Hibernate: 
+    drop table if exists categories cascade
+2026-04-08T16:05:41.092+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists comment_likes cascade
+Hibernate: 
+    drop table if exists comment_likes cascade
+2026-04-08T16:05:41.093+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists comments cascade
+Hibernate: 
+    drop table if exists comments cascade
+2026-04-08T16:05:41.094+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists communities cascade
+Hibernate: 
+    drop table if exists communities cascade
+2026-04-08T16:05:41.095+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists community_members cascade
+Hibernate: 
+    drop table if exists community_members cascade
+2026-04-08T16:05:41.096+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists event_sessions cascade
+Hibernate: 
+    drop table if exists event_sessions cascade
+2026-04-08T16:05:41.097+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists events cascade
+Hibernate: 
+    drop table if exists events cascade
+2026-04-08T16:05:41.097+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists host_profiles cascade
+Hibernate: 
+    drop table if exists host_profiles cascade
+2026-04-08T16:05:41.098+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists orders cascade
+Hibernate: 
+    drop table if exists orders cascade
+2026-04-08T16:05:41.098+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists post_bookmarks cascade
+Hibernate: 
+    drop table if exists post_bookmarks cascade
+2026-04-08T16:05:41.099+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists post_likes cascade
+Hibernate: 
+    drop table if exists post_likes cascade
+2026-04-08T16:05:41.099+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists posts cascade
+Hibernate: 
+    drop table if exists posts cascade
+2026-04-08T16:05:41.100+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists refunds cascade
+Hibernate: 
+    drop table if exists refunds cascade
+2026-04-08T16:05:41.100+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists reports cascade
+Hibernate: 
+    drop table if exists reports cascade
+2026-04-08T16:05:41.101+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    drop table if exists users cascade
+Hibernate: 
+    drop table if exists users cascade
+2026-04-08T16:05:41.108+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table categories (
+        sort_order integer,
+        id bigint generated by default as identity,
+        description varchar(255),
+        name varchar(255) not null unique,
+        primary key (id)
+    )
+Hibernate: 
+    create table categories (
+        sort_order integer,
+        id bigint generated by default as identity,
+        description varchar(255),
+        name varchar(255) not null unique,
+        primary key (id)
+    )
+2026-04-08T16:05:41.173+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table comment_likes (
+        comment_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        user_id bigint not null,
+        primary key (id),
+        unique (comment_id, user_id)
+    )
+Hibernate: 
+    create table comment_likes (
+        comment_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        user_id bigint not null,
+        primary key (id),
+        unique (comment_id, user_id)
+    )
+2026-04-08T16:05:41.195+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table comments (
+        is_hidden boolean not null,
+        like_count integer,
+        author_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        parent_id bigint,
+        post_id bigint not null,
+        content TEXT not null,
+        primary key (id)
+    )
+Hibernate: 
+    create table comments (
+        is_hidden boolean not null,
+        like_count integer,
+        author_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        parent_id bigint,
+        post_id bigint not null,
+        content TEXT not null,
+        primary key (id)
+    )
+2026-04-08T16:05:41.214+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table communities (
+        is_public boolean,
+        member_count integer,
+        created_at timestamp(6) not null,
+        creator_id bigint not null,
+        event_id bigint,
+        id bigint generated by default as identity,
+        description TEXT,
+        name varchar(255) not null,
+        thumbnail_url varchar(255),
+        primary key (id)
+    )
+Hibernate: 
+    create table communities (
+        is_public boolean,
+        member_count integer,
+        created_at timestamp(6) not null,
+        creator_id bigint not null,
+        event_id bigint,
+        id bigint generated by default as identity,
+        description TEXT,
+        name varchar(255) not null,
+        thumbnail_url varchar(255),
+        primary key (id)
+    )
+2026-04-08T16:05:41.230+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table community_members (
+        community_id bigint not null,
+        id bigint generated by default as identity,
+        joined_at timestamp(6) not null,
+        user_id bigint not null,
+        role varchar(255) not null check ((role in ('ADMIN','MEMBER'))),
+        primary key (id),
+        unique (community_id, user_id)
+    )
+Hibernate: 
+    create table community_members (
+        community_id bigint not null,
+        id bigint generated by default as identity,
+        joined_at timestamp(6) not null,
+        user_id bigint not null,
+        role varchar(255) not null check ((role in ('ADMIN','MEMBER'))),
+        primary key (id),
+        unique (community_id, user_id)
+    )
+2026-04-08T16:05:41.253+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table event_sessions (
+        current_attendees integer,
+        is_default boolean,
+        is_online boolean,
+        max_attendees integer,
+        price integer not null,
+        sort_order integer,
+        created_at timestamp(6) not null,
+        end_time timestamp(6),
+        event_id bigint not null,
+        id bigint generated by default as identity,
+        start_time timestamp(6),
+        updated_at timestamp(6),
+        description TEXT,
+        location varchar(255),
+        online_link varchar(255),
+        region_sido varchar(255),
+        region_sigungu varchar(255),
+        title varchar(255) not null,
+        primary key (id)
+    )
+Hibernate: 
+    create table event_sessions (
+        current_attendees integer,
+        is_default boolean,
+        is_online boolean,
+        max_attendees integer,
+        price integer not null,
+        sort_order integer,
+        created_at timestamp(6) not null,
+        end_time timestamp(6),
+        event_id bigint not null,
+        id bigint generated by default as identity,
+        start_time timestamp(6),
+        updated_at timestamp(6),
+        description TEXT,
+        location varchar(255),
+        online_link varchar(255),
+        region_sido varchar(255),
+        region_sigungu varchar(255),
+        title varchar(255) not null,
+        primary key (id)
+    )
+2026-04-08T16:05:41.270+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table events (
+        has_session boolean,
+        is_hidden boolean not null,
+        is_online boolean,
+        max_attendees integer,
+        price integer not null,
+        category_id bigint,
+        created_at timestamp(6) not null,
+        creator_id bigint not null,
+        end_date timestamp(6),
+        id bigint generated by default as identity,
+        start_date timestamp(6),
+        updated_at timestamp(6),
+        description TEXT,
+        location varchar(255),
+        purchase_type varchar(255) check ((purchase_type in ('SINGLE','MULTI'))),
+        status varchar(255) not null check ((status in ('DRAFT','PUBLISHED','ONGOING','ENDED','CANCELLED'))),
+        thumbnail_url varchar(255),
+        title varchar(255) not null,
+        type varchar(255) not null check ((type in ('SEMINAR','CLASS','MEETUP','CONFERENCE'))),
+        primary key (id)
+    )
+Hibernate: 
+    create table events (
+        has_session boolean,
+        is_hidden boolean not null,
+        is_online boolean,
+        max_attendees integer,
+        price integer not null,
+        category_id bigint,
+        created_at timestamp(6) not null,
+        creator_id bigint not null,
+        end_date timestamp(6),
+        id bigint generated by default as identity,
+        start_date timestamp(6),
+        updated_at timestamp(6),
+        description TEXT,
+        location varchar(255),
+        purchase_type varchar(255) check ((purchase_type in ('SINGLE','MULTI'))),
+        status varchar(255) not null check ((status in ('DRAFT','PUBLISHED','ONGOING','ENDED','CANCELLED'))),
+        thumbnail_url varchar(255),
+        title varchar(255) not null,
+        type varchar(255) not null check ((type in ('SEMINAR','CLASS','MEETUP','CONFERENCE'))),
+        primary key (id)
+    )
+2026-04-08T16:05:41.286+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table host_profiles (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        user_id bigint not null unique,
+        org_description varchar(1000),
+        manager_name varchar(255),
+        org_name varchar(255) not null,
+        org_number varchar(255) not null,
+        primary key (id)
+    )
+Hibernate: 
+    create table host_profiles (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        user_id bigint not null unique,
+        org_description varchar(1000),
+        manager_name varchar(255),
+        org_name varchar(255) not null,
+        org_number varchar(255) not null,
+        primary key (id)
+    )
+2026-04-08T16:05:41.307+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table orders (
+        amount integer not null,
+        quantity integer not null,
+        event_id bigint not null,
+        id bigint generated by default as identity,
+        ordered_at timestamp(6) not null,
+        paid_at timestamp(6),
+        user_id bigint not null,
+        payment_method varchar(255),
+        status varchar(255) not null check ((status in ('PENDING','PAID','CANCELLED','REFUNDED','REGISTERED','REFUND_REQUESTED'))),
+        toss_order_id varchar(255),
+        toss_payment_key varchar(255),
+        primary key (id)
+    )
+Hibernate: 
+    create table orders (
+        amount integer not null,
+        quantity integer not null,
+        event_id bigint not null,
+        id bigint generated by default as identity,
+        ordered_at timestamp(6) not null,
+        paid_at timestamp(6),
+        user_id bigint not null,
+        payment_method varchar(255),
+        status varchar(255) not null check ((status in ('PENDING','PAID','CANCELLED','REFUNDED','REGISTERED','REFUND_REQUESTED'))),
+        toss_order_id varchar(255),
+        toss_payment_key varchar(255),
+        primary key (id)
+    )
+2026-04-08T16:05:41.322+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table post_bookmarks (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        post_id bigint not null,
+        user_id bigint not null,
+        primary key (id),
+        unique (post_id, user_id)
+    )
+Hibernate: 
+    create table post_bookmarks (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        post_id bigint not null,
+        user_id bigint not null,
+        primary key (id),
+        unique (post_id, user_id)
+    )
+2026-04-08T16:05:41.344+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table post_likes (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        post_id bigint not null,
+        user_id bigint not null,
+        primary key (id),
+        unique (post_id, user_id)
+    )
+Hibernate: 
+    create table post_likes (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        post_id bigint not null,
+        user_id bigint not null,
+        primary key (id),
+        unique (post_id, user_id)
+    )
+2026-04-08T16:05:41.361+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table posts (
+        comment_count integer,
+        is_hidden boolean not null,
+        is_notice boolean not null,
+        is_pinned boolean not null,
+        like_count integer,
+        view_count integer,
+        author_id bigint not null,
+        community_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        content TEXT not null,
+        title varchar(255) not null,
+        type varchar(255) not null check ((type in ('GENERAL','REVIEW','QUESTION','NOTICE'))),
+        primary key (id)
+    )
+Hibernate: 
+    create table posts (
+        comment_count integer,
+        is_hidden boolean not null,
+        is_notice boolean not null,
+        is_pinned boolean not null,
+        like_count integer,
+        view_count integer,
+        author_id bigint not null,
+        community_id bigint not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        content TEXT not null,
+        title varchar(255) not null,
+        type varchar(255) not null check ((type in ('GENERAL','REVIEW','QUESTION','NOTICE'))),
+        primary key (id)
+    )
+2026-04-08T16:05:41.386+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table refunds (
+        amount integer not null,
+        id bigint generated by default as identity,
+        order_id bigint not null,
+        processed_at timestamp(6),
+        requested_at timestamp(6) not null,
+        user_id bigint not null,
+        reason varchar(255),
+        status varchar(255) not null check ((status in ('PENDING','APPROVED','REJECTED'))),
+        primary key (id)
+    )
+Hibernate: 
+    create table refunds (
+        amount integer not null,
+        id bigint generated by default as identity,
+        order_id bigint not null,
+        processed_at timestamp(6),
+        requested_at timestamp(6) not null,
+        user_id bigint not null,
+        reason varchar(255),
+        status varchar(255) not null check ((status in ('PENDING','APPROVED','REJECTED'))),
+        primary key (id)
+    )
+2026-04-08T16:05:41.411+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table reports (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        reporter_id bigint not null,
+        resolved_at timestamp(6),
+        target_id bigint not null,
+        detail TEXT,
+        admin_action varchar(255) check ((admin_action in ('DELETE','HIDE','WARN','DISMISS'))),
+        reason varchar(255) not null,
+        status varchar(255) not null check ((status in ('PENDING','RESOLVED','REJECTED'))),
+        target_type varchar(255) not null check ((target_type in ('EVENT','POST','COMMENT','USER'))),
+        primary key (id)
+    )
+Hibernate: 
+    create table reports (
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        reporter_id bigint not null,
+        resolved_at timestamp(6),
+        target_id bigint not null,
+        detail TEXT,
+        admin_action varchar(255) check ((admin_action in ('DELETE','HIDE','WARN','DISMISS'))),
+        reason varchar(255) not null,
+        status varchar(255) not null check ((status in ('PENDING','RESOLVED','REJECTED'))),
+        target_type varchar(255) not null check ((target_type in ('EVENT','POST','COMMENT','USER'))),
+        primary key (id)
+    )
+2026-04-08T16:05:41.429+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    create table users (
+        is_active boolean not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        email varchar(255) not null unique,
+        nickname varchar(255) not null,
+        password varchar(255) not null,
+        phone varchar(255),
+        profile_img varchar(255),
+        provider varchar(255) not null check ((provider in ('LOCAL','GOOGLE'))),
+        role varchar(255) not null check ((role in ('ADMIN','HOST','USER'))),
+        primary key (id)
+    )
+Hibernate: 
+    create table users (
+        is_active boolean not null,
+        created_at timestamp(6) not null,
+        id bigint generated by default as identity,
+        updated_at timestamp(6),
+        email varchar(255) not null unique,
+        nickname varchar(255) not null,
+        password varchar(255) not null,
+        phone varchar(255),
+        profile_img varchar(255),
+        provider varchar(255) not null check ((provider in ('LOCAL','GOOGLE'))),
+        role varchar(255) not null check ((role in ('ADMIN','HOST','USER'))),
+        primary key (id)
+    )
+2026-04-08T16:05:41.448+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comment_likes 
+       add constraint FK3wa5u7bs1p1o9hmavtgdgk1go 
+       foreign key (comment_id) 
+       references comments
+Hibernate: 
+    alter table if exists comment_likes 
+       add constraint FK3wa5u7bs1p1o9hmavtgdgk1go 
+       foreign key (comment_id) 
+       references comments
+2026-04-08T16:05:41.454+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comment_likes 
+       add constraint FK6h3lbneryl5pyb9ykaju7werx 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists comment_likes 
+       add constraint FK6h3lbneryl5pyb9ykaju7werx 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.460+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       add constraint FKn2na60ukhs76ibtpt9burkm27 
+       foreign key (author_id) 
+       references users
+Hibernate: 
+    alter table if exists comments 
+       add constraint FKn2na60ukhs76ibtpt9burkm27 
+       foreign key (author_id) 
+       references users
+2026-04-08T16:05:41.466+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       add constraint FKlri30okf66phtcgbe5pok7cc0 
+       foreign key (parent_id) 
+       references comments
+Hibernate: 
+    alter table if exists comments 
+       add constraint FKlri30okf66phtcgbe5pok7cc0 
+       foreign key (parent_id) 
+       references comments
+2026-04-08T16:05:41.470+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists comments 
+       add constraint FKh4c7lvsc298whoyd4w9ta25cr 
+       foreign key (post_id) 
+       references posts
+Hibernate: 
+    alter table if exists comments 
+       add constraint FKh4c7lvsc298whoyd4w9ta25cr 
+       foreign key (post_id) 
+       references posts
+2026-04-08T16:05:41.476+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists communities 
+       add constraint FKehds1lhi1y9a8rweslp1esncn 
+       foreign key (creator_id) 
+       references users
+Hibernate: 
+    alter table if exists communities 
+       add constraint FKehds1lhi1y9a8rweslp1esncn 
+       foreign key (creator_id) 
+       references users
+2026-04-08T16:05:41.480+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists communities 
+       add constraint FKhi7jr3il90nrhisu3htfl4ks 
+       foreign key (event_id) 
+       references events
+Hibernate: 
+    alter table if exists communities 
+       add constraint FKhi7jr3il90nrhisu3htfl4ks 
+       foreign key (event_id) 
+       references events
+2026-04-08T16:05:41.486+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists community_members 
+       add constraint FKqn9g17tqcwnoy41o2am9fnlep 
+       foreign key (community_id) 
+       references communities
+Hibernate: 
+    alter table if exists community_members 
+       add constraint FKqn9g17tqcwnoy41o2am9fnlep 
+       foreign key (community_id) 
+       references communities
+2026-04-08T16:05:41.491+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists community_members 
+       add constraint FKme7k1stbnwi6cpmm8a6sgcikn 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists community_members 
+       add constraint FKme7k1stbnwi6cpmm8a6sgcikn 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.496+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists event_sessions 
+       add constraint FK4j89lx7pd3n6ugkg9bcmgpu5j 
+       foreign key (event_id) 
+       references events
+Hibernate: 
+    alter table if exists event_sessions 
+       add constraint FK4j89lx7pd3n6ugkg9bcmgpu5j 
+       foreign key (event_id) 
+       references events
+2026-04-08T16:05:41.504+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists events 
+       add constraint FKo6mla8j1p5bokt4dxrlmgwc28 
+       foreign key (category_id) 
+       references categories
+Hibernate: 
+    alter table if exists events 
+       add constraint FKo6mla8j1p5bokt4dxrlmgwc28 
+       foreign key (category_id) 
+       references categories
+2026-04-08T16:05:41.511+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists events 
+       add constraint FK7ljm71n1057envlomdxcni5hs 
+       foreign key (creator_id) 
+       references users
+Hibernate: 
+    alter table if exists events 
+       add constraint FK7ljm71n1057envlomdxcni5hs 
+       foreign key (creator_id) 
+       references users
+2026-04-08T16:05:41.522+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists host_profiles 
+       add constraint FKmoas5i4ry1m9mwgbgb1jdrhli 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists host_profiles 
+       add constraint FKmoas5i4ry1m9mwgbgb1jdrhli 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.532+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists orders 
+       add constraint FK43g2yroy6l7lfomw37wajkqrn 
+       foreign key (event_id) 
+       references events
+Hibernate: 
+    alter table if exists orders 
+       add constraint FK43g2yroy6l7lfomw37wajkqrn 
+       foreign key (event_id) 
+       references events
+2026-04-08T16:05:41.541+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists orders 
+       add constraint FK32ql8ubntj5uh44ph9659tiih 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists orders 
+       add constraint FK32ql8ubntj5uh44ph9659tiih 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.551+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_bookmarks 
+       add constraint FKclpw1l6wrci96rfj0dtt3bfah 
+       foreign key (post_id) 
+       references posts
+Hibernate: 
+    alter table if exists post_bookmarks 
+       add constraint FKclpw1l6wrci96rfj0dtt3bfah 
+       foreign key (post_id) 
+       references posts
+2026-04-08T16:05:41.562+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_bookmarks 
+       add constraint FK9b5c09u5arho7ei76d78bn7ww 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists post_bookmarks 
+       add constraint FK9b5c09u5arho7ei76d78bn7ww 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.569+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_likes 
+       add constraint FKa5wxsgl4doibhbed9gm7ikie2 
+       foreign key (post_id) 
+       references posts
+Hibernate: 
+    alter table if exists post_likes 
+       add constraint FKa5wxsgl4doibhbed9gm7ikie2 
+       foreign key (post_id) 
+       references posts
+2026-04-08T16:05:41.575+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists post_likes 
+       add constraint FKkgau5n0nlewg6o9lr4yibqgxj 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists post_likes 
+       add constraint FKkgau5n0nlewg6o9lr4yibqgxj 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.581+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists posts 
+       add constraint FK6xvn0811tkyo3nfjk2xvqx6ns 
+       foreign key (author_id) 
+       references users
+Hibernate: 
+    alter table if exists posts 
+       add constraint FK6xvn0811tkyo3nfjk2xvqx6ns 
+       foreign key (author_id) 
+       references users
+2026-04-08T16:05:41.588+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists posts 
+       add constraint FK7rk45ficmsfhe8n1dojvqt6ui 
+       foreign key (community_id) 
+       references communities
+Hibernate: 
+    alter table if exists posts 
+       add constraint FK7rk45ficmsfhe8n1dojvqt6ui 
+       foreign key (community_id) 
+       references communities
+2026-04-08T16:05:41.594+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists refunds 
+       add constraint FKsk9rqm7f6y8b1g0qob018hdm7 
+       foreign key (order_id) 
+       references orders
+Hibernate: 
+    alter table if exists refunds 
+       add constraint FKsk9rqm7f6y8b1g0qob018hdm7 
+       foreign key (order_id) 
+       references orders
+2026-04-08T16:05:41.600+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists refunds 
+       add constraint FKrtxief4co3k1lfklj7n05m8mo 
+       foreign key (user_id) 
+       references users
+Hibernate: 
+    alter table if exists refunds 
+       add constraint FKrtxief4co3k1lfklj7n05m8mo 
+       foreign key (user_id) 
+       references users
+2026-04-08T16:05:41.605+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    alter table if exists reports 
+       add constraint FKd3qiw2om5d2oh5xb7fbdcq225 
+       foreign key (reporter_id) 
+       references users
+Hibernate: 
+    alter table if exists reports 
+       add constraint FKd3qiw2om5d2oh5xb7fbdcq225 
+       foreign key (reporter_id) 
+       references users
+2026-04-08T16:05:41.617+09:00  INFO 182719 --- [venueon-backend] [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
+2026-04-08T16:05:41.733+09:00  INFO 182719 --- [venueon-backend] [           main] o.s.d.j.r.query.QueryEnhancerFactories   : Hibernate is in classpath; If applicable, HQL parser will be used.
+2026-04-08T16:05:42.043+09:00 DEBUG 182719 --- [venueon-backend] [           main] c.v.u.a.i.s.JwtAuthenticationFilter      : Filter 'jwtAuthenticationFilter' configured for use
+2026-04-08T16:05:44.012+09:00  INFO 182719 --- [venueon-backend] [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name customUserDetailsService
+2026-04-08T16:05:44.900+09:00  INFO 182719 --- [venueon-backend] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
+2026-04-08T16:05:45.029+09:00  INFO 182719 --- [venueon-backend] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat started on port 8080 (http) with context path '/'
+2026-04-08T16:05:45.044+09:00  INFO 182719 --- [venueon-backend] [           main] com.venueon.VenueOnApplication           : Started VenueOnApplication in 6.941 seconds (process running for 10.361)
+2026-04-08T16:05:45.234+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    select
+        count(*) 
+    from
+        users uje1_0
+Hibernate: 
+    select
+        count(*) 
+    from
+        users uje1_0
+2026-04-08T16:05:45.272+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : === 개발용 초기 데이터 생성 시작 ===
+2026-04-08T16:05:45.421+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.789+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.793+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.797+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.919+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.924+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.926+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.930+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.932+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.935+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.938+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.940+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.943+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.947+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        users
+        (created_at, email, is_active, nickname, password, phone, profile_img, provider, role, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.951+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.956+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.959+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.962+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.965+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.968+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.971+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.976+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.980+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.983+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        host_profiles
+        (created_at, manager_name, org_description, org_name, org_number, updated_at, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:45.987+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:45.992+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:45.995+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:45.999+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.002+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.006+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.009+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.011+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.013+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.015+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        categories
+        (description, name, sort_order) 
+    values
+        (?, ?, ?)
+2026-04-08T16:05:46.019+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.026+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.031+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.036+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.040+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.045+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.048+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.054+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.059+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.064+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.069+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.078+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.083+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.087+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.092+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.097+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.101+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.105+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.108+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.113+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.118+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.122+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.126+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.133+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.138+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.142+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : 세션 생성 완료: 기본 세션 10개, 추가 세션 5개
+2026-04-08T16:05:46.145+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.151+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.156+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.160+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.165+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.171+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        orders
+        (amount, event_id, ordered_at, paid_at, payment_method, quantity, status, toss_order_id, toss_payment_key, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.176+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.182+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.186+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.190+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        reports
+        (admin_action, created_at, detail, reason, reporter_id, resolved_at, status, target_id, target_type) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.197+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        refunds
+        (amount, order_id, processed_at, reason, requested_at, status, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        refunds
+        (amount, order_id, processed_at, reason, requested_at, status, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.203+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    insert 
+    into
+        refunds
+        (amount, order_id, processed_at, reason, requested_at, status, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        refunds
+        (amount, order_id, processed_at, reason, requested_at, status, user_id) 
+    values
+        (?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:05:46.209+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : === 개발용 초기 데이터 생성 완료 ===
+2026-04-08T16:05:46.209+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : Admin: 1명, User: 3명, Host: 10명
+2026-04-08T16:05:46.250+09:00 DEBUG 182719 --- [venueon-backend] [           main] org.hibernate.SQL                        : 
+    select
+        count(*) 
+    from
+        event_sessions esje1_0
+Hibernate: 
+    select
+        count(*) 
+    from
+        event_sessions esje1_0
+2026-04-08T16:05:46.254+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : Category: 10개, Event: 10개, Session: 15개
+2026-04-08T16:05:46.255+09:00  INFO 182719 --- [venueon-backend] [           main] c.venueon.common.config.DataInitializer  : Order: 6개, Report: 4개, Refund: 2개
+2026-04-08T16:05:47.605+09:00  INFO 182719 --- [venueon-backend] [nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-04-08T16:05:47.606+09:00  INFO 182719 --- [venueon-backend] [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2026-04-08T16:05:47.611+09:00  INFO 182719 --- [venueon-backend] [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 5 ms
+2026-04-08T16:05:47.965+09:00 ERROR 182719 --- [venueon-backend] [nio-8080-exec-1] c.v.c.exception.GlobalExceptionHandler   : Exception: JSON parse error: Cannot map `null` into type `boolean` (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)
+
+org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot map `null` into type `boolean` (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)
+	at org.springframework.http.converter.AbstractJacksonHttpMessageConverter.readJavaType(AbstractJacksonHttpMessageConverter.java:362) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.http.converter.AbstractJacksonHttpMessageConverter.read(AbstractJacksonHttpMessageConverter.java:318) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodArgumentResolver.readWithMessageConverters(AbstractMessageConverterMethodArgumentResolver.java:203) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.readWithMessageConverters(RequestResponseBodyMethodProcessor.java:175) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.resolveArgument(RequestResponseBodyMethodProcessor.java:150) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.method.support.HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:122) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.method.support.InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:230) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:180) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:934) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:853) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:86) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:963) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:866) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1003) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:903) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:649) ~[tomcat-embed-core-11.0.15.jar:6.1]
+	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:874) ~[spring-webmvc-7.0.2.jar:7.0.2]
+	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:710) ~[tomcat-embed-core-11.0.15.jar:6.1]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:128) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat-embed-websocket-11.0.15.jar:11.0.15]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:235) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$FilterObservation$SimpleFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:493) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:354) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator.lambda$wrapSecured$0(ObservationFilterChainDecorator.java:86) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:132) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.access.intercept.AuthorizationFilter.doFilter(AuthorizationFilter.java:101) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:126) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:120) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:132) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:86) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:181) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at com.venueon.user.adapter.in.security.JwtAuthenticationFilter.doFilterInternal(JwtAuthenticationFilter.java:52) ~[main/:na]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:110) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:96) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$0(ObservationFilterChainDecorator.java:337) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:228) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:237) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:195) ~[spring-security-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.ServletRequestPathFilter.doFilter(ServletRequestPathFilter.java:52) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebSecurityConfiguration.java:317) ~[spring-security-config-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:355) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:272) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.ServerHttpObservationFilter.doFilterInternal(ServerHttpObservationFilter.java:110) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:199) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-7.0.2.jar:7.0.2]
+	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:107) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:77) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:341) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:397) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1778) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:946) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:480) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:57) ~[tomcat-embed-core-11.0.15.jar:11.0.15]
+	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
+Caused by: tools.jackson.databind.exc.MismatchedInputException: Cannot map `null` into type `boolean` (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)
+ at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #424] (through reference chain: com.venueon.event.adapter.in.web.dto.EventCreateRequest["sessions"]->java.util.ArrayList[0]->com.venueon.event.adapter.in.web.dto.SessionCreateRequest["isOnline"])
+	at tools.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:67) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1794) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.jdk.NumberDeserializers$PrimitiveOrWrapperDeserializer.getNullValue(NumberDeserializers.java:167) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.ValueDeserializer.getAbsentValue(ValueDeserializer.java:384) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.PropertyValueBuffer._findMissing(PropertyValueBuffer.java:299) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.PropertyValueBuffer.getParameters(PropertyValueBuffer.java:214) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.ValueInstantiator.createFromObjectWith(ValueInstantiator.java:271) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.PropertyBasedCreator.build(PropertyBasedCreator.java:271) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:703) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1417) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:480) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer.deserialize(BeanDeserializer.java:200) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.jdk.CollectionDeserializer._deserializeNoNullChecks(CollectionDeserializer.java:493) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.jdk.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:348) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.jdk.CollectionDeserializer.deserialize(CollectionDeserializer.java:238) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.jdk.CollectionDeserializer.deserialize(CollectionDeserializer.java:29) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:561) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:752) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:598) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1417) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:480) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.bean.BeanDeserializer.deserialize(BeanDeserializer.java:200) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.deser.DeserializationContextExt.readRootValue(DeserializationContextExt.java:265) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1646) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at tools.jackson.databind.ObjectReader.readValue(ObjectReader.java:1171) ~[jackson-databind-3.0.3.jar:3.0.3]
+	at org.springframework.http.converter.AbstractJacksonHttpMessageConverter.readJavaType(AbstractJacksonHttpMessageConverter.java:351) ~[spring-web-7.0.2.jar:7.0.2]
+	... 125 common frames omitted
+
+2026-04-08T16:06:31.059+09:00 DEBUG 182719 --- [venueon-backend] [nio-8080-exec-2] org.hibernate.SQL                        : 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        events
+        (category_id, created_at, creator_id, description, end_date, has_session, is_hidden, is_online, location, max_attendees, price, purchase_type, start_date, status, thumbnail_url, title, type, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+2026-04-08T16:06:31.073+09:00 DEBUG 182719 --- [venueon-backend] [nio-8080-exec-2] org.hibernate.SQL                        : 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+Hibernate: 
+    insert 
+    into
+        event_sessions
+        (created_at, current_attendees, description, end_time, event_id, is_default, is_online, location, max_attendees, online_link, price, region_sido, region_sigungu, sort_order, start_time, title, updated_at) 
+    values
+        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+
+> Task :bootRun FAILED
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':bootRun'.
+> Process 'command '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'' finished with non-zero exit value 137 (this value may indicate that the process was terminated with the SIGKILL signal, which is often caused by the system running out of memory)
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights from a Build Scan (powered by Develocity).
+> Get more help at https://help.gradle.org.
+
+BUILD FAILED in 15m 40s
+4 actionable tasks: 1 executed, 3 up-to-date

--- a/backend/build_log.txt
+++ b/backend/build_log.txt
@@ -1,0 +1,13 @@
+> Task :compileJava
+> Task :processResources UP-TO-DATE
+> Task :classes
+> Task :resolveMainClassName
+> Task :bootJar
+> Task :jar
+> Task :assemble
+> Task :check
+> Task :build
+
+BUILD SUCCESSFUL in 5s
+5 actionable tasks: 4 executed, 1 up-to-date
+Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html

--- a/backend/src/main/java/com/venueon/common/config/DataInitializer.java
+++ b/backend/src/main/java/com/venueon/common/config/DataInitializer.java
@@ -3,9 +3,12 @@ package com.venueon.common.config;
 import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
 import com.venueon.category.adapter.out.persistence.repository.CategoryJpaRepository;
 import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
 import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
+import com.venueon.event.adapter.out.persistence.repository.EventSessionJpaRepository;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
 import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
 import com.venueon.order.domain.model.OrderStatus;
@@ -44,6 +47,7 @@ public class DataInitializer implements ApplicationRunner {
     private final HostProfileJpaRepository hostProfileRepository;
     private final CategoryJpaRepository categoryRepository;
     private final EventJpaRepository eventRepository;
+    private final EventSessionJpaRepository eventSessionRepository;
     private final OrderJpaRepository orderRepository;
     private final ReportJpaRepository reportRepository;
     private final RefundJpaRepository refundRepository;
@@ -64,13 +68,14 @@ public class DataInitializer implements ApplicationRunner {
         List<UserJpaEntity> hosts = createHosts();
         List<CategoryJpaEntity> categories = createCategories();
         List<EventJpaEntity> events = createEvents(hosts, categories);
+        createSessions(events);
         List<OrderJpaEntity> orders = createOrders(users, events);
         List<ReportJpaEntity> reports = createReports(users, events);
         List<RefundJpaEntity> refunds = createRefunds(users, orders);
 
         log.info("=== 개발용 초기 데이터 생성 완료 ===");
         log.info("Admin: 1명, User: {}명, Host: {}명", users.size(), hosts.size());
-        log.info("Category: {}개, Event: {}개", categories.size(), events.size());
+        log.info("Category: {}개, Event: {}개, Session: {}개", categories.size(), events.size(), eventSessionRepository.count());
         log.info("Order: {}개, Report: {}개, Refund: {}개", orders.size(), reports.size(), refunds.size());
     }
 
@@ -342,6 +347,98 @@ public class DataInitializer implements ApplicationRunner {
                         .endDate(LocalDateTime.of(2026, 6, 29, 18, 0))
                         .build()
         ));
+    }
+
+    /**
+     * 세션 생성 — 모든 이벤트에 기본 세션(is_default=true) 생성
+     * AI Bootcamp(index 0)와 Future Science Conference(index 9)는 hasSession=true로 다중 세션 예시
+     */
+    private void createSessions(List<EventJpaEntity> events) {
+        // 1) 모든 이벤트에 기본 세션 생성
+        for (EventJpaEntity event : events) {
+            eventSessionRepository.save(EventSessionJpaEntity.builder()
+                    .event(event)
+                    .title(event.getTitle())
+                    .description(event.getDescription())
+                    .sortOrder(0)
+                    .startTime(event.getStartDate())
+                    .endTime(event.getEndDate())
+                    .location(event.getLocation())
+                    .isOnline(event.isOnline())
+                    .price(event.getPrice())
+                    .maxAttendees(event.getMaxAttendees())
+                    .isDefault(true)
+                    .build());
+        }
+
+        // 2) AI & Cloud Bootcamp — 다중 세션 예시 (hasSession=true 이벤트)
+        EventJpaEntity bootcamp = events.get(0);
+        eventSessionRepository.save(EventSessionJpaEntity.builder()
+                .event(bootcamp)
+                .title("Day 1: AI 모델 배포")
+                .description("TensorFlow/PyTorch 모델을 AWS SageMaker에 배포하는 실습")
+                .sortOrder(1)
+                .startTime(LocalDateTime.of(2026, 4, 12, 10, 0))
+                .endTime(LocalDateTime.of(2026, 4, 12, 18, 0))
+                .location("서울 강남구 테헤란로 123 넥스트코드 교육센터")
+                .price(80000)
+                .maxAttendees(40)
+                .isDefault(false)
+                .build());
+        eventSessionRepository.save(EventSessionJpaEntity.builder()
+                .event(bootcamp)
+                .title("Day 2: 클라우드 인프라 설계")
+                .description("AWS/GCP 기반 마이크로서비스 아키텍처 설계 및 배포 파이프라인 구축")
+                .sortOrder(2)
+                .startTime(LocalDateTime.of(2026, 4, 13, 10, 0))
+                .endTime(LocalDateTime.of(2026, 4, 13, 18, 0))
+                .location("서울 강남구 테헤란로 123 넥스트코드 교육센터")
+                .price(80000)
+                .maxAttendees(40)
+                .isDefault(false)
+                .build());
+
+        // 3) Future Science Conference — 다중 세션 예시 (온라인 포함)
+        EventJpaEntity sciConf = events.get(9);
+        eventSessionRepository.save(EventSessionJpaEntity.builder()
+                .event(sciConf)
+                .title("세션 A: 생명공학의 미래")
+                .description("유전자 편집 기술과 맞춤형 의료의 최신 연구 성과 발표")
+                .sortOrder(1)
+                .startTime(LocalDateTime.of(2026, 6, 28, 10, 0))
+                .endTime(LocalDateTime.of(2026, 6, 28, 12, 0))
+                .location("서울 동대문구 회기로 85 국제회의실 A홀")
+                .price(0)
+                .maxAttendees(100)
+                .isDefault(false)
+                .build());
+        eventSessionRepository.save(EventSessionJpaEntity.builder()
+                .event(sciConf)
+                .title("세션 B: 양자컴퓨팅")
+                .description("양자 알고리즘과 오류 보정 기술의 최신 동향")
+                .sortOrder(2)
+                .startTime(LocalDateTime.of(2026, 6, 28, 14, 0))
+                .endTime(LocalDateTime.of(2026, 6, 28, 16, 0))
+                .isOnline(true)
+                .onlineLink("https://zoom.us/j/1234567890")
+                .price(0)
+                .maxAttendees(200)
+                .isDefault(false)
+                .build());
+        eventSessionRepository.save(EventSessionJpaEntity.builder()
+                .event(sciConf)
+                .title("세션 C: 우주과학")
+                .description("차세대 우주탐사 기술과 민간 우주산업의 전망")
+                .sortOrder(3)
+                .startTime(LocalDateTime.of(2026, 6, 29, 10, 0))
+                .endTime(LocalDateTime.of(2026, 6, 29, 12, 0))
+                .location("서울 동대문구 회기로 85 국제회의실 B홀")
+                .price(0)
+                .maxAttendees(100)
+                .isDefault(false)
+                .build());
+
+        log.info("세션 생성 완료: 기본 세션 {}개, 추가 세션 5개", events.size());
     }
 
     private List<OrderJpaEntity> createOrders(List<UserJpaEntity> users, List<EventJpaEntity> events) {

--- a/backend/src/main/java/com/venueon/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/venueon/common/exception/ErrorCode.java
@@ -23,7 +23,11 @@ public enum ErrorCode {
     ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인의 주문만 조회 가능합니다."),
     ALREADY_REFUNDED(HttpStatus.UNPROCESSABLE_ENTITY, "이미 환불 처리된 주문입니다."),
     REFUND_NOT_ALLOWED(HttpStatus.UNPROCESSABLE_ENTITY, "환불이 불가능한 주문 상태입니다."),
-    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "환불 처리 중 오류가 발생했습니다.");
+    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "환불 처리 중 오류가 발생했습니다."),
+    
+    // Session
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다."),
+    SESSION_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "기본 세션이거나 등록된 주문이 있어 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/venueon/common/exception/GlobalExceptionHandler.java
@@ -51,6 +51,6 @@ public class GlobalExceptionHandler {
         log.error("Exception: {}", e.getMessage(), e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
-                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+                .body(ApiResponse.error("서버 내부 오류: " + e.getClass().getSimpleName() + " - " + e.getMessage()));
     }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventCreateRequest.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventCreateRequest.java
@@ -2,10 +2,12 @@ package com.venueon.event.adapter.in.web.dto;
 
 import com.venueon.event.application.port.in.CreateEventUseCase.CreateEventCommand;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 이벤트 생성 요청 DTO
@@ -31,7 +33,11 @@ public record EventCreateRequest(
         LocalDateTime startDate,
 
         @NotNull(message = "종료일은 필수입니다.")
-        LocalDateTime endDate
+        LocalDateTime endDate,
+        
+        boolean hasSession,
+        PurchaseType purchaseType,
+        List<SessionCreateRequest> sessions
 ) {
     /**
      * DTO → UseCase Command 변환
@@ -49,7 +55,10 @@ public record EventCreateRequest(
                 maxAttendees,
                 thumbnailUrl,
                 startDate,
-                endDate
+                endDate,
+                hasSession,
+                purchaseType != null ? purchaseType : PurchaseType.SINGLE,
+                sessions
         );
     }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventDetailResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventDetailResponse.java
@@ -4,8 +4,11 @@ import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 
 import java.time.LocalDateTime;
+
+import java.util.List;
 
 /**
  * 이벤트 상세 응답 DTO (Host 정보 포함)
@@ -27,7 +30,10 @@ public record EventDetailResponse(
         Long creatorId,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        HostInfoDto host
+        boolean hasSession,
+        PurchaseType purchaseType,
+        HostInfoDto host,
+        List<SessionResponse> sessions
 ) {
     /**
      * Host 정보가 없는 경우 (fallback)
@@ -37,9 +43,16 @@ public record EventDetailResponse(
     }
 
     /**
-     * Host 정보를 포함한 생성
+     * Host 정보만 있는 경우 (sessions 없음, 과거 하위 호환)
      */
     public static EventDetailResponse from(Event event, HostInfo hostInfo) {
+        return from(event, hostInfo, null);
+    }
+
+    /**
+     * Host 정보 및 Sessions 포함한 생성
+     */
+    public static EventDetailResponse from(Event event, HostInfo hostInfo, List<SessionResponse> sessions) {
         HostInfoDto hostDto = null;
         if (hostInfo != null) {
             hostDto = new HostInfoDto(
@@ -68,7 +81,10 @@ public record EventDetailResponse(
                 event.getCreatorId(),
                 event.getCreatedAt(),
                 event.getUpdatedAt(),
-                hostDto
+                event.getHasSession(),
+                event.getPurchaseType(),
+                hostDto,
+                sessions == null ? List.of() : sessions
         );
     }
 

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
@@ -3,6 +3,7 @@ package com.venueon.event.adapter.in.web.dto;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 
 import java.time.LocalDateTime;
 
@@ -23,7 +24,9 @@ public record EventListResponse(
         LocalDateTime endDate,
         Long categoryId,
         Long creatorId,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        boolean hasSession,
+        PurchaseType purchaseType
 ) {
     public static EventListResponse from(Event event) {
         return new EventListResponse(
@@ -40,7 +43,9 @@ public record EventListResponse(
                 event.getEndDate(),
                 event.getCategoryId(),
                 event.getCreatorId(),
-                event.getCreatedAt()
+                event.getCreatedAt(),
+                event.getHasSession(),
+                event.getPurchaseType()
         );
     }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventUpdateRequest.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventUpdateRequest.java
@@ -2,6 +2,7 @@ package com.venueon.event.adapter.in.web.dto;
 
 import com.venueon.event.application.port.in.UpdateEventUseCase.UpdateEventCommand;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -27,7 +28,10 @@ public record EventUpdateRequest(
         LocalDateTime startDate,
 
         @NotNull(message = "종료일은 필수입니다.")
-        LocalDateTime endDate
+        LocalDateTime endDate,
+        
+        boolean hasSession,
+        PurchaseType purchaseType
 ) {
     public UpdateEventCommand toCommand(Long eventId, Long requesterId, String requesterRole) {
         return new UpdateEventCommand(
@@ -44,7 +48,9 @@ public record EventUpdateRequest(
                 maxAttendees,
                 thumbnailUrl,
                 startDate,
-                endDate
+                endDate,
+                hasSession,
+                purchaseType != null ? purchaseType : PurchaseType.SINGLE
         );
     }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionCreateRequest.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionCreateRequest.java
@@ -1,0 +1,17 @@
+package com.venueon.event.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+public record SessionCreateRequest(
+    @NotBlank(message = "세션 제목은 필수입니다.") String title,
+    String description,
+    int sortOrder,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    String location,
+    boolean isOnline,
+    String onlineLink,
+    int price,
+    int maxAttendees
+) {}

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionReorderRequest.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionReorderRequest.java
@@ -1,0 +1,8 @@
+package com.venueon.event.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record SessionReorderRequest(
+    @NotNull(message = "세션 ID 목록은 필수입니다.") List<Long> sessionIds
+) {}

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionResponse.java
@@ -1,0 +1,40 @@
+package com.venueon.event.adapter.in.web.dto;
+
+import com.venueon.event.domain.model.EventSession;
+import java.time.LocalDateTime;
+
+public record SessionResponse(
+    Long id,
+    Long eventId,
+    String title,
+    String description,
+    int sortOrder,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    String location,
+    boolean isOnline,
+    String onlineLink,
+    int price,
+    int maxAttendees,
+    int currentAttendees,
+    boolean isDefault
+) {
+    public static SessionResponse from(EventSession session) {
+        return new SessionResponse(
+            session.getId(),
+            session.getEventId(),
+            session.getTitle(),
+            session.getDescription(),
+            session.getSortOrder(),
+            session.getStartTime(),
+            session.getEndTime(),
+            session.getLocation(),
+            session.getIsOnline(),
+            session.getOnlineLink(),
+            session.getPrice(),
+            session.getMaxAttendees(),
+            session.getCurrentAttendees(),
+            session.getIsDefault()
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionUpdateRequest.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/SessionUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.venueon.event.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+public record SessionUpdateRequest(
+    @NotBlank(message = "세션 제목은 필수입니다.") String title,
+    String description,
+    int sortOrder,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    String location,
+    boolean isOnline,
+    String onlineLink,
+    int price,
+    int maxAttendees
+) {}

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventMapper.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventMapper.java
@@ -5,6 +5,7 @@ import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,8 @@ public class EventMapper {
                 entity.getThumbnailUrl(),
                 entity.getStartDate(),
                 entity.getEndDate(),
+                entity.isHasSession(),
+                entity.getPurchaseType(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt()
         );
@@ -69,6 +72,8 @@ public class EventMapper {
                 .thumbnailUrl(domain.getThumbnailUrl())
                 .startDate(domain.getStartDate())
                 .endDate(domain.getEndDate())
+                .hasSession(domain.getHasSession())
+                .purchaseType(domain.getPurchaseType())
                 .createdAt(domain.getCreatedAt())
                 .updatedAt(domain.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventSessionMapper.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventSessionMapper.java
@@ -1,0 +1,78 @@
+package com.venueon.event.adapter.out.persistence;
+
+import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
+import com.venueon.event.domain.model.EventSession;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * EventSessionJpaEntity ↔ EventSession 도메인 모델 변환
+ */
+@Component
+@RequiredArgsConstructor
+public class EventSessionMapper {
+
+    private final EntityManager entityManager;
+
+    /**
+     * JPA Entity → 도메인 모델
+     */
+    public EventSession toDomain(EventSessionJpaEntity entity) {
+        return new EventSession(
+                entity.getId(),
+                entity.getEvent() != null ? entity.getEvent().getId() : null,
+                entity.getTitle(),
+                entity.getDescription(),
+                entity.getSortOrder(),
+                entity.getStartTime(),
+                entity.getEndTime(),
+                entity.getLocation(),
+                entity.getRegionSido(),
+                entity.getRegionSigungu(),
+                entity.isOnline(),
+                entity.getOnlineLink(),
+                entity.getPrice(),
+                entity.getMaxAttendees(),
+                entity.getCurrentAttendees(),
+                entity.isDefault(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    /**
+     * 도메인 모델 → JPA Entity
+     */
+    public EventSessionJpaEntity toJpaEntity(EventSession domain, EventJpaEntity eventEntity) {
+        return EventSessionJpaEntity.builder()
+                .id(domain.getId())
+                .event(eventEntity)
+                .title(domain.getTitle())
+                .description(domain.getDescription())
+                .sortOrder(domain.getSortOrder())
+                .startTime(domain.getStartTime())
+                .endTime(domain.getEndTime())
+                .location(domain.getLocation())
+                .regionSido(domain.getRegionSido())
+                .regionSigungu(domain.getRegionSigungu())
+                .isOnline(domain.getIsOnline())
+                .onlineLink(domain.getOnlineLink())
+                .price(domain.getPrice())
+                .maxAttendees(domain.getMaxAttendees())
+                .currentAttendees(domain.getCurrentAttendees())
+                .isDefault(domain.getIsDefault())
+                .createdAt(domain.getCreatedAt())
+                .updatedAt(domain.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 도메인 모델 → JPA Entity (eventId로 참조)
+     */
+    public EventSessionJpaEntity toJpaEntity(EventSession domain, Long eventId) {
+        EventJpaEntity eventRef = entityManager.getReference(EventJpaEntity.class, eventId);
+        return toJpaEntity(domain, eventRef);
+    }
+}

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventSessionPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventSessionPersistenceAdapter.java
@@ -1,0 +1,59 @@
+package com.venueon.event.adapter.out.persistence;
+
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
+import com.venueon.event.adapter.out.persistence.repository.EventSessionJpaRepository;
+import com.venueon.event.application.port.out.SessionPort;
+import com.venueon.event.domain.model.EventSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * SessionPort 구현체 — JPA 연동
+ */
+@Component
+@RequiredArgsConstructor
+public class EventSessionPersistenceAdapter implements SessionPort {
+
+    private final EventSessionJpaRepository sessionRepository;
+    private final EventSessionMapper sessionMapper;
+
+    @Override
+    public EventSession save(EventSession session, Long eventId) {
+        EventSessionJpaEntity entity = sessionMapper.toJpaEntity(session, eventId);
+        EventSessionJpaEntity saved = sessionRepository.save(entity);
+        return sessionMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<EventSession> findById(Long id) {
+        return sessionRepository.findById(id)
+                .map(sessionMapper::toDomain);
+    }
+
+    @Override
+    public List<EventSession> findByEventId(Long eventId) {
+        return sessionRepository.findByEventIdOrderBySortOrder(eventId)
+                .stream()
+                .map(sessionMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        sessionRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<EventSession> findDefaultByEventId(Long eventId) {
+        return sessionRepository.findByEventIdAndIsDefaultTrue(eventId)
+                .map(sessionMapper::toDomain);
+    }
+
+    @Override
+    public int countByEventId(Long eventId) {
+        return sessionRepository.countByEventId(eventId);
+    }
+}

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventJpaEntity.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventJpaEntity.java
@@ -3,6 +3,7 @@ package com.venueon.event.adapter.out.persistence.entity;
 import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
 import com.venueon.event.domain.model.EventStatus;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -70,6 +71,15 @@ public class EventJpaEntity {
 
     @Column(name = "end_date")
     private LocalDateTime endDate;
+
+    @Column(name = "has_session")
+    @Builder.Default
+    private boolean hasSession = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purchase_type")
+    @Builder.Default
+    private PurchaseType purchaseType = PurchaseType.SINGLE;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventSessionJpaEntity.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/EventSessionJpaEntity.java
@@ -1,0 +1,86 @@
+package com.venueon.event.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * EventSession JPA Entity — DB 매핑 전용
+ * 도메인 로직은 EventSession.java에 위치
+ */
+@Entity
+@Table(name = "event_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class EventSessionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private EventJpaEntity event;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "sort_order")
+    @Builder.Default
+    private int sortOrder = 0;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    // 장소 / 온라인 (세션별 독립)
+    private String location;
+
+    @Column(name = "region_sido")
+    private String regionSido;
+
+    @Column(name = "region_sigungu")
+    private String regionSigungu;
+
+    @Column(name = "is_online")
+    @Builder.Default
+    private boolean isOnline = false;
+
+    @Column(name = "online_link")
+    private String onlineLink;
+
+    // 가격 / 정원 (구매 단위)
+    @Builder.Default
+    private int price = 0;
+
+    @Column(name = "max_attendees")
+    @Builder.Default
+    private int maxAttendees = 0;
+
+    @Column(name = "current_attendees")
+    @Builder.Default
+    private int currentAttendees = 0;
+
+    // 시스템 관리
+    @Column(name = "is_default")
+    @Builder.Default
+    private boolean isDefault = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/repository/EventSessionJpaRepository.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/repository/EventSessionJpaRepository.java
@@ -1,0 +1,16 @@
+package com.venueon.event.adapter.out.persistence.repository;
+
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EventSessionJpaRepository extends JpaRepository<EventSessionJpaEntity, Long> {
+
+    List<EventSessionJpaEntity> findByEventIdOrderBySortOrder(Long eventId);
+
+    Optional<EventSessionJpaEntity> findByEventIdAndIsDefaultTrue(Long eventId);
+
+    int countByEventId(Long eventId);
+}

--- a/backend/src/main/java/com/venueon/event/application/port/in/CreateEventUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/CreateEventUseCase.java
@@ -2,8 +2,11 @@ package com.venueon.event.application.port.in;
 
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
+import com.venueon.event.adapter.in.web.dto.SessionCreateRequest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 이벤트 생성 유스케이스 (Port-In)
@@ -27,6 +30,9 @@ public interface CreateEventUseCase {
             int maxAttendees,
             String thumbnailUrl,
             LocalDateTime startDate,
-            LocalDateTime endDate
+            LocalDateTime endDate,
+            boolean hasSession,
+            PurchaseType purchaseType,
+            List<SessionCreateRequest> sessions
     ) {}
 }

--- a/backend/src/main/java/com/venueon/event/application/port/in/CreateSessionUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/CreateSessionUseCase.java
@@ -1,0 +1,25 @@
+package com.venueon.event.application.port.in;
+
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.domain.model.EventSession;
+import java.time.LocalDateTime;
+
+public interface CreateSessionUseCase {
+    EventSession createSession(CreateSessionCommand command);
+    EventSession createDefaultSession(Event event);
+
+    record CreateSessionCommand(
+        Long eventId,
+        Long requesterId,
+        String title,
+        String description,
+        int sortOrder,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        String location,
+        boolean isOnline,
+        String onlineLink,
+        int price,
+        int maxAttendees
+    ) {}
+}

--- a/backend/src/main/java/com/venueon/event/application/port/in/DeleteSessionUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/DeleteSessionUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.event.application.port.in;
+
+public interface DeleteSessionUseCase {
+    void deleteSession(Long sessionId, Long eventId, Long requesterId);
+}

--- a/backend/src/main/java/com/venueon/event/application/port/in/GetSessionUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/GetSessionUseCase.java
@@ -1,0 +1,8 @@
+package com.venueon.event.application.port.in;
+
+import com.venueon.event.domain.model.EventSession;
+import java.util.List;
+
+public interface GetSessionUseCase {
+    List<EventSession> getSessionsByEventId(Long eventId);
+}

--- a/backend/src/main/java/com/venueon/event/application/port/in/ReorderSessionUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/ReorderSessionUseCase.java
@@ -1,0 +1,7 @@
+package com.venueon.event.application.port.in;
+
+import java.util.List;
+
+public interface ReorderSessionUseCase {
+    void reorderSessions(Long eventId, Long requesterId, List<Long> sessionIds);
+}

--- a/backend/src/main/java/com/venueon/event/application/port/in/UpdateEventUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/UpdateEventUseCase.java
@@ -2,6 +2,7 @@ package com.venueon.event.application.port.in;
 
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventType;
+import com.venueon.event.domain.model.PurchaseType;
 import java.time.LocalDateTime;
 
 public interface UpdateEventUseCase {
@@ -21,7 +22,9 @@ public interface UpdateEventUseCase {
             int maxAttendees,
             String thumbnailUrl,
             LocalDateTime startDate,
-            LocalDateTime endDate
+            LocalDateTime endDate,
+            boolean hasSession,
+            PurchaseType purchaseType
     ) {
     }
 }

--- a/backend/src/main/java/com/venueon/event/application/port/in/UpdateSessionUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/UpdateSessionUseCase.java
@@ -1,0 +1,24 @@
+package com.venueon.event.application.port.in;
+
+import com.venueon.event.domain.model.EventSession;
+import java.time.LocalDateTime;
+
+public interface UpdateSessionUseCase {
+    EventSession updateSession(UpdateSessionCommand command);
+
+    record UpdateSessionCommand(
+        Long sessionId,
+        Long eventId,
+        Long requesterId,
+        String title,
+        String description,
+        int sortOrder,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        String location,
+        boolean isOnline,
+        String onlineLink,
+        int price,
+        int maxAttendees
+    ) {}
+}

--- a/backend/src/main/java/com/venueon/event/application/port/out/SessionPort.java
+++ b/backend/src/main/java/com/venueon/event/application/port/out/SessionPort.java
@@ -1,0 +1,25 @@
+package com.venueon.event.application.port.out;
+
+import com.venueon.event.domain.model.EventSession;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 세션 저장/조회 인터페이스 (Port-Out)
+ * Service는 이 포트만 의존 — JPA 직접 참조 금지
+ */
+public interface SessionPort {
+
+    EventSession save(EventSession session, Long eventId);
+
+    Optional<EventSession> findById(Long id);
+
+    List<EventSession> findByEventId(Long eventId);
+
+    void deleteById(Long id);
+
+    Optional<EventSession> findDefaultByEventId(Long eventId);
+
+    int countByEventId(Long eventId);
+}

--- a/backend/src/main/java/com/venueon/event/application/service/EventCommandService.java
+++ b/backend/src/main/java/com/venueon/event/application/service/EventCommandService.java
@@ -5,6 +5,7 @@ import com.venueon.event.application.port.in.CreateEventUseCase;
 import com.venueon.event.application.port.in.DeleteEventUseCase;
 import com.venueon.event.application.port.in.UpdateEventStatusUseCase;
 import com.venueon.event.application.port.in.UpdateEventUseCase;
+import com.venueon.event.application.port.in.CreateSessionUseCase;
 import com.venueon.event.application.port.out.EventRepositoryPort;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
 public class EventCommandService implements CreateEventUseCase, UpdateEventStatusUseCase, DeleteEventUseCase, UpdateEventUseCase {
 
     private final EventRepositoryPort eventRepositoryPort;
+    private final CreateSessionUseCase createSessionUseCase;
 
     @Override
     public Event createEvent(CreateEventCommand command) {
@@ -41,13 +43,37 @@ public class EventCommandService implements CreateEventUseCase, UpdateEventStatu
                 command.thumbnailUrl(),
                 command.startDate(),
                 command.endDate(),
-                false,                      // hasSession (기본값 — Step2에서 확장)
-                PurchaseType.SINGLE,        // purchaseType (기본값 — Step2에서 확장)
+                command.hasSession(),
+                command.purchaseType(),
                 LocalDateTime.now(),        // createdAt
                 LocalDateTime.now()         // updatedAt
         );
 
-        return eventRepositoryPort.save(event);
+        Event savedEvent = eventRepositoryPort.save(event);
+
+        if (!savedEvent.getHasSession()) {
+            createSessionUseCase.createDefaultSession(savedEvent);
+        } else if (command.sessions() != null && !command.sessions().isEmpty()) {
+            command.sessions().forEach(sessionReq -> {
+                CreateSessionUseCase.CreateSessionCommand sessionCommand = new CreateSessionUseCase.CreateSessionCommand(
+                        savedEvent.getId(),
+                        command.creatorId(),
+                        sessionReq.title(),
+                        sessionReq.description(),
+                        sessionReq.sortOrder(),
+                        sessionReq.startTime(),
+                        sessionReq.endTime(),
+                        sessionReq.location(),
+                        sessionReq.isOnline(),
+                        sessionReq.onlineLink(),
+                        sessionReq.price(),
+                        sessionReq.maxAttendees()
+                );
+                createSessionUseCase.createSession(sessionCommand);
+            });
+        }
+
+        return savedEvent;
     }
 
     @Override
@@ -92,8 +118,8 @@ public class EventCommandService implements CreateEventUseCase, UpdateEventStatu
                 command.thumbnailUrl(),
                 command.startDate(),
                 command.endDate(),
-                event.getHasSession(),      // 기존값 유지 — Step2에서 확장
-                event.getPurchaseType()     // 기존값 유지 — Step2에서 확장
+                command.hasSession(),
+                command.purchaseType()
         );
 
         return eventRepositoryPort.save(event);

--- a/backend/src/main/java/com/venueon/event/application/service/EventCommandService.java
+++ b/backend/src/main/java/com/venueon/event/application/service/EventCommandService.java
@@ -8,6 +8,7 @@ import com.venueon.event.application.port.in.UpdateEventUseCase;
 import com.venueon.event.application.port.out.EventRepositoryPort;
 import com.venueon.event.domain.model.Event;
 import com.venueon.event.domain.model.EventStatus;
+import com.venueon.event.domain.model.PurchaseType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,8 @@ public class EventCommandService implements CreateEventUseCase, UpdateEventStatu
                 command.thumbnailUrl(),
                 command.startDate(),
                 command.endDate(),
+                false,                      // hasSession (기본값 — Step2에서 확장)
+                PurchaseType.SINGLE,        // purchaseType (기본값 — Step2에서 확장)
                 LocalDateTime.now(),        // createdAt
                 LocalDateTime.now()         // updatedAt
         );
@@ -88,7 +91,9 @@ public class EventCommandService implements CreateEventUseCase, UpdateEventStatu
                 command.maxAttendees(),
                 command.thumbnailUrl(),
                 command.startDate(),
-                command.endDate()
+                command.endDate(),
+                event.getHasSession(),      // 기존값 유지 — Step2에서 확장
+                event.getPurchaseType()     // 기존값 유지 — Step2에서 확장
         );
 
         return eventRepositoryPort.save(event);

--- a/backend/src/main/java/com/venueon/event/application/service/EventSessionService.java
+++ b/backend/src/main/java/com/venueon/event/application/service/EventSessionService.java
@@ -1,0 +1,183 @@
+package com.venueon.event.application.service;
+
+import com.venueon.common.annotation.UseCase;
+import com.venueon.common.exception.BusinessException;
+import com.venueon.common.exception.ErrorCode;
+import com.venueon.event.application.port.in.*;
+import com.venueon.event.application.port.out.EventRepositoryPort;
+import com.venueon.event.application.port.out.SessionPort;
+import com.venueon.event.domain.model.Event;
+import com.venueon.event.domain.model.EventSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class EventSessionService implements 
+        CreateSessionUseCase, UpdateSessionUseCase, DeleteSessionUseCase, 
+        GetSessionUseCase, ReorderSessionUseCase {
+
+    private final SessionPort sessionPort;
+    private final EventRepositoryPort eventRepositoryPort;
+
+    @Override
+    public EventSession createDefaultSession(Event event) {
+        EventSession session = new EventSession(
+                null,
+                event.getId(),
+                "기본 세션",
+                "이벤트 전체가 하나의 세션으로 판매됩니다.",
+                0,
+                event.getStartDate() != null ? event.getStartDate() : null,
+                event.getEndDate() != null ? event.getEndDate() : null,
+                event.getLocation() != null ? event.getLocation() : "미정",
+                null, // regionSido
+                null, // regionSigungu
+                event.getIsOnline(),
+                null, // onlineLink
+                event.getPrice(),
+                event.getMaxAttendees(),
+                0, // currentAttendees
+                true, // isDefault
+                null,
+                null
+        );
+        return sessionPort.save(session, event.getId());
+    }
+
+    @Override
+    public EventSession createSession(CreateSessionCommand command) {
+        Event event = getEventAndValidateOwner(command.eventId(), command.requesterId());
+
+        if (!event.getHasSession()) {
+            throw new IllegalStateException("세션 관리가 비활성화된 이벤트입니다.");
+        }
+
+        EventSession session = new EventSession(
+                null,
+                command.eventId(),
+                command.title(),
+                command.description(),
+                command.sortOrder(),
+                command.startTime(),
+                command.endTime(),
+                command.location(),
+                null, // regionSido
+                null, // regionSigungu
+                command.isOnline(),
+                command.onlineLink(),
+                command.price(),
+                command.maxAttendees(),
+                0, // currentAttendees
+                false, // isDefault
+                null,
+                null
+        );
+
+        return sessionPort.save(session, command.eventId());
+    }
+
+    @Override
+    public EventSession updateSession(UpdateSessionCommand command) {
+        getEventAndValidateOwner(command.eventId(), command.requesterId());
+
+        EventSession session = sessionPort.findById(command.sessionId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.getEventId().equals(command.eventId())) {
+            throw new IllegalArgumentException("세션이 해당 이벤트에 속하지 않습니다.");
+        }
+
+        session.updateDetails(
+                command.title(),
+                command.description(),
+                command.sortOrder(),
+                command.startTime(),
+                command.endTime(),
+                command.location(),
+                null, // regionSido
+                null, // regionSigungu
+                command.isOnline(),
+                command.onlineLink(),
+                command.price(),
+                command.maxAttendees()
+        );
+
+        return sessionPort.save(session, command.eventId());
+    }
+
+    @Override
+    public void deleteSession(Long sessionId, Long eventId, Long requesterId) {
+        getEventAndValidateOwner(eventId, requesterId);
+
+        EventSession session = sessionPort.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.getEventId().equals(eventId)) {
+            throw new IllegalArgumentException("세션이 해당 이벤트에 속하지 않습니다.");
+        }
+
+        if (session.getIsDefault()) {
+            throw new BusinessException(ErrorCode.SESSION_DELETE_NOT_ALLOWED);
+        }
+
+        // TODO: Step 3에서 Order 연동 시, 해당 세션에 주문이 있는지 검증 추가
+        // if (orderRepositoryPort.existsBySessionId(sessionId)) { throw Error }
+
+        sessionPort.deleteById(sessionId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EventSession> getSessionsByEventId(Long eventId) {
+        return sessionPort.findByEventId(eventId);
+    }
+
+    @Override
+    public void reorderSessions(Long eventId, Long requesterId, List<Long> sessionIds) {
+        getEventAndValidateOwner(eventId, requesterId);
+
+        List<EventSession> sessions = sessionPort.findByEventId(eventId);
+        Map<Long, EventSession> sessionMap = sessions.stream()
+                .collect(Collectors.toMap(EventSession::getId, Function.identity()));
+
+        int order = 1;
+        for (Long sessionId : sessionIds) {
+            EventSession session = sessionMap.get(sessionId);
+            if (session != null) {
+                session.updateDetails(
+                        session.getTitle(),
+                        session.getDescription(),
+                        order++,
+                        session.getStartTime(),
+                        session.getEndTime(),
+                        session.getLocation(),
+                        session.getRegionSido(),
+                        session.getRegionSigungu(),
+                        session.getIsOnline(),
+                        session.getOnlineLink(),
+                        session.getPrice(),
+                        session.getMaxAttendees()
+                );
+                sessionPort.save(session, eventId);
+            }
+        }
+    }
+
+    private Event getEventAndValidateOwner(Long eventId, Long requesterId) {
+        Event event = eventRepositoryPort.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
+
+        if (!event.isOwnedBy(requesterId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        return event;
+    }
+}

--- a/backend/src/main/java/com/venueon/event/domain/model/Event.java
+++ b/backend/src/main/java/com/venueon/event/domain/model/Event.java
@@ -22,6 +22,8 @@ public class Event {
     private String thumbnailUrl;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+    private boolean hasSession;
+    private PurchaseType purchaseType;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -31,6 +33,7 @@ public class Event {
                  EventType type, EventStatus status, String location, boolean isOnline,
                  int price, int maxAttendees, String thumbnailUrl,
                  LocalDateTime startDate, LocalDateTime endDate,
+                 boolean hasSession, PurchaseType purchaseType,
                  LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.creatorId = creatorId;
@@ -46,6 +49,8 @@ public class Event {
         this.thumbnailUrl = thumbnailUrl;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.hasSession = hasSession;
+        this.purchaseType = purchaseType != null ? purchaseType : PurchaseType.SINGLE;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -77,7 +82,8 @@ public class Event {
 
     public void updateDetails(Long categoryId, String title, String description, EventType type,
                               String location, boolean isOnline, int price, int maxAttendees,
-                              String thumbnailUrl, LocalDateTime startDate, LocalDateTime endDate) {
+                              String thumbnailUrl, LocalDateTime startDate, LocalDateTime endDate,
+                              boolean hasSession, PurchaseType purchaseType) {
         this.categoryId = categoryId;
         this.title = title;
         this.description = description;
@@ -91,6 +97,8 @@ public class Event {
         }
         this.startDate = startDate;
         this.endDate = endDate;
+        this.hasSession = hasSession;
+        this.purchaseType = purchaseType != null ? purchaseType : PurchaseType.SINGLE;
         this.updatedAt = LocalDateTime.now();
     }
 
@@ -114,6 +122,8 @@ public class Event {
     public String getThumbnailUrl() { return thumbnailUrl; }
     public LocalDateTime getStartDate() { return startDate; }
     public LocalDateTime getEndDate() { return endDate; }
+    public boolean getHasSession() { return hasSession; }
+    public PurchaseType getPurchaseType() { return purchaseType; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/venueon/event/domain/model/EventSession.java
+++ b/backend/src/main/java/com/venueon/event/domain/model/EventSession.java
@@ -1,0 +1,150 @@
+package com.venueon.event.domain.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * EventSession 도메인 모델 (순수 POJO)
+ * JPA/Spring 의존 없음 — 비즈니스 로직만 포함
+ *
+ * 세션은 이벤트의 구매 단위이며, 각각 독립적인 장소/가격/정원을 가진다.
+ * hasSession=false인 이벤트도 내부적으로 기본 세션(is_default=true) 1개가 자동 생성된다.
+ */
+public class EventSession {
+
+    private Long id;
+    private Long eventId;
+    private String title;
+    private String description;
+    private int sortOrder;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    // 장소 / 온라인 (세션별 독립)
+    private String location;
+    private String regionSido;
+    private String regionSigungu;
+    private boolean isOnline;
+    private String onlineLink;
+
+    // 가격 / 정원 (구매 단위)
+    private int price;
+    private int maxAttendees;
+    private int currentAttendees;
+
+    // 시스템 관리
+    private boolean isDefault;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    protected EventSession() {}
+
+    public EventSession(Long id, Long eventId, String title, String description, int sortOrder,
+                         LocalDateTime startTime, LocalDateTime endTime,
+                         String location, String regionSido, String regionSigungu,
+                         boolean isOnline, String onlineLink,
+                         int price, int maxAttendees, int currentAttendees,
+                         boolean isDefault,
+                         LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.eventId = eventId;
+        this.title = title;
+        this.description = description;
+        this.sortOrder = sortOrder;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.location = location;
+        this.regionSido = regionSido;
+        this.regionSigungu = regionSigungu;
+        this.isOnline = isOnline;
+        this.onlineLink = onlineLink;
+        this.price = price;
+        this.maxAttendees = maxAttendees;
+        this.currentAttendees = currentAttendees;
+        this.isDefault = isDefault;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // --- 비즈니스 행위 메서드 ---
+
+    /**
+     * 정원이 남아있는지 확인
+     */
+    public boolean isAvailable() {
+        return maxAttendees == 0 || currentAttendees < maxAttendees;
+    }
+
+    /**
+     * 요청 수량만큼 자리가 있는지 확인
+     */
+    public boolean hasCapacity(int quantity) {
+        return maxAttendees == 0 || (currentAttendees + quantity) <= maxAttendees;
+    }
+
+    /**
+     * 참석자 수 증가 (주문 확정 시)
+     */
+    public void incrementAttendees(int quantity) {
+        this.currentAttendees += quantity;
+    }
+
+    /**
+     * 참석자 수 감소 (주문 취소/환불 시)
+     */
+    public void decrementAttendees(int quantity) {
+        this.currentAttendees = Math.max(0, this.currentAttendees - quantity);
+    }
+
+    /**
+     * 세션 정보 수정
+     */
+    public void updateDetails(String title, String description, int sortOrder,
+                               LocalDateTime startTime, LocalDateTime endTime,
+                               String location, String regionSido, String regionSigungu,
+                               boolean isOnline, String onlineLink,
+                               int price, int maxAttendees) {
+        this.title = title;
+        this.description = description;
+        this.sortOrder = sortOrder;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.location = location;
+        this.regionSido = regionSido;
+        this.regionSigungu = regionSigungu;
+        this.isOnline = isOnline;
+        this.onlineLink = onlineLink;
+        this.price = price;
+        this.maxAttendees = maxAttendees;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 세션 정렬 순서 변경
+     */
+    public void changeSortOrder(int newOrder) {
+        this.sortOrder = newOrder;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // --- Getters ---
+
+    public Long getId() { return id; }
+    public Long getEventId() { return eventId; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public int getSortOrder() { return sortOrder; }
+    public LocalDateTime getStartTime() { return startTime; }
+    public LocalDateTime getEndTime() { return endTime; }
+    public String getLocation() { return location; }
+    public String getRegionSido() { return regionSido; }
+    public String getRegionSigungu() { return regionSigungu; }
+    public boolean getIsOnline() { return isOnline; }
+    public String getOnlineLink() { return onlineLink; }
+    public int getPrice() { return price; }
+    public int getMaxAttendees() { return maxAttendees; }
+    public int getCurrentAttendees() { return currentAttendees; }
+    public boolean getIsDefault() { return isDefault; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/venueon/event/domain/model/PurchaseType.java
+++ b/backend/src/main/java/com/venueon/event/domain/model/PurchaseType.java
@@ -1,0 +1,10 @@
+package com.venueon.event.domain.model;
+
+/**
+ * 구매 유형 enum
+ * SINGLE: 세션 하나만 선택 구매
+ * MULTI: 여러 세션 동시 구매 가능
+ */
+public enum PurchaseType {
+    SINGLE, MULTI
+}

--- a/backend/src/main/java/com/venueon/event/presentation/EventController.java
+++ b/backend/src/main/java/com/venueon/event/presentation/EventController.java
@@ -4,9 +4,12 @@ import com.venueon.common.dto.ApiResponse;
 import com.venueon.event.adapter.in.web.dto.EventDetailResponse;
 import com.venueon.event.adapter.in.web.dto.EventListResponse;
 import com.venueon.event.application.port.in.GetEventListUseCase.EventSearchCondition;
+import com.venueon.event.application.port.in.GetSessionUseCase;
 import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
 import com.venueon.event.application.service.EventQueryService;
+import com.venueon.event.adapter.in.web.dto.SessionResponse;
 import com.venueon.event.domain.model.Event;
+import com.venueon.event.domain.model.EventSession;
 import com.venueon.event.domain.model.EventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,6 +17,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 이벤트 공개 API — 누구나 접근 가능
@@ -24,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 public class EventController {
 
     private final EventQueryService eventQueryService;
+    private final GetSessionUseCase getSessionUseCase;
 
     /**
      * 이벤트 목록 조회 (검색/필터/페이징)
@@ -63,7 +70,13 @@ public class EventController {
     public ApiResponse<EventDetailResponse> getEventDetail(@PathVariable Long id) {
         Event event = eventQueryService.getEventById(id);
         HostInfo hostInfo = eventQueryService.getHostInfoByCreatorId(event.getCreatorId());
-        EventDetailResponse response = EventDetailResponse.from(event, hostInfo);
+        
+        List<SessionResponse> sessions = getSessionUseCase.getSessionsByEventId(id)
+                .stream()
+                .map(SessionResponse::from)
+                .collect(Collectors.toList());
+                
+        EventDetailResponse response = EventDetailResponse.from(event, hostInfo, sessions);
         return ApiResponse.success(response);
     }
 

--- a/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java
+++ b/backend/src/main/java/com/venueon/event/presentation/HostSessionController.java
@@ -1,0 +1,93 @@
+package com.venueon.event.presentation;
+
+import com.venueon.common.dto.ApiResponse;
+import com.venueon.event.adapter.in.web.dto.*;
+import com.venueon.event.application.port.in.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/host/events/{eventId}/sessions")
+@RequiredArgsConstructor
+public class HostSessionController {
+
+    private final CreateSessionUseCase createSessionUseCase;
+    private final UpdateSessionUseCase updateSessionUseCase;
+    private final DeleteSessionUseCase deleteSessionUseCase;
+    private final ReorderSessionUseCase reorderSessionUseCase;
+
+    @PostMapping
+    public ApiResponse<SessionResponse> createSession(
+            @PathVariable Long eventId,
+            @RequestHeader("X-User-Id") Long hostId,
+            @Valid @RequestBody SessionCreateRequest request) {
+
+        var command = new CreateSessionUseCase.CreateSessionCommand(
+                eventId,
+                hostId,
+                request.title(),
+                request.description(),
+                request.sortOrder(),
+                request.startTime(),
+                request.endTime(),
+                request.location(),
+                request.isOnline(),
+                request.onlineLink(),
+                request.price(),
+                request.maxAttendees()
+        );
+
+        var session = createSessionUseCase.createSession(command);
+        return ApiResponse.success(SessionResponse.from(session));
+    }
+
+    @PutMapping("/{sessionId}")
+    public ApiResponse<SessionResponse> updateSession(
+            @PathVariable Long eventId,
+            @PathVariable Long sessionId,
+            @RequestHeader("X-User-Id") Long hostId,
+            @Valid @RequestBody SessionUpdateRequest request) {
+
+        var command = new UpdateSessionUseCase.UpdateSessionCommand(
+                sessionId,
+                eventId,
+                hostId,
+                request.title(),
+                request.description(),
+                request.sortOrder(),
+                request.startTime(),
+                request.endTime(),
+                request.location(),
+                request.isOnline(),
+                request.onlineLink(),
+                request.price(),
+                request.maxAttendees()
+        );
+
+        var session = updateSessionUseCase.updateSession(command);
+        return ApiResponse.success(SessionResponse.from(session));
+    }
+
+    @DeleteMapping("/{sessionId}")
+    public ApiResponse<Void> deleteSession(
+            @PathVariable Long eventId,
+            @PathVariable Long sessionId,
+            @RequestHeader("X-User-Id") Long hostId) {
+
+        deleteSessionUseCase.deleteSession(sessionId, eventId, hostId);
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/reorder")
+    public ApiResponse<Void> reorderSessions(
+            @PathVariable Long eventId,
+            @RequestHeader("X-User-Id") Long hostId,
+            @Valid @RequestBody SessionReorderRequest request) {
+
+        reorderSessionUseCase.reorderSessions(eventId, hostId, request.sessionIds());
+        return ApiResponse.success(null);
+    }
+}

--- a/backend/src/main/java/com/venueon/event/presentation/SessionController.java
+++ b/backend/src/main/java/com/venueon/event/presentation/SessionController.java
@@ -1,0 +1,30 @@
+package com.venueon.event.presentation;
+
+import com.venueon.common.dto.ApiResponse;
+import com.venueon.event.adapter.in.web.dto.SessionResponse;
+import com.venueon.event.application.port.in.GetSessionUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/events/{eventId}/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final GetSessionUseCase getSessionUseCase;
+
+    @GetMapping
+    public ApiResponse<List<SessionResponse>> getSessionsByEventId(@PathVariable Long eventId) {
+        var sessions = getSessionUseCase.getSessionsByEventId(eventId);
+        var response = sessions.stream()
+                .map(SessionResponse::from)
+                .toList();
+
+        return ApiResponse.success(response);
+    }
+}

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateOrderRequest.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateOrderRequest.java
@@ -13,6 +13,8 @@ public class CreateOrderRequest {
     @NotNull(message = "이벤트 ID는 필수입니다.")
     private Long eventId;
 
+    private Long sessionId;
+
     @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
     private int quantity = 1;
 

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderDetailResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderDetailResponse.java
@@ -23,4 +23,5 @@ public class OrderDetailResponse {
     private String organizer;
     private String location;
     private LocalDateTime eventStartDate;
+    private String eventStatus;
 }

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -11,6 +11,8 @@ import com.venueon.order.domain.model.Order;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
+import com.venueon.event.adapter.out.persistence.repository.EventSessionJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,7 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
     private final OrderJpaRepository orderJpaRepository;
     private final EventJpaRepository eventJpaRepository;
     private final UserJpaRepository userJpaRepository;
+    private final EventSessionJpaRepository eventSessionJpaRepository;
 
     @Override
     public Order save(Order order) {
@@ -39,9 +42,16 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
             EventJpaEntity event = eventJpaRepository.findById(order.getEventId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
 
+            EventSessionJpaEntity session = null;
+            if (order.getSessionId() != null) {
+                session = eventSessionJpaRepository.findById(order.getSessionId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND)); // Or Session NotFound
+            }
+
             entity = OrderJpaEntity.builder()
                     .user(user)
                     .event(event)
+                    .session(session)
                     .status(order.getStatus())
                     .quantity(order.getQuantity())
                     .amount(order.getAmount())
@@ -91,6 +101,19 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
     }
 
     @Override
+    public long countBySessionIdAndStatusIn(Long sessionId, List<OrderStatus> statuses) {
+        return orderJpaRepository.countBySessionIdAndStatusIn(sessionId, statuses);
+    }
+
+    @Override
+    public List<Order> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses) {
+        return orderJpaRepository.findByUserIdAndSessionIdAndStatusIn(userId, sessionId, statuses)
+                .stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Page<Order> findByUserId(Long userId, Pageable pageable) {
         return orderJpaRepository.findByUserId(userId, pageable).map(this::toDomain);
     }
@@ -106,6 +129,7 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
                 entity.getId(),
                 entity.getUser().getId(),
                 entity.getEvent().getId(),
+                entity.getSession() != null ? entity.getSession().getId() : null,
                 entity.getStatus(),
                 entity.getQuantity(),
                 entity.getAmount(),

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
@@ -1,6 +1,7 @@
 package com.venueon.order.adapter.out.persistence.entity;
 
 import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
@@ -28,6 +29,10 @@ public class OrderJpaEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
     private EventJpaEntity event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private EventSessionJpaEntity session;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -71,5 +76,9 @@ public class OrderJpaEntity {
 
     public void updateStatus(OrderStatus newStatus) {
         this.status = newStatus;
+    }
+
+    public EventSessionJpaEntity getSession() {
+        return session;
     }
 }

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -23,10 +23,14 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     List<OrderJpaEntity> findByUserIdAndEventId(Long userId, Long eventId);
 
     long countByEventIdAndStatusIn(Long eventId, List<OrderStatus> statuses);
+    
+    long countBySessionIdAndStatusIn(Long sessionId, List<OrderStatus> statuses);
 
     java.util.Optional<OrderJpaEntity> findByTossOrderId(String tossOrderId);
 
     List<OrderJpaEntity> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
+    
+    List<OrderJpaEntity> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);
 
     Page<OrderJpaEntity> findByEventIdIn(List<Long> eventIds, Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/order/application/port/in/RequestRefundUseCase.java
+++ b/backend/src/main/java/com/venueon/order/application/port/in/RequestRefundUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.order.application.port.in;
+
+public interface RequestRefundUseCase {
+    void requestRefund(Long orderId, Long userId, int amount, String reason);
+}

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -18,7 +18,11 @@ public interface OrderRepositoryPort {
     
     List<Order> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
     
+    List<Order> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);
+    
     long countByEventIdAndStatusIn(Long eventId, List<OrderStatus> statuses);
+    
+    long countBySessionIdAndStatusIn(Long sessionId, List<OrderStatus> statuses);
     
     Page<Order> findByUserId(Long userId, Pageable pageable);
 

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -11,6 +11,7 @@ import com.venueon.order.application.port.out.RefundSavePort;
 import com.venueon.order.domain.model.Order;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.order.adapter.in.web.dto.*;
+import com.venueon.order.application.port.in.RequestRefundUseCase;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -271,11 +272,11 @@ public class OrderService {
     private OrderDetailResponse toOrderDetailResponse(Order order) {
         // Event Title 및 상세 정보를 가져오기 위해 EventJpaRepository 호출 필요
         EventJpaEntity event = eventRepository.findById(order.getEventId()).orElse(null);
-        
+
         String eventTitle = event != null ? event.getTitle() : "알 수 없는 이벤트";
         String organizer = event != null ? "호스트 " + event.getCreator().getId() : "알 수 없는 호스트";
         String location = event != null ? (event.isOnline() ? "온라인" : event.getLocation()) : "-";
-        
+
         return OrderDetailResponse.builder()
                 .orderId(order.getId())
                 .eventId(order.getEventId())
@@ -289,6 +290,7 @@ public class OrderService {
                 .organizer(organizer)
                 .location(location)
                 .eventStartDate(event != null ? event.getStartDate() : null)
+                .eventStatus(event != null ? event.getStatus().name() : "DRAFT")
                 .build();
     }
 
@@ -310,7 +312,7 @@ public class OrderService {
 
         order.requestRefund();
         orderRepository.save(order);
-        
+
         requestRefundUseCase.requestRefund(orderId, userId, order.getAmount(), reason);
     }
 }

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -5,6 +5,7 @@ import com.venueon.common.exception.ErrorCode;
 import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
 import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
 import com.venueon.order.adapter.out.payment.TossPaymentClient;
+import com.venueon.order.application.port.in.RequestRefundUseCase;
 import com.venueon.order.application.port.out.OrderRepositoryPort;
 import com.venueon.order.application.port.out.RefundSavePort;
 import com.venueon.order.domain.model.Order;
@@ -35,12 +36,13 @@ public class OrderService {
     private final UserJpaRepository userRepository;
     private final TossPaymentClient tossPaymentClient;
     private final RefundSavePort refundSavePort;
+    private final RequestRefundUseCase requestRefundUseCase;
 
     @Value("${toss.client-key}")
     private String tossClientKey;
 
     /**
-     * 단건 주문 생성 (PENDING상태)
+     * 단건 주문 생성 (PENDING 상태)
      * API 스펙: POST /orders
      */
     @Transactional

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -12,6 +12,8 @@ import com.venueon.order.domain.model.Order;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.order.adapter.in.web.dto.*;
 import com.venueon.order.application.port.in.RequestRefundUseCase;
+import com.venueon.event.application.port.out.SessionPort;
+import com.venueon.event.domain.model.EventSession;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,7 @@ public class OrderService {
     private final TossPaymentClient tossPaymentClient;
     private final RefundSavePort refundSavePort;
     private final RequestRefundUseCase requestRefundUseCase;
+    private final SessionPort sessionPort;
 
     @Value("${toss.client-key}")
     private String tossClientKey;
@@ -56,33 +59,55 @@ public class OrderService {
         UserJpaEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
 
-        // 3. 중복 주문 검증 (PAID, REGISTERED 상태인 완료된 주문만)
-        List<Order> existingOrders = orderRepository.findByUserIdAndEventIdAndStatusIn(
-                userId, request.getEventId(),
+        // 3. 세션 조회 및 검증
+        EventSession session = null;
+        if (request.getSessionId() != null) {
+            session = sessionPort.findById(request.getSessionId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND)); // Session Not Found
+            if (!session.getEventId().equals(event.getId())) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        } else {
+            if (event.isHasSession()) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 세션이 필수인 이벤트
+            }
+            session = sessionPort.findDefaultByEventId(event.getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        }
+
+        // 3-2. 중복 주문 검증 (세션 기준)
+        List<Order> existingOrders = orderRepository.findByUserIdAndSessionIdAndStatusIn(
+                userId, session.getId(),
                 List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
         if (!existingOrders.isEmpty()) {
             throw new BusinessException(ErrorCode.ORDER_ALREADY_EXISTS);
         }
 
-        // 4. 정원 초과 검증
-        long currentAttendees = orderRepository.countByEventIdAndStatusIn(
-                request.getEventId(),
+        // 4. 정원 초과 검증 (세션 기준)
+        long currentAttendees = orderRepository.countBySessionIdAndStatusIn(
+                session.getId(),
                 List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
-        if (event.getMaxAttendees() > 0 && currentAttendees + request.getQuantity() > event.getMaxAttendees()) {
+        if (session.getMaxAttendees() > 0 && currentAttendees + request.getQuantity() > session.getMaxAttendees()) {
             throw new BusinessException(ErrorCode.EVENT_FULL);
         }
 
-        // 5. 주문 금액 계산
-        int totalAmount = event.getPrice() * request.getQuantity();
+        // 5. 주문 금액 계산 (세션 금액 기준)
+        int totalAmount = session.getPrice() * request.getQuantity();
 
-        // 6. 순수 도메인 모델 생성 및 초기 저장 (ID 발급용)
-        Order pendingOrder = Order.createPending(userId, request.getEventId(), request.getQuantity(), totalAmount,
+        // 6. 순수 도메인 모델 생성 및 초기 저장
+        Order pendingOrder = Order.createPending(userId, request.getEventId(), session.getId(), request.getQuantity(), totalAmount,
                 request.getPaymentMethod());
         Order savedOrder = orderRepository.save(pendingOrder);
 
-        // 7. tossOrderId 발급 및 도메인 객체 업데이트
+        // 7. tossOrderId 발급 및 무료 승인 처리
         String tossOrderId = "venueon_order_" + savedOrder.getId() + "_" + System.currentTimeMillis();
         savedOrder.updateTossOrderId(tossOrderId);
+        
+        // 무료 주문인 경우 즉시 승인 및 참석자 증가
+        if (savedOrder.getStatus() == OrderStatus.REGISTERED) {
+            session.incrementAttendees(savedOrder.getQuantity());
+            sessionPort.save(session, event.getId());
+        }
 
         // 8. 변경된(tossOrderId가 추가된) 도메인 모델 다시 저장
         savedOrder = orderRepository.save(savedOrder);
@@ -128,7 +153,17 @@ public class OrderService {
         // 4. 도메인 모델 상태 업데이트 (PENDING → PAID)
         order.confirmPayment(request.getPaymentKey());
 
-        // 5. 도메인 모델 저장
+        // 5. 세션 참석자 업데이트
+        int qty = order.getQuantity();
+        Long evtId = order.getEventId();
+        if (order.getSessionId() != null) {
+            sessionPort.findById(order.getSessionId()).ifPresent(session -> {
+                session.incrementAttendees(qty);
+                sessionPort.save(session, evtId);
+            });
+        }
+
+        // 6. 도메인 모델 저장
         order = orderRepository.save(order);
 
         log.info("결제 승인 완료: orderId={}, paymentKey={}", orderId, request.getPaymentKey());
@@ -184,6 +219,17 @@ public class OrderService {
         if ("DONE".equals(status) && order.getStatus() == OrderStatus.PENDING) {
             order.confirmPayment(paymentKey);
             orderRepository.save(order); // 변경 상태 저장
+            
+            // 참석자 업데이트
+            int qty = order.getQuantity();
+            Long evtId = order.getEventId();
+            if (order.getSessionId() != null) {
+                sessionPort.findById(order.getSessionId()).ifPresent(session -> {
+                    session.incrementAttendees(qty);
+                    sessionPort.save(session, evtId);
+                });
+            }
+            
             log.info("Webhook: 결제 확인 완료. orderId={}", order.getId());
         }
     }
@@ -246,6 +292,16 @@ public class OrderService {
         // 6. 도메인 상태 변경
         order.refund();
         orderRepository.save(order);
+        
+        // 세션 참석자 감소
+        int qty = order.getQuantity();
+        Long evtId = order.getEventId();
+        if (order.getSessionId() != null) {
+            sessionPort.findById(order.getSessionId()).ifPresent(session -> {
+                session.decrementAttendees(qty);
+                sessionPort.save(session, evtId);
+            });
+        }
 
         // 7. refunds 테이블에 환불 이력 저장
         refundSavePort.saveRefundRecord(orderId, userId, order.getAmount(), reason);

--- a/backend/src/main/java/com/venueon/order/application/service/RefundCommandService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/RefundCommandService.java
@@ -1,4 +1,4 @@
-package com.venueon.report.application.service;
+package com.venueon.order.application.service;
 
 import com.venueon.common.annotation.UseCase;
 import com.venueon.common.exception.BusinessException;
@@ -7,7 +7,7 @@ import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
 import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
 import com.venueon.report.adapter.out.persistence.entity.RefundJpaEntity;
 import com.venueon.report.adapter.out.persistence.repository.RefundJpaRepository;
-import com.venueon.report.application.port.in.RequestRefundUseCase;
+import com.venueon.order.application.port.in.RequestRefundUseCase;
 import com.venueon.report.domain.model.RefundStatus;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
 import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;

--- a/backend/src/main/java/com/venueon/order/domain/model/Order.java
+++ b/backend/src/main/java/com/venueon/order/domain/model/Order.java
@@ -10,6 +10,7 @@ public class Order {
     private Long id;
     private Long userId;
     private Long eventId;
+    private Long sessionId;
     private OrderStatus status;
     private int quantity;
     private int amount;
@@ -21,13 +22,14 @@ public class Order {
 
     protected Order() {}
 
-    public Order(Long id, Long userId, Long eventId, OrderStatus status,
+    public Order(Long id, Long userId, Long eventId, Long sessionId, OrderStatus status,
                  int quantity, int amount, String paymentMethod,
                  String tossPaymentKey, String tossOrderId,
                  LocalDateTime orderedAt, LocalDateTime paidAt) {
         this.id = id;
         this.userId = userId;
         this.eventId = eventId;
+        this.sessionId = sessionId;
         this.status = status;
         this.quantity = quantity;
         this.amount = amount;
@@ -38,9 +40,9 @@ public class Order {
         this.paidAt = paidAt;
     }
 
-    public static Order createPending(Long userId, Long eventId, int quantity, int amount, String paymentMethod) {
+    public static Order createPending(Long userId, Long eventId, Long sessionId, int quantity, int amount, String paymentMethod) {
         OrderStatus initialStatus = (amount == 0) ? OrderStatus.REGISTERED : OrderStatus.PENDING;
-        return new Order(null, userId, eventId, initialStatus, quantity, amount, paymentMethod, null, null, LocalDateTime.now(), null);
+        return new Order(null, userId, eventId, sessionId, initialStatus, quantity, amount, paymentMethod, null, null, LocalDateTime.now(), null);
     }
 
     // --- 비즈니스 행위 ---
@@ -89,6 +91,7 @@ public class Order {
     public Long getId() { return id; }
     public Long getUserId() { return userId; }
     public Long getEventId() { return eventId; }
+    public Long getSessionId() { return sessionId; }
     public OrderStatus getStatus() { return status; }
     public int getQuantity() { return quantity; }
     public int getAmount() { return amount; }

--- a/backend/src/main/java/com/venueon/report/application/port/in/RequestRefundUseCase.java
+++ b/backend/src/main/java/com/venueon/report/application/port/in/RequestRefundUseCase.java
@@ -1,5 +1,0 @@
-package com.venueon.report.application.port.in;
-
-public interface RequestRefundUseCase {
-    void requestRefund(Long orderId, Long userId, int amount, String reason);
-}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,7 +9,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.config.import=optional:file:../.env[.properties]
 
 # JPA
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 

--- a/docs/세션_CRUD_구현_계획서.md
+++ b/docs/세션_CRUD_구현_계획서.md
@@ -1,0 +1,814 @@
+# 📋 이벤트 세션 CRUD 구현 계획서
+
+> **작성일:** 2026-04-08  
+> **기반:** 현재 코드베이스 분석 + ERD v3 + API 스펙 v5.1  
+> **목표:** 세션을 이벤트의 핵심 구매 단위로 격상하는 설계 및 구현  
+> **향후 확장:** 세션 패키지(묶음 상품) 기능까지 고려한 구조 설계
+
+---
+
+## 📌 목차
+
+1. [현재 상태 분석](#1-현재-상태-분석)
+2. [핵심 설계 원칙](#2-핵심-설계-원칙)
+3. [확정된 설계 결정](#3-확정된-설계-결정)
+4. [DB 스키마 변경](#4-db-스키마-변경)
+5. [백엔드 구현 계획](#5-백엔드-구현-계획)
+6. [프론트엔드 구현 계획](#6-프론트엔드-구현-계획)
+7. [향후 패키지 기능 설계](#7-향후-패키지-기능-설계)
+8. [구현 로드맵](#8-구현-로드맵)
+9. [검증 체크리스트](#9-검증-체크리스트)
+
+---
+
+## 1. 현재 상태 분석
+
+### 이미 존재하는 것
+
+| 항목 | 상태 | 위치 |
+|------|------|------|
+| ERD `EVENT_SESSION` 테이블 설계 | ✅ 문서화됨 | `docs/ERD_설계서_v3.md` |
+| API 스펙 (#36~#40) 세션 CRUD | ✅ 문서화됨 | `docs/VenueOn_최종_API_스펙_v5.1.md` |
+| Event 도메인 모델 (순수 POJO) | ✅ 구현됨 | `event/domain/model/Event.java` |
+| Event JPA Entity | ✅ 구현됨 | `event/adapter/out/persistence/entity/EventJpaEntity.java` |
+| Event CRUD (Host Controller) | ✅ 구현됨 | `event/presentation/HostEventController.java` |
+| Event 생성/수정 DTO | ✅ 구현됨 | `event/adapter/in/web/dto/EventCreateRequest.java` |
+| EventForm (Frontend) | ✅ 구현됨 | `frontend/src/app/events/new/_components/EventForm.tsx` |
+| Order 도메인 모델 | ✅ 구현됨 | `order/domain/model/Order.java` |
+
+### 아직 없는 것 (이번에 구현)
+
+| 항목 | 비고 |
+|------|------|
+| `EventSession` 도메인 모델 | 순수 POJO |
+| `EventSessionJpaEntity` | JPA 매핑 |
+| Session CRUD API 전체 (Controller → Service → Repository) | 5개 엔드포인트 |
+| Event에 `hasSession` / `purchaseType` 필드 | 도메인 + JPA + DTO 모두 |
+| Session에 지역/온라인링크/가격/정원 필드 | ERD 확장 필요 |
+| Order/Cart에 `sessionId` FK | 구매 단위 변경 |
+| Frontend 세션 관리 탭 UI | EventForm 확장 |
+| Frontend BFF 세션 API 라우트 | Next.js API Routes |
+
+---
+
+## 2. 핵심 설계 원칙
+
+### 세션 = 구매 단위
+
+현재:
+```
+Event 1 ←→ N Order (이벤트 전체를 구매)
+```
+
+변경 후:
+```
+Event 1 ←→ N Session ←→ N Order (세션 단위로 구매)
+    └── hasSession=false → 시스템이 기본 세션 1개 자동 생성
+```
+
+### 세션 없는 이벤트 = 자동 1:1 매칭
+
+```
+이벤트 생성
+  ├── hasSession = true  → 호스트가 세션 직접 생성 (1~N개)
+  └── hasSession = false → 시스템이 기본 세션 1개 자동 생성 (is_default=true)
+                            → 이벤트의 가격/날짜/장소를 그대로 복사
+```
+
+**핵심:** `hasSession=false`인 이벤트도 내부적으로는 세션 1개가 존재합니다.  
+Order, Cart, Wishlist 등 모든 곳에서 **항상 세션 ID를 참조**하므로  
+나중에 세션을 추가하거나 패키지를 만들 때 DB 스키마 변경이 필요 없습니다.
+
+---
+
+## 3. 확정된 설계 결정
+
+| # | 결정 사항 | 결정 | 근거 |
+|---|----------|------|------|
+| 1 | 세션별 가격 vs 이벤트 전체 가격 | **세션별 개별 가격** | Event.price는 `hasSession=false`일 때 기본 세션 가격으로만 사용. 세션별로 다른 가치를 반영 가능 |
+| 2 | 세션별 온/오프라인 독립 여부 | **세션별 독립** | 하나의 이벤트 내 하이브리드 구성 가능 (세션1: 오프라인 강남, 세션2: 온라인 Zoom) |
+| 3 | 주문 있는 이벤트의 `hasSession` 전환 | **기본 세션 유지 + 추가만 허용** | 기존 기본 세션(is_default=true)의 주문은 유지하고 새 세션만 추가 가능 |
+| 4 | 복수 세션 구매 시 Order 구조 | **세션마다 개별 Order** | 기존 Order 구조 최소 변경. `session_id` FK만 추가 |
+
+---
+
+## 4. DB 스키마 변경
+
+### 4-1. EVENT_SESSION 테이블 (확장)
+
+기존 ERD의 EVENT_SESSION 대비 구매 단위 역할을 위한 필드 추가:
+
+```sql
+CREATE TABLE event_session (
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+    event_id        BIGINT NOT NULL,                    -- → EVENT.id (FK)
+    
+    -- 기본 정보
+    title           VARCHAR(200) NOT NULL,              -- 세션 제목
+    description     TEXT,                                -- 세션 설명
+    sort_order      INT DEFAULT 0,                      -- 정렬 순서
+    
+    -- 시간
+    start_time      TIMESTAMP,                          -- 세션 시작 시간
+    end_time        TIMESTAMP,                          -- 세션 종료 시간
+    
+    -- 🆕 장소 / 온라인 (세션별 독립)
+    location        VARCHAR(255),                       -- 세션별 장소 (지역/강의장)
+    region_sido     VARCHAR(20),                        -- 시/도
+    region_sigungu  VARCHAR(30),                        -- 시/군/구
+    is_online       BOOLEAN DEFAULT FALSE,              -- 세션별 온/오프라인
+    online_link     VARCHAR(500),                       -- 온라인 세션 URL (Zoom, Teams 등)
+    
+    -- 🆕 가격 / 정원 (구매 단위)
+    price           INT DEFAULT 0,                      -- 세션별 가격
+    max_attendees   INT DEFAULT 0,                      -- 세션별 정원
+    current_attendees INT DEFAULT 0,                    -- 현재 등록 인원
+    
+    -- 🆕 시스템 관리
+    is_default      BOOLEAN DEFAULT FALSE,              -- 자동 생성된 기본 세션 여부
+    
+    -- 타임스탬프
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    
+    CONSTRAINT fk_session_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+);
+```
+
+### 4-2. EVENT 테이블 필드 추가
+
+```sql
+ALTER TABLE events ADD COLUMN has_session    BOOLEAN DEFAULT FALSE;  -- 세션 사용 여부
+ALTER TABLE events ADD COLUMN purchase_type  VARCHAR(10) DEFAULT 'SINGLE';  -- SINGLE/MULTI
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `has_session` | BOOLEAN | false면 기본 세션 자동 생성, true면 호스트가 세션 직접 관리 |
+| `purchase_type` | VARCHAR(10) | `SINGLE` = 세션 1개만 구매 / `MULTI` = 여러 세션 동시 구매 |
+
+### 4-3. ORDER 테이블 필드 추가
+
+```sql
+ALTER TABLE orders ADD COLUMN session_id BIGINT;  -- → EVENT_SESSION.id (FK)
+ALTER TABLE orders ADD CONSTRAINT fk_order_session 
+    FOREIGN KEY (session_id) REFERENCES event_session(id);
+```
+
+### 4-4. CART 테이블 필드 추가
+
+```sql
+ALTER TABLE cart ADD COLUMN session_id BIGINT;  -- → EVENT_SESSION.id (FK)
+ALTER TABLE cart ADD CONSTRAINT fk_cart_session 
+    FOREIGN KEY (session_id) REFERENCES event_session(id);
+```
+
+### 4-5. 변경 후 ERD 관계
+
+```
+EVENT 1 ──→ N EVENT_SESSION  (이벤트 → 세션들)
+EVENT_SESSION 1 ──→ N ORDER   (세션 → 주문들)
+EVENT_SESSION 1 ──→ N CART    (세션 → 장바구니)
+```
+
+---
+
+## 5. 백엔드 구현 계획
+
+### Phase 1: 도메인 모델 + JPA Entity
+
+#### 1-1. `PurchaseType` Enum
+```
+event/domain/model/PurchaseType.java
+```
+```java
+public enum PurchaseType {
+    SINGLE,  // 세션 하나만 선택 구매
+    MULTI    // 여러 세션 동시 구매 가능
+}
+```
+
+#### 1-2. `EventSession` 도메인 모델
+```
+event/domain/model/EventSession.java
+```
+순수 POJO — 비즈니스 로직 포함:
+- `isAvailable()` — 정원 체크 (currentAttendees < maxAttendees)
+- `hasCapacity(int quantity)` — 수량만큼 자리 있는지
+- `isDefault()` — 자동 생성 기본 세션 여부
+- `incrementAttendees()` / `decrementAttendees()` — 참석자 수 관리
+- `updateDetails(...)` — 세션 정보 수정
+
+#### 1-3. `EventSessionJpaEntity`
+```
+event/adapter/out/persistence/entity/EventSessionJpaEntity.java
+```
+JPA 매핑:
+- `@ManyToOne` → `EventJpaEntity`
+- 모든 새 필드 포함 (location, region_sido, region_sigungu, is_online, online_link, price, max_attendees, current_attendees, is_default)
+
+#### 1-4. `Event` 도메인 / JPA 필드 추가
+- `hasSession: boolean`
+- `purchaseType: PurchaseType`
+- 도메인 모델, JPA Entity, Mapper 모두 업데이트
+
+### Phase 2: Repository + Port
+
+#### 2-1. Repository
+```
+event/adapter/out/persistence/repository/EventSessionJpaRepository.java
+```
+```java
+List<EventSessionJpaEntity> findByEventIdOrderBySortOrder(Long eventId);
+Optional<EventSessionJpaEntity> findByEventIdAndIsDefaultTrue(Long eventId);
+int countByEventId(Long eventId);
+```
+
+#### 2-2. UseCase Port (in)
+```
+event/application/port/in/
+  ├── CreateSessionUseCase.java
+  ├── UpdateSessionUseCase.java
+  ├── DeleteSessionUseCase.java
+  ├── GetSessionUseCase.java
+  └── ReorderSessionUseCase.java
+```
+
+#### 2-3. Persistence Port (out)
+```
+event/application/port/out/SessionPort.java
+```
+```java
+EventSession save(EventSession session);
+Optional<EventSession> findById(Long id);
+List<EventSession> findByEventId(Long eventId);
+void deleteById(Long id);
+Optional<EventSession> findDefaultByEventId(Long eventId);
+```
+
+#### 2-4. Mapper
+```
+event/adapter/out/persistence/EventSessionMapper.java
+```
+도메인 ↔ JPA Entity 변환
+
+### Phase 3: Service 구현
+
+```
+event/application/service/EventSessionService.java
+```
+
+핵심 로직:
+1. **이벤트 생성 시 `hasSession=false`이면 기본 세션 자동 생성**
+   - Event의 price, startDate, endDate, location, isOnline 정보 복사
+   - `is_default = true` 설정
+2. **세션 CRUD**
+   - 생성: 이벤트 소유자 검증 → 세션 저장
+   - 수정: 이벤트 소유자 + 세션 존재 검증 → 업데이트
+   - 삭제: 이벤트 소유자 + 주문 존재 여부 검증 → 주문 있으면 삭제 불가
+   - 목록: eventId로 조회, sortOrder 정렬
+3. **세션 순서 변경 (Reorder)**
+   - `List<Long> sessionIds` 순서대로 sortOrder 업데이트
+4. **`hasSession` 전환 로직**
+   - `false → true`: 기존 기본 세션(is_default=true) 유지, 새 세션 추가 가능
+   - `true → false`: 추가 세션이 주문에 연결되어 있지 않으면 삭제 가능
+
+### Phase 4: Controller (API)
+
+> **아키텍처 원칙:** CRUD 주체가 다르면 Controller 분리 (교훈 3)  
+> 기존 `HostEventController` + `EventController` 패턴을 따름
+
+**호스트 CRUD:**
+```
+event/presentation/HostSessionController.java  (@RequestMapping("/host/events/{eventId}/sessions"))
+```
+
+| # | Method | Path | 설명 | Auth |
+|---|--------|------|------|------|
+| 37 | `POST` | `/host/events/{eventId}/sessions` | 세션 추가 | 🔑 HOST |
+| 38 | `PUT` | `/host/events/{eventId}/sessions/{sessionId}` | 세션 수정 | 🔑 HOST |
+| 39 | `DELETE` | `/host/events/{eventId}/sessions/{sessionId}` | 세션 삭제 | 🔑 HOST |
+| 40 | `PATCH` | `/host/events/{eventId}/sessions/reorder` | 세션 순서 변경 | 🔑 HOST |
+
+**일반 조회:**
+```
+event/presentation/EventController.java 에 추가 (또는 별도 SessionController.java)
+```
+
+| # | Method | Path | 설명 | Auth |
+|---|--------|------|------|------|
+| 36 | `GET` | `/events/{eventId}/sessions` | 세션 목록 조회 | ❌ |
+
+### Phase 5: DTO
+
+#### Request DTO
+```
+event/adapter/in/web/dto/SessionCreateRequest.java
+```
+```java
+public record SessionCreateRequest(
+    @NotBlank String title,
+    String description,
+    int sortOrder,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    String location,
+    String regionSido,
+    String regionSigungu,
+    boolean isOnline,
+    String onlineLink,
+    int price,
+    int maxAttendees
+) {}
+```
+
+```
+event/adapter/in/web/dto/SessionUpdateRequest.java  — 동일 구조
+event/adapter/in/web/dto/SessionReorderRequest.java
+```
+```java
+public record SessionReorderRequest(
+    @NotNull List<Long> sessionIds  // 새 순서대로 세션 ID 목록
+) {}
+```
+
+#### Response DTO
+```
+event/adapter/in/web/dto/SessionResponse.java
+```
+```java
+public record SessionResponse(
+    Long id,
+    Long eventId,
+    String title,
+    String description,
+    int sortOrder,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    String location,
+    String regionSido,
+    String regionSigungu,
+    boolean isOnline,
+    String onlineLink,
+    int price,
+    int maxAttendees,
+    int currentAttendees,
+    boolean isDefault
+) {}
+```
+
+### Phase 6: 이벤트 생성/수정 API 확장
+
+`EventCreateRequest`에 세션 관련 필드 추가:
+```java
+boolean hasSession,                      // 세션 사용 여부
+PurchaseType purchaseType,               // SINGLE / MULTI
+List<SessionCreateRequest> sessions      // 직접 생성할 세션 목록 (null이면 기본 세션)
+```
+
+---
+
+## 6. 프론트엔드 구현 계획
+
+### 6-1. EventForm 탭 UI 확장
+
+현재 EventForm 단일 폼 → **탭 방식**으로 확장:
+
+```
+┌─────────────────────────────────────────────┐
+│  강의 제목                                    │
+│  강의 이미지                                   │
+│  강의 정보                                    │
+│                                             │
+│  세션을 사용하시겠습니까?  [ ○ 사용안함  ● 사용 ] │
+│                                             │
+│  ┌──────┬────────┐                           │
+│  │ ⚙️ 일반 │ 📋 세션  │  ← 탭 (hasSession일 때) │
+│  └──────┴────────┘                           │
+│                                             │
+│  [일반 탭]                                    │
+│  가격 / 날짜 / 온라인여부 / 장소               │
+│  구매 모드: ○ 단일 세션 구매  ○ 복수 세션 구매   │
+│                                             │
+│  [세션 탭] (hasSession=true일 때만 표시)        │
+│  ┌──────────────────────────────────────┐    │
+│  │ 세션 1: 오리엔테이션                    │    │
+│  │ 10:00-11:00 | 서울 강남구 | ₩30,000   │ ✏️🗑️│
+│  ├──────────────────────────────────────┤    │
+│  │ 세션 2: Spring Core                  │    │
+│  │ 11:00-13:00 | 온라인 (Zoom) | ₩40,000 │ ✏️🗑️│
+│  ├──────────────────────────────────────┤    │
+│  │ + 세션 추가                           │    │
+│  └──────────────────────────────────────┘    │
+│                                             │
+│  [임시 저장] [게시하기] [나가기]                │
+└─────────────────────────────────────────────┘
+```
+
+### 6-2. UI 상태별 동작
+
+| `hasSession` | 화면 | 가격/장소 |
+|---|---|---|
+| `false` | 탭 없음, 기존 폼만 표시 | 이벤트 레벨에서 입력 → 기본 세션에 복사 |
+| `true` | 일반/세션 탭 전환 | 세션 탭에서 세션별로 개별 입력 |
+
+### 6-3. 세션 편집 인라인 폼
+
+세션 추가/편집 시 입력 필드:
+- 세션 제목
+- 세션 설명
+- 시작/종료 시간
+- 온라인 여부 토글
+  - 온라인 → 링크 입력
+  - 오프라인 → 장소 + 시/도 + 시/군/구 입력
+- 가격
+- 정원
+
+### 6-4. Frontend BFF API 라우트 추가
+
+> 아키텍처 원칙에 따라 호스트 CRUD와 일반 조회 경로를 분리
+
+**호스트 CRUD:**
+```
+frontend/src/app/api/host/events/[eventId]/sessions/route.ts
+  → POST: 백엔드 POST /v1/host/events/{eventId}/sessions 프록시
+
+frontend/src/app/api/host/events/[eventId]/sessions/[sessionId]/route.ts
+  → PUT:    백엔드 PUT /v1/host/events/{eventId}/sessions/{sessionId} 프록시
+  → DELETE: 백엔드 DELETE /v1/host/events/{eventId}/sessions/{sessionId} 프록시
+
+frontend/src/app/api/host/events/[eventId]/sessions/reorder/route.ts
+  → PATCH: 백엔드 PATCH /v1/host/events/{eventId}/sessions/reorder 프록시
+```
+
+**일반 조회:**
+```
+frontend/src/app/api/events/[eventId]/sessions/route.ts
+  → GET: 백엔드 GET /v1/events/{eventId}/sessions 프록시
+```
+
+### 6-5. 이벤트 상세 페이지 (고객 뷰) 변경
+
+- `hasSession=true`: 세션 카드 목록 표시 (제목, 시간, 장소/링크, 가격, 잔여석, 구매/장바구니 버튼)
+- `hasSession=false`: 현재와 동일 (단일 구매 버튼)
+- 세션별 장바구니 추가: `POST /cart` 요청에 `sessionId` 포함
+
+---
+
+## 7. 향후 패키지 기능 설계
+
+> 지금 당장 구현하지 않지만, 세션 CRUD 설계 시 호환성을 확보하기 위해 미리 검토한 내용
+
+### 7-1. 개념
+
+**패키지 = 여러 세션을 묶은 하나의 이벤트**
+
+```
+호스트 A의 이벤트들:
+  Spring Boot 기초 → 세션1(개론), 세션2(실습)
+  Spring JPA      → 세션3(엔티티), 세션4(쿼리)
+
+패키지 이벤트:
+  "Spring 풀코스 패키지" = 세션1 + 세션3 + 세션4 (묶음 판매)
+```
+
+패키지는 **이벤트 목록에 함께 노출**되는 하나의 이벤트로 취급됩니다.
+
+### 7-2. DB 구조 (향후)
+
+`EventType`에 `PACKAGE` 추가 + 테이블 2개 신규:
+
+```sql
+-- EventType enum에 PACKAGE 추가
+-- SEMINAR, CLASS, MEETUP, CONFERENCE, PACKAGE
+
+-- 패키지 메타 정보
+CREATE TABLE session_package (
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+    event_id        BIGINT NOT NULL,              -- → EVENT.id (type=PACKAGE인 이벤트)
+    pricing_type    VARCHAR(20) NOT NULL,          -- FLAT_PRICE / INDIVIDUAL_DISCOUNT
+    flat_price      INT,                           -- 통 가격 (FLAT_PRICE 모드 시)
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 패키지에 포함된 세션 목록
+CREATE TABLE session_package_item (
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+    package_id      BIGINT NOT NULL,               -- → SESSION_PACKAGE.id
+    session_id      BIGINT NOT NULL,               -- → EVENT_SESSION.id
+    discount_rate   INT DEFAULT 0,                 -- 개별 할인율 (INDIVIDUAL_DISCOUNT 모드 시)
+    sort_order      INT DEFAULT 0
+);
+```
+
+### 7-3. 가격 모드
+
+호스트가 패키지 생성 시 2가지 중 선택:
+
+| 모드 | 설명 | 예시 |
+|------|------|------|
+| **통 가격 (FLAT_PRICE)** | 패키지에 단일 가격 설정 | 세션 3개 합계 ₩110,000 → 패키지 ₩79,000 |
+| **세션별 할인 (INDIVIDUAL_DISCOUNT)** | 세션마다 할인율 설정, 합산 | 세션1: 20%, 세션2: 30%, 세션3: 20% → 합계 ₩84,000 |
+
+### 7-4. 권한 구분
+
+| 역할 | 가능한 작업 |
+|------|-----------|
+| **호스트** | 자기 이벤트의 세션만 불러와서 패키지 구성 |
+| **어드민** | 모든 호스트의 세션 검색 → 크로스 호스트 패키지 구성 가능 |
+
+> ⚠️ **크로스 호스트 패키지**의 경우 정산 로직(호스트별 수익 분배)이 복잡해지므로  
+> MVP에서는 호스트 자기 세션 패키지만 → 이후 어드민 크로스 패키지 순서로 구현 권장
+
+### 7-5. 현재 세션 설계와의 호환성
+
+| 지금 구현하는 것 | 패키지 추가 시 |
+|---|---|
+| `EVENT_SESSION`에 price, location 등 | 그대로 활용 ✅ |
+| `Order.session_id` FK | 패키지 구매 시 각 세션별 Order 생성 ✅ |
+| `EventType` (4개 유형) | `PACKAGE` 추가만 하면 됨 ✅ |
+| `Event.has_session=false → 기본 세션` | 패키지 이벤트도 `has_session=false` ✅ |
+
+**결론:** 세션 CRUD를 잘 만들면 패키지는 테이블 2개(`session_package`, `session_package_item`)와 `EventType.PACKAGE` 추가만으로 구현 가능.
+
+### 7-6. 패키지 구현 우선순위
+
+```
+1단계: 호스트 패키지 (자기 세션, 통 가격)         ← 가장 단순
+2단계: 세션별 할인 모드 추가                      ← pricing_type 분기만
+3단계: 어드민 크로스 호스트 패키지 + 정산 로직       ← 복잡, 후순위
+```
+
+---
+
+## 8. 구현 워크플로 (기능별 BE+FE 묶음)
+
+> **원칙:** 기능 단위로 BE API 구현 → 즉시 FE 연결까지 한 번에 검증.  
+> API를 두 번 검증하지 않도록 백엔드와 프론트엔드를 묶어서 진행.
+
+---
+
+### Step 1: 세션 도메인 기반 구축 (BE 선행)
+
+> **범위:** BE only — 이후 Step의 토대가 되는 도메인/인프라 레이어  
+> **FE 없음:** 이 단계는 API가 아직 없으므로 BE 컴파일 검증만
+
+#### 1-1. PurchaseType Enum 생성
+- 파일: `event/domain/model/PurchaseType.java`
+- 값: `SINGLE` (세션 하나만 구매), `MULTI` (여러 세션 동시 구매)
+
+#### 1-2. EventSession 도메인 모델 생성
+- 파일: `event/domain/model/EventSession.java`
+- 순수 POJO, JPA 의존 없음
+- 필드: id, eventId, title, description, sortOrder, startTime, endTime, location, regionSido, regionSigungu, isOnline, onlineLink, price, maxAttendees, currentAttendees, isDefault, createdAt, updatedAt
+- 비즈니스 메서드: `isAvailable()`, `hasCapacity(int)`, `incrementAttendees(int)`, `decrementAttendees(int)`, `updateDetails(...)`
+
+#### 1-3. EventSessionJpaEntity 생성
+- 파일: `event/adapter/out/persistence/entity/EventSessionJpaEntity.java`
+- `@Entity @Table(name = "event_sessions")`
+- `@ManyToOne(fetch = FetchType.LAZY)` → EventJpaEntity
+- `@Builder`, `@CreationTimestamp`, `@UpdateTimestamp`
+
+#### 1-4. EventSessionJpaRepository 생성
+- 파일: `event/adapter/out/persistence/repository/EventSessionJpaRepository.java`
+- `findByEventIdOrderBySortOrder(Long eventId)`
+- `findByEventIdAndIsDefaultTrue(Long eventId)`
+- `countByEventId(Long eventId)`
+
+#### 1-5. EventSessionMapper 생성
+- 파일: `event/adapter/out/persistence/EventSessionMapper.java`
+- `toDomain(EventSessionJpaEntity)` → `EventSession`
+- `toJpaEntity(EventSession, EventJpaEntity)` → `EventSessionJpaEntity`
+
+#### 1-6. SessionPort (out 포트) 생성
+- 파일: `event/application/port/out/SessionPort.java`
+- 인터페이스: `save()`, `findById()`, `findByEventId()`, `deleteById()`, `findDefaultByEventId()`
+
+#### 1-7. EventSessionPersistenceAdapter 생성
+- 파일: `event/adapter/out/persistence/EventSessionPersistenceAdapter.java`
+- `SessionPort` 구현 — Repository + Mapper 조합
+
+#### 1-8. Event 도메인에 필드 추가
+- `Event.java`에 `hasSession(boolean)`, `purchaseType(PurchaseType)` 추가
+- 생성자, getter, `updateDetails()` 업데이트
+
+#### 1-9. EventJpaEntity에 필드 추가
+- `EventJpaEntity.java`에 `has_session`, `purchase_type` 컬럼 추가
+
+#### 1-10. EventMapper 업데이트
+- `EventMapper.java`에 hasSession, purchaseType 매핑 추가
+
+#### ✅ 검증
+```bash
+cd backend && ./gradlew compileJava
+```
+컴파일 에러 없으면 Step 1 완료.
+
+---
+
+### Step 2: 세션 CRUD API + 이벤트 폼 세션 탭 (BE + FE)
+
+> **범위:** 세션 5개 API 전체 + EventForm 세션 관리 탭  
+> **BE → FE 순서로 구현, API 수정 즉시 프론트 연결 검증**
+
+#### BE 파트
+
+**2-1. UseCase Port (in) 생성**
+- 파일 위치: `event/application/port/in/`
+- `CreateSessionUseCase.java` — inner record `CreateSessionCommand` 포함
+- `UpdateSessionUseCase.java` — inner record `UpdateSessionCommand` 포함
+- `DeleteSessionUseCase.java`
+- `GetSessionUseCase.java`
+- `ReorderSessionUseCase.java` — inner record `ReorderCommand` 포함
+
+**2-2. EventSessionService 구현**
+- 파일: `event/application/service/EventSessionService.java`
+- 모든 UseCase 구현
+- **createSession:** 이벤트 조회 → 소유자 검증 → 세션 저장
+- **updateSession:** 세션 조회 → 소유자 검증 → updateDetails → 저장
+- **deleteSession:** 소유자 검증 → is_default면 삭제 불가 → 주문 있으면 삭제 불가 → 삭제
+- **getSessions:** eventId로 조회, sortOrder 정렬
+- **reorderSessions:** 소유자 검증 → sessionIds 순서대로 sortOrder 업데이트
+- **createDefaultSession:** 이벤트 생성 시 `hasSession=false`면 이벤트 정보를 복사한 기본 세션 자동 생성
+
+**2-3. Request/Response DTO 생성**
+- `SessionCreateRequest.java` — title, description, sortOrder, startTime, endTime, location, regionSido, regionSigungu, isOnline, onlineLink, price, maxAttendees + `toCommand()` 메서드
+- `SessionUpdateRequest.java` — 동일 구조 + `toCommand(eventId, sessionId, requesterId)`
+- `SessionReorderRequest.java` — `List<Long> sessionIds`
+- `SessionResponse.java` — 전체 필드 + `static from(EventSession)` 팩토리
+
+**2-4. HostSessionController 생성 (호스트 CRUD)**
+- 파일: `event/presentation/HostSessionController.java`
+- 경로 prefix: `/host/events/{eventId}/sessions`
+- 기존 `HostEventController` 패턴 따름
+- `POST   /host/events/{eventId}/sessions` — 세션 추가 (HOST, X-User-Id)
+- `PUT    /host/events/{eventId}/sessions/{sessionId}` — 세션 수정 (HOST)
+- `DELETE /host/events/{eventId}/sessions/{sessionId}` — 세션 삭제 (HOST)
+- `PATCH  /host/events/{eventId}/sessions/reorder` — 세션 순서 변경 (HOST)
+
+**2-5. SessionController 확장 (일반 조회)**
+- 파일: `event/presentation/EventController.java`에 추가 또는 별도 `SessionController.java`
+- 경로: `/events/{eventId}/sessions`
+- `GET /events/{eventId}/sessions` — 세션 목록 조회 (인증 불필요)
+
+**2-6. EventCreateRequest/UpdateRequest 확장**
+- `hasSession`, `purchaseType`, `List<SessionCreateRequest> sessions` 필드 추가
+- 이벤트 생성 서비스에서 세션 처리 로직 연동
+
+**2-7. EventDetailResponse 확장**
+- `sessions: List<SessionResponse>` 필드 추가
+- 이벤트 상세 API에서 세션 목록 포함하여 반환
+
+**2-8. BE 컴파일 검증**
+```bash
+cd backend && ./gradlew compileJava
+```
+
+#### FE 파트
+
+**2-9. BFF API 라우트 생성**
+- **호스트 CRUD (기존 BFF 패턴 따름):**
+  - `frontend/src/app/api/host/events/[eventId]/sessions/route.ts` — POST
+  - `frontend/src/app/api/host/events/[eventId]/sessions/[sessionId]/route.ts` — PUT, DELETE
+  - `frontend/src/app/api/host/events/[eventId]/sessions/reorder/route.ts` — PATCH
+- **일반 조회:**
+  - `frontend/src/app/api/events/[eventId]/sessions/route.ts` — GET
+
+**2-10. EventForm에 세션 토글 + 탭 추가**
+- `EventForm.tsx` 수정
+- formData에 `hasSession`, `purchaseType`, `sessions` 추가
+- 세션 토글 UI: 스위치 방식
+- hasSession=true일 때 **일반 | 세션** 탭 표시
+
+**2-11. SessionTab 컴포넌트 생성**
+- 파일: `frontend/src/app/events/new/_components/SessionTab.tsx`
+- 세션 카드 리스트 (sortOrder 순)
+- 각 카드: 제목, 시간, 장소/링크, 가격, 정원, ✏️수정 🗑️삭제 버튼
+- "+ 세션 추가" 버튼
+
+**2-12. SessionForm 컴포넌트 생성**
+- 파일: `frontend/src/app/events/new/_components/SessionForm.tsx`
+- 세션 추가/수정 인라인 폼
+- 필드: 제목, 설명, 시작/종료, 온라인 토글(→링크 or 장소), 가격, 정원
+- 저장/취소 버튼
+
+**2-13. CSS 스타일 추가**
+- 파일: `frontend/src/app/events/new/_components/SessionTab.module.css`
+
+**2-14. handleSubmit 확장**
+- payload에 `hasSession`, `purchaseType`, `sessions` 포함
+
+#### ✅ 통합 검증
+1. 백엔드 서버 실행
+2. 프론트 dev 서버 실행
+3. 이벤트 생성 페이지 → 세션 토글 ON → 탭 전환 확인
+4. 세션 추가 → POST API → 목록 반영 확인
+5. 세션 수정 → PUT API → 변경 반영 확인
+6. 세션 삭제 → DELETE API → 목록에서 제거 확인
+7. 세션 없이 이벤트 생성 → 기본 세션 자동 생성 확인 (DB 확인)
+
+---
+
+### Step 3: 구매 연동 + 이벤트 상세 세션 UI (BE + FE)
+
+> **범위:** Order/Cart에 sessionId 연결 + 이벤트 상세 페이지 세션 구매 UI  
+> **핵심:** 세션이 실제 구매 단위로 작동하게 만드는 마무리 단계
+
+#### BE 파트
+
+**3-1. Order 도메인에 sessionId 추가**
+- `Order.java`에 `sessionId: Long` 필드 추가
+- `createPending()` 팩토리 메서드에 `sessionId` 파라미터 추가
+- 생성자, getter 업데이트
+
+**3-2. OrderJpaEntity에 sessionId 추가**
+- `OrderJpaEntity`에 `session_id` 컬럼 + `@ManyToOne` → `EventSessionJpaEntity`
+- OrderMapper 업데이트
+
+**3-3. Cart 도메인/JPA에 sessionId 추가**
+- Cart 도메인 모델에 `sessionId: Long` 필드 추가
+- CartJpaEntity에 `session_id` 컬럼 + FK 추가
+- CartMapper 업데이트
+
+**3-4. 주문 생성 API 수정**
+- `OrderCreateRequest`에 `sessionId` 필드 추가
+- 주문 생성 시 세션 존재 확인 + 정원 체크 (`session.hasCapacity()`)
+- 주문 확정 시 세션의 `currentAttendees` 증가
+- 주문 취소/환불 시 세션의 `currentAttendees` 감소
+
+**3-5. 장바구니 API 수정**
+- `CartCreateRequest`에 `sessionId` 필드 추가
+- 장바구니 추가 시 세션 기준 중복 체크
+- 장바구니 목록 응답에 세션 정보 포함
+
+**3-6. BE 컴파일 검증**
+```bash
+cd backend && ./gradlew compileJava
+```
+
+#### FE 파트
+
+**3-7. 이벤트 상세 페이지 세션 목록 표시**
+- `frontend/src/app/events/[id]/page.tsx` 수정
+- `hasSession=true`: 세션 카드 목록 표시
+  - 카드 내용: 세션 제목, 시간, 장소/온라인링크, 가격, 잔여석(`max - current`)
+  - 각 카드에 **구매** / **장바구니 담기** 버튼
+- `hasSession=false`: 현재와 동일 (단일 구매 버튼, 기본 세션 ID 자동 전달)
+
+**3-8. 주문 생성 요청에 sessionId 포함**
+- `POST /api/orders` 호출 시 `sessionId` 파라미터 전달
+- `hasSession=false` 이벤트: 기본 세션(is_default=true)의 ID 자동 사용
+
+**3-9. 장바구니 요청에 sessionId 포함**
+- `POST /api/cart` 호출 시 `sessionId` 파라미터 전달
+- 장바구니 페이지에서 **"이벤트명 > 세션명"** 형태로 아이템 표시
+
+**3-10. purchaseType에 따른 UI 분기**
+- `SINGLE`: 세션 선택 시 라디오 버튼 형태 (1개만 선택 가능)
+- `MULTI`: 체크박스 형태 (여러 세션 선택 후 한번에 장바구니/구매)
+
+#### ✅ 통합 검증
+1. 세션 있는 이벤트 상세 → 세션 카드 목록 표시 확인
+2. 세션 카드에서 구매 → Order에 sessionId 저장 확인
+3. 세션 카드에서 장바구니 → Cart에 sessionId 저장 확인
+4. 세션 없는 이벤트 → 기존과 동일하게 구매 동작 확인 (기본 세션 ID 자동)
+5. `SINGLE` 모드 → 세션 1개만 선택 가능 확인
+6. `MULTI` 모드 → 여러 세션 선택 구매 확인
+7. 주문 확정 후 세션 currentAttendees 증가 확인
+8. 정원 초과 시 구매 차단 확인
+
+---
+
+## 9. 검증 체크리스트
+
+### 세션 기본 CRUD
+- [ ] `hasSession=false` 이벤트 생성 → 기본 세션 자동 생성 (is_default=true)
+- [ ] `hasSession=true` 이벤트 생성 → 세션 직접 입력 가능
+- [ ] 세션 생성 (POST) — 이벤트 소유자만 가능
+- [ ] 세션 수정 (PUT) — 이벤트 소유자만 가능
+- [ ] 세션 삭제 (DELETE) — 주문 있으면 삭제 불가
+- [ ] 세션 목록 조회 (GET) — sortOrder 정렬
+- [ ] 세션 순서 변경 (PATCH reorder)
+
+### 세션 필드
+- [ ] 세션별 장소 저장/조회 (location, region_sido, region_sigungu)
+- [ ] 세션별 온라인 링크 저장/조회 (is_online=true일 때 online_link)
+- [ ] 세션별 가격 저장/조회
+- [ ] 세션별 정원 + 현재 인원 관리
+
+### hasSession 전환
+- [ ] `false → true`: 기본 세션 유지 + 추가 세션 생성 가능
+- [ ] 이벤트 수정에서 hasSession 변경 시 기존 데이터 보존
+
+### 구매 연동
+- [ ] 세션 단위 주문 생성 (Order.sessionId)
+- [ ] 세션 단위 장바구니 추가 (Cart.sessionId)
+- [ ] `purchaseType=SINGLE` — 세션 1개만 선택 가능
+- [ ] `purchaseType=MULTI` — 여러 세션 동시 선택/구매 가능
+
+### 프론트엔드
+- [ ] EventForm에서 세션 사용 토글 동작
+- [ ] 세션 탭 표시/숨김 전환
+- [ ] 세션 추가/수정/삭제 UI 정상 동작
+- [ ] 이벤트 상세 페이지 — 세션 카드 목록 표시
+- [ ] 이벤트 상세 페이지 — 세션별 구매/장바구니 버튼

--- a/frontend/src/app/api/events/[id]/status/route.ts
+++ b/frontend/src/app/api/events/[id]/status/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
+import { getIronSession } from "iron-session";
+import { SessionData, sessionOptions } from "@/lib/session";
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 export async function PATCH(
@@ -14,14 +17,8 @@ export async function PATCH(
 
     // 세션에서 userId 추출
     const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("session");
-    let userId = "1"; // 기본값
-    if (sessionCookie) {
-      try {
-        const session = JSON.parse(sessionCookie.value);
-        userId = String(session.id);
-      } catch {}
-    }
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+    const userId = String(session.userId || 5);
 
     // 백엔드는 쿼리 파라미터로 status를 받음
     const response = await fetch(

--- a/frontend/src/app/api/events/route.ts
+++ b/frontend/src/app/api/events/route.ts
@@ -30,8 +30,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data);
   } catch (error) {
     console.error("Failed to fetch events from backend:", error);
+    console.error("Failed to fetch events from backend:", error);
     return NextResponse.json(
-      { status: "ERROR", message: "Failed to fetch events", data: null },
+      { status: "ERROR", message: "Failed to fetch events: " + (error instanceof Error ? error.message : String(error)), data: null },
       { status: 500 }
     );
   }
@@ -65,8 +66,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     console.error("Failed to create event:", error);
+    console.error("Failed to create event:", error);
     return NextResponse.json(
-      { status: "ERROR", message: "Failed to create event", data: null },
+      { status: "ERROR", message: "Failed to create event: " + (error instanceof Error ? error.message : String(error)), data: null },
       { status: 500 }
     );
   }

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -149,6 +149,23 @@ export default async function EventDetailPage({ params }: Props) {
                   <span>💰 <strong>가격:</strong> {session.price === 0 ? '무료' : `₩${session.price.toLocaleString()}`}</span>
                   <span>👤 <strong>인원:</strong> {session.currentAttendees} / {session.maxAttendees} 명</span>
                 </div>
+                {/* 세션 개별 수강 신청 버튼 */}
+                {event.status === 'PUBLISHED' && session.currentAttendees < session.maxAttendees && (
+                  <div style={{ marginTop: '16px', textAlign: 'right' }}>
+                    <Link href={`/orders/checkout?eventId=${id}&quantity=1&sessionId=${session.id}`} style={{ textDecoration: 'none' }}>
+                      <Button variant="primary" size="medium">
+                        이 세션 수강 신청
+                      </Button>
+                    </Link>
+                  </div>
+                )}
+                {event.status === 'PUBLISHED' && session.maxAttendees > 0 && session.currentAttendees >= session.maxAttendees && (
+                  <div style={{ marginTop: '16px', textAlign: 'right' }}>
+                    <Button variant="outlined" size="medium" disabled>
+                      정원 초과
+                    </Button>
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -179,11 +196,17 @@ export default async function EventDetailPage({ params }: Props) {
           <Button variant="outlined" size="large">강의 목록</Button>
         </Link>
         {event.status === 'PUBLISHED' ? (
-          <Link href={`/orders/checkout?eventId=${id}&quantity=1`} style={{ textDecoration: 'none' }}>
-            <Button variant="primary" size="large">
-              수강 신청
+          event.hasSession ? (
+            <Button variant="primary" size="large" disabled>
+              ↑ 위 세션 목록에서 선택해주세요
             </Button>
-          </Link>
+          ) : (
+            <Link href={`/orders/checkout?eventId=${id}&quantity=1`} style={{ textDecoration: 'none' }}>
+              <Button variant="primary" size="large">
+                수강 신청
+              </Button>
+            </Link>
+          )
         ) : (
           <Button variant="primary" size="large" disabled>
             신청 불가

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -44,6 +44,8 @@ export default async function EventDetailPage({ params }: Props) {
   const { id } = await params;
   const event = await getEventDetail(id);
 
+  console.log("EVENT PAYLOAD FROM BACKEND:", JSON.stringify(event, null, 2));
+
   if (!event || event.error) {
     return (
       <div className={styles.container} style={{ textAlign: 'center', padding: '100px 0' }}>
@@ -125,6 +127,33 @@ export default async function EventDetailPage({ params }: Props) {
           </div>
         </div>
       </section>
+
+      {/* 다중 세션 정보 섹션 (있는 경우에만 표시) */}
+      {event.hasSession && event.sessions && event.sessions.length > 0 && (
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>
+            세션 일정 ({event.purchaseType === 'PACKAGE' ? '패키지(전체 필수 수강)' : '선택형 수강'})
+          </h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            {event.sessions.map((session: any, index: number) => (
+              <div key={session.id || index} style={{ border: '1px solid #eaeaea', padding: '16px', borderRadius: '12px', background: '#fafafa' }}>
+                <h4 style={{ margin: '0 0 8px 0', fontSize: '16px' }}>{session.title || `세션 ${index + 1}`}</h4>
+                {session.description && (
+                  <p style={{ fontSize: '14px', color: '#666', marginBottom: '12px', lineHeight: '1.5' }}>
+                    {session.description}
+                  </p>
+                )}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px', fontSize: '14px', color: '#333' }}>
+                  <span>🕒 <strong>시간:</strong> {format(new Date(session.startTime), 'MM-dd HH:mm')} ~ {format(new Date(session.endTime), 'HH:mm')}</span>
+                  <span>🏫 <strong>장소:</strong> {session.isOnline ? '온라인' : session.location}</span>
+                  <span>💰 <strong>가격:</strong> {session.price === 0 ? '무료' : `₩${session.price.toLocaleString()}`}</span>
+                  <span>👤 <strong>인원:</strong> {session.currentAttendees} / {session.maxAttendees} 명</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* 주최자 정보 섹션 */}
       <section className={styles.section}>

--- a/frontend/src/app/events/new/_components/EventForm.tsx
+++ b/frontend/src/app/events/new/_components/EventForm.tsx
@@ -25,6 +25,11 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
   const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const [hasSession, setHasSession] = useState<boolean>(initialData?.hasSession || false);
+  const [purchaseType, setPurchaseType] = useState<'SINGLE' | 'MULTI'>(initialData?.purchaseType || 'SINGLE');
+  const [activeTab, setActiveTab] = useState<'general' | 'sessions'>('general');
+  const [sessions, setSessions] = useState<any[]>(initialData?.sessions || []);
+
   const [formData, setFormData] = useState({
     title: initialData?.title || '',
     description: initialData?.description || '',
@@ -118,6 +123,10 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     }
   };
 
+  const calculatedTotalPrice = hasSession 
+    ? sessions.reduce((sum, s) => sum + (Number(s.price) || 0), 0)
+    : Number(formData.price) || 0;
+
   const handleSubmit = async (isDraft: boolean) => {
     setLoading(true);
     try {
@@ -139,12 +148,27 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         type: 'SEMINAR',
         location: formData.location,
         isOnline: isOnline,
-        price: parseInt(formData.price || '0', 10),
+        price: calculatedTotalPrice,
         maxAttendees: initialData?.maxAttendees || 50,
         thumbnailUrl: thumbnailUrl,
         startDate: startDateStr,
         endDate: endDateStr,
+        hasSession,
+        purchaseType,
+        sessions: hasSession ? sessions.map(s => ({
+          ...s,
+          price: Number(s.price) || 0,
+          maxAttendees: Number(s.maxAttendees) || 50,
+          startTime: s.date ? `${s.date}T10:00:00` : startDateStr,
+          endTime: s.date ? `${s.date}T18:00:00` : endDateStr,
+          location: s.location || formData.location,
+          isOnline: s.isOnline !== undefined ? s.isOnline : isOnline,
+          description: s.description || '',
+          onlineLink: s.onlineLink || '',
+        })) : undefined,
       };
+
+      console.log("[DEBUG] API Request Payload:", JSON.stringify(payload, null, 2));
 
       let res;
       if (mode === 'create') {
@@ -161,7 +185,17 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         });
       }
 
-      if (!res.ok) throw new Error(`이벤트 ${mode === 'create' ? '생성' : '수정'} 실패`);
+      if (!res.ok) {
+        let errMsg = `이벤트 ${mode === 'create' ? '생성' : '수정'} 실패`;
+        try {
+          const errData = await res.json();
+          console.error("[DEBUG] API Error Response:", JSON.stringify(errData, null, 2));
+          if (errData && errData.message) errMsg += ` - ${errData.message}`;
+        } catch (e) {
+          console.error("[DEBUG] API Error Response (Not JSON):", res.status, res.statusText);
+        }
+        throw new Error(errMsg);
+      }
 
       const resData = await res.json();
       const targetId = mode === 'create' ? resData.data.id : eventId;
@@ -261,59 +295,210 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         />
       </div>
 
-      <div className={styles.grid3}>
-        <div className={styles.formGroup}>
-          <label className={styles.label}>총 가격</label>
-          <div className={styles.priceInputWrapper}>
-            <span className={styles.currencyIcon}>₩</span>
+      <div className={styles.formGroup}>
+        <label className={styles.label}>세션을 사용하시겠습니까?</label>
+        <div style={{ display: 'flex', gap: '1rem', marginTop: '0.5rem' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+            <input type="radio" name="hasSession" checked={!hasSession} onChange={() => setHasSession(false)} />
+            사용안함 (이벤트 전체 판매)
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+            <input type="radio" name="hasSession" checked={hasSession} onChange={() => setHasSession(true)} />
+            사용 (세션별 개별 판매)
+          </label>
+        </div>
+      </div>
+
+      <div style={{ marginTop: '2rem', padding: '1.5rem', background: '#f8f9fa', borderRadius: '8px', marginBottom: '2rem' }}>
+        <h3 style={{ fontSize: '1.1rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
+          {hasSession ? '세션 공통 설정 (기본값)' : '이벤트 상세 설정'}
+        </h3>
+        
+        <div className={styles.grid3}>
+          <div className={styles.formGroup}>
+            <label className={styles.label}>총 가격</label>
+            <div className={styles.priceInputWrapper}>
+              <span className={styles.currencyIcon}>₩</span>
+              <input
+                type="number"
+                name="price"
+                className={styles.priceInput}
+                value={hasSession ? calculatedTotalPrice : formData.price}
+                onChange={handleChange}
+                disabled={hasSession}
+              />
+            </div>
+            {hasSession && <span style={{ fontSize: '0.8rem', color: '#666', marginTop: '4px', display: 'block' }}>세션 설정에서 추가한 금액의 합계입니다.</span>}
+          </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.label}>{hasSession ? '기본 날짜' : '날짜'}</label>
             <input
-              type="number"
-              name="price"
-              className={styles.priceInput}
-              value={formData.price}
+              type="date"
+              name="date"
+              className={styles.dateInput}
+              value={formData.date}
               onChange={handleChange}
             />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.label}>온라인/오프라인</label>
+            <select
+              name="isOnlineStr"
+              className={styles.selectInput}
+              value={formData.isOnlineStr}
+              onChange={handleChange}
+            >
+              <option value="">옵션을 선택하세요.</option>
+              <option value="false">오프라인</option>
+              <option value="true">온라인</option>
+            </select>
           </div>
         </div>
 
         <div className={styles.formGroup}>
-          <label className={styles.label}>날짜</label>
+          <label className={styles.label}>{hasSession ? '기본 장소' : '장소'}</label>
           <input
-            type="date"
-            name="date"
-            className={styles.dateInput}
-            value={formData.date}
+            type="text"
+            name="location"
+            className={styles.standardInput}
+            placeholder="오프라인 강의일 경우 주소를 입력해주세요."
+            value={formData.location}
             onChange={handleChange}
+            disabled={formData.isOnlineStr === 'true'}
           />
         </div>
 
-        <div className={styles.formGroup}>
-          <label className={styles.label}>온라인/오프라인</label>
-          <select
-            name="isOnlineStr"
-            className={styles.selectInput}
-            value={formData.isOnlineStr}
-            onChange={handleChange}
-          >
-            <option value="">옵션을 선택하세요.</option>
-            <option value="false">오프라인</option>
-            <option value="true">온라인</option>
-          </select>
-        </div>
+        {hasSession && (
+          <div className={styles.formGroup}>
+            <label className={styles.label}>세션 구매 방식</label>
+            <div style={{ display: 'flex', gap: '1rem', marginTop: '0.5rem' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                <input type="radio" name="purchaseType" checked={purchaseType === 'SINGLE'} onChange={() => setPurchaseType('SINGLE')} />
+                단일 선택 (고객이 1개의 세션만 선택 가능)
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                <input type="radio" name="purchaseType" checked={purchaseType === 'MULTI'} onChange={() => setPurchaseType('MULTI')} />
+                복수 선택 (고객이 여러 세션을 동시 구매 가능)
+              </label>
+            </div>
+          </div>
+        )}
       </div>
 
-      <div className={styles.formGroup}>
-        <label className={styles.label}>장소</label>
-        <input
-          type="text"
-          name="location"
-          className={styles.standardInput}
-          placeholder="오프라인 강의일 경우 주소를 입력해주세요."
-          value={formData.location}
-          onChange={handleChange}
-          disabled={formData.isOnlineStr === 'true'}
-        />
-      </div>
+      {hasSession && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginBottom: '2rem' }}>
+          <h3 style={{ fontSize: '1.2rem', fontWeight: 'bold', borderBottom: '2px solid #000', paddingBottom: '0.5rem' }}>세션 목록</h3>
+          <p style={{ color: '#666', fontSize: '0.9rem' }}>이벤트 내에 포함될 세션들을 아래에 추가해주세요. 날짜와 장소를 비워두면 위의 '공통 설정'을 자동으로 따릅니다.</p>
+          
+          {sessions.length === 0 ? (
+            <div style={{ padding: '2rem', textAlign: 'center', background: '#f9f9f9', borderRadius: '8px', border: '1px dashed #ccc' }}>
+              <p style={{ color: '#888', marginBottom: '1rem' }}>등록된 세션이 없습니다.</p>
+              <button 
+                type="button"
+                onClick={() => setSessions([...sessions, { title: '새 세션', price: 0, maxAttendees: 50, sortOrder: sessions.length, date: undefined, location: undefined }])}
+                style={{ padding: '0.5rem 1rem', background: '#000', color: '#fff', borderRadius: '4px', border: 'none', cursor: 'pointer' }}
+              >
+                + 세션 추가하기
+              </button>
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              {sessions.map((session, index) => (
+                <div key={index} style={{ border: '1px solid #ddd', borderRadius: '8px', padding: '1rem', position: 'relative' }}>
+                  <button 
+                    type="button" 
+                    onClick={() => {
+                        const newSessions = [...sessions];
+                        newSessions.splice(index, 1);
+                        setSessions(newSessions);
+                    }}
+                    style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'none', border: 'none', color: '#ff4d4f', cursor: 'pointer' }}
+                  >
+                    🗑️ 삭제
+                  </button>
+                  <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '1fr 1fr' }}>
+                    <div style={{ gridColumn: '1 / -1' }}>
+                      <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>세션 제목</label>
+                      <input 
+                        type="text" 
+                        value={session.title || ''} 
+                        onChange={(e) => {
+                            const newSessions = [...sessions];
+                            newSessions[index].title = e.target.value;
+                            setSessions(newSessions);
+                        }}
+                        style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }} 
+                      />
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>가격</label>
+                      <input 
+                        type="number" 
+                        value={session.price || 0} 
+                        onChange={(e) => {
+                            const newSessions = [...sessions];
+                            newSessions[index].price = parseInt(e.target.value, 10);
+                            setSessions(newSessions);
+                        }}
+                        style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }} 
+                      />
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>정원 명수</label>
+                      <input 
+                        type="number" 
+                        value={session.maxAttendees || 0} 
+                        onChange={(e) => {
+                            const newSessions = [...sessions];
+                            newSessions[index].maxAttendees = parseInt(e.target.value, 10);
+                            setSessions(newSessions);
+                        }}
+                        style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }} 
+                      />
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>세션 날짜 <span style={{fontWeight:'normal', color:'#666'}}>(비울시 일반설정 동기화)</span></label>
+                      <input 
+                        type="date" 
+                        value={session.date !== undefined ? session.date : formData.date} 
+                        onChange={(e) => {
+                            const newSessions = [...sessions];
+                            newSessions[index].date = e.target.value === "" ? undefined : e.target.value;
+                            setSessions(newSessions);
+                        }}
+                        style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }} 
+                      />
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>세션 장소 <span style={{fontWeight:'normal', color:'#666'}}>(비울시 일반설정 동기화)</span></label>
+                      <input 
+                        type="text" 
+                        value={session.location !== undefined ? session.location : formData.location} 
+                        placeholder="일반 설정과 다른 경우 입력"
+                        onChange={(e) => {
+                            const newSessions = [...sessions];
+                            newSessions[index].location = e.target.value === "" ? undefined : e.target.value;
+                            setSessions(newSessions);
+                        }}
+                        style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }} 
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <button 
+                type="button"
+                onClick={() => setSessions([...sessions, { title: '새 세션', price: 0, maxAttendees: 50, sortOrder: sessions.length, date: undefined, location: undefined }])}
+                style={{ padding: '1rem', background: '#f5f5f5', color: '#333', borderRadius: '8px', border: '1px dashed #ccc', cursor: 'pointer', fontWeight: 'bold', marginTop: '0.5rem' }}
+              >
+                + 세션 항목 추가
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className={styles.bottomSection}>
         <div className={styles.hostSection}>

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -45,15 +45,21 @@ function CheckoutContent() {
 
         const eventId = searchParams.get('eventId') || '1';
         const quantity = searchParams.get('quantity') || '1';
+        const sessionId = searchParams.get('sessionId');
+
+        const requestBody: any = {
+          eventId: Number(eventId),
+          quantity: Number(quantity),
+          paymentMethod: 'CARD',
+        };
+        if (sessionId) {
+          requestBody.sessionId = Number(sessionId);
+        }
 
         const res = await fetch('/api/orders', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            eventId: Number(eventId),
-            quantity: Number(quantity),
-            paymentMethod: 'CARD',
-          }),
+          body: JSON.stringify(requestBody),
         });
 
         if (!res.ok) {


### PR DESCRIPTION
VO-625 지역정보입력
VO-627 세션리스트 CRUD

## 📝 작업 내용
이벤트 세션 관리를 위한 스펙(VO-627)을 반영하여 세션 생성, 수정 및 세션 단위의 결제 프로세스를 모두 연결했습니다. (Step 1 ~ 3 완료)

### 1️⃣ 백엔드 (도메인 및 API 연동)
- **`EventSession` 도메인 및 JPA 설계**: 세션의 독립적인 장소/시간/가격/정원 관리를 위해 아키텍처 반영 (`event_sessions` 테이블).
- **`Order` 도메인에 sessionId 연결**: 
  - 주문 생성 시점에 단일/다중 세션을 파악하여 정원 초과 여부를 세션 단위로 체크.
  - 토스 결제 웹훅(`/toss/webhook`) 및 결제 승인/취소 시나리오 속에서 `session.currentAttendees` (참석자 카운트) 증가/감소 연동.
- JPA Repository 내 Session ID 기반 검색/정원 체크 쿼리(`countBySessionIdAndStatusIn` 등) 추가 및 최적화.
- 글로벌 Exception Handler 개선으로 500 에러 상세 로깅 지원.

### 2️⃣ 프론트엔드 (UI 및 BFF 최적화)
- **이벤트 생성 폼(EventForm.tsx)**: 다회차 세션을 위한 동적 탭 입력 환경 및 Payload 생성 지원.
- **BFF 세션 컨텍스트 연동 문제 해결**: 이벤트 상태 변경 시 `iron-session` 쿠키를 바탕으로 JWT Authoriztion 인증을 원활히 전달하도록 `route.ts` 최적화 (외래 키 FK 제약조건 버그 해결).
- **이벤트 상세 및 결제 화면(Checkout)**:
  - `hasSession === true`인 이벤트의 경우 통합수강신청 하단 버튼 비활성화 대신, **각 개별 세션 박스의 우측 하단에 별도 "이 세션 수강 신청" 버튼 구비**.
  - 결제 엔드포인트(`/api/orders`) 호출 시 장바구니/주문 도메인으로 선택된 `sessionId`가 정상 전달되도록 쿼리스트링 파싱 부분 수정.

## ✅ 참고 사항
- 현재 테스트 환경에서 `application-dev.properties`의 `ddl-auto`가 `update` 상태로 동작하여 테이블 날림 없이 호스트/유저 기반을 보존하고 있습니다. DB 관련 충돌이 나면 참고해주세요.
- 장바구니 장바구니(Cart) 도메인의 경우 아직 배포 스펙상 미존재이므로 스코프를 `Order` 도메인 집중 연동으로 마무리 하였습니다.
