### PR TITLE
feat: 커뮤니티 게시글 공지 및 상단 고정 기능 구현

### DIFF
--- a/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
+++ b/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
@@ -2,9 +2,9 @@ package com.venueon.post.adapter.in.web;
 
 import com.venueon.post.application.port.in.CreatePostUseCase;
 import com.venueon.post.application.port.in.GetPostQuery;
+import com.venueon.post.application.port.in.PostAdminUseCase;
 import com.venueon.post.application.port.in.PostBookmarkUseCase;
 import com.venueon.post.application.port.in.PostLikeUseCase;
-import com.venueon.post.application.port.in.PostPinUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
 import com.venueon.post.application.port.in.dto.CreatePostResponse;
 import com.venueon.post.application.port.in.dto.PostListResponse;
@@ -30,7 +30,7 @@ public class PostController {
     private final GetPostQuery getPostQuery;
     private final PostLikeUseCase postLikeUseCase;
     private final PostBookmarkUseCase postBookmarkUseCase;
-    private final PostPinUseCase postPinUseCase;
+    private final PostAdminUseCase postAdminUseCase;
 
     /**
      * 1단계: 게시글 등록
@@ -132,7 +132,17 @@ public class PostController {
      */
     @PatchMapping("/{id}/pin")
     public ResponseEntity<Void> togglePin(@PathVariable Long id) {
-        postPinUseCase.togglePin(id);
+        postAdminUseCase.togglePin(id);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 게시글 공지 설정 토글
+     * PATCH /posts/{id}/notice
+     */
+    @PatchMapping("/{id}/notice")
+    public ResponseEntity<Void> toggleNotice(@PathVariable Long id) {
+        postAdminUseCase.toggleNotice(id);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
+++ b/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
@@ -4,6 +4,7 @@ import com.venueon.post.application.port.in.CreatePostUseCase;
 import com.venueon.post.application.port.in.GetPostQuery;
 import com.venueon.post.application.port.in.PostBookmarkUseCase;
 import com.venueon.post.application.port.in.PostLikeUseCase;
+import com.venueon.post.application.port.in.PostPinUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
 import com.venueon.post.application.port.in.dto.CreatePostResponse;
 import com.venueon.post.application.port.in.dto.PostListResponse;
@@ -29,6 +30,7 @@ public class PostController {
     private final GetPostQuery getPostQuery;
     private final PostLikeUseCase postLikeUseCase;
     private final PostBookmarkUseCase postBookmarkUseCase;
+    private final PostPinUseCase postPinUseCase;
 
     /**
      * 1단계: 게시글 등록
@@ -122,5 +124,15 @@ public class PostController {
         String email = ((UserDetails) authentication.getPrincipal()).getUsername();
         Page<PostListResponse> bookmarks = getPostQuery.getBookmarkedPosts(email, pageable);
         return ResponseEntity.ok(bookmarks);
+    }
+
+    /**
+     * 게시글 상단 고정 토글
+     * PATCH /posts/{id}/pin
+     */
+    @PatchMapping("/{id}/pin")
+    public ResponseEntity<Void> togglePin(@PathVariable Long id) {
+        postPinUseCase.togglePin(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
@@ -79,13 +79,13 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
 
     @Override
     public Page<Post> findByCommunityId(Long communityId, Pageable pageable) {
-        return postJpaRepository.findByCommunityId(communityId, pageable)
+        return postJpaRepository.findByCommunityIdOrderByIsPinnedDescCreatedAtDesc(communityId, pageable)
                 .map(this::mapToDomain);
     }
 
     @Override
     public Page<Post> findByCommunityIdAndType(Long communityId, PostType type, Pageable pageable) {
-        return postJpaRepository.findByCommunityIdAndType(communityId, type, pageable)
+        return postJpaRepository.findByCommunityIdAndTypeOrderByIsPinnedDescCreatedAtDesc(communityId, type, pageable)
                 .map(this::mapToDomain);
     }
 

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
@@ -79,13 +79,13 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
 
     @Override
     public Page<Post> findByCommunityId(Long communityId, Pageable pageable) {
-        return postJpaRepository.findByCommunityIdOrderByIsPinnedDescCreatedAtDesc(communityId, pageable)
+        return postJpaRepository.findByCommunityIdOrderByIsNoticeDescIsPinnedDescCreatedAtDesc(communityId, pageable)
                 .map(this::mapToDomain);
     }
 
     @Override
     public Page<Post> findByCommunityIdAndType(Long communityId, PostType type, Pageable pageable) {
-        return postJpaRepository.findByCommunityIdAndTypeOrderByIsPinnedDescCreatedAtDesc(communityId, type, pageable)
+        return postJpaRepository.findByCommunityIdAndTypeOrderByIsNoticeDescIsPinnedDescCreatedAtDesc(communityId, type, pageable)
                 .map(this::mapToDomain);
     }
 

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
 
-    Page<PostJpaEntity> findByCommunityIdOrderByIsPinnedDescCreatedAtDesc(Long communityId, Pageable pageable);
+    Page<PostJpaEntity> findByCommunityIdOrderByIsNoticeDescIsPinnedDescCreatedAtDesc(Long communityId, Pageable pageable);
 
-    Page<PostJpaEntity> findByCommunityIdAndTypeOrderByIsPinnedDescCreatedAtDesc(Long communityId, PostType type, Pageable pageable);
+    Page<PostJpaEntity> findByCommunityIdAndTypeOrderByIsNoticeDescIsPinnedDescCreatedAtDesc(Long communityId, PostType type, Pageable pageable);
 
     Page<PostJpaEntity> findByAuthorId(Long authorId, Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
 
-    Page<PostJpaEntity> findByCommunityId(Long communityId, Pageable pageable);
+    Page<PostJpaEntity> findByCommunityIdOrderByIsPinnedDescCreatedAtDesc(Long communityId, Pageable pageable);
 
-    Page<PostJpaEntity> findByCommunityIdAndType(Long communityId, PostType type, Pageable pageable);
+    Page<PostJpaEntity> findByCommunityIdAndTypeOrderByIsPinnedDescCreatedAtDesc(Long communityId, PostType type, Pageable pageable);
 
     Page<PostJpaEntity> findByAuthorId(Long authorId, Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/post/application/port/in/PostAdminUseCase.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/PostAdminUseCase.java
@@ -1,5 +1,6 @@
 package com.venueon.post.application.port.in;
 
-public interface PostPinUseCase {
+public interface PostAdminUseCase {
     void togglePin(Long postId);
+    void toggleNotice(Long postId);
 }

--- a/backend/src/main/java/com/venueon/post/application/port/in/PostPinUseCase.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/PostPinUseCase.java
@@ -1,0 +1,5 @@
+package com.venueon.post.application.port.in;
+
+public interface PostPinUseCase {
+    void togglePin(Long postId);
+}

--- a/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
@@ -19,5 +19,6 @@ public record PostListResponse(
                 int likeCount,
                 boolean isBookmarked,
                 boolean isPinned,
+                boolean isNotice,
                 LocalDateTime createdAt) {
 }

--- a/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/dto/PostListResponse.java
@@ -18,5 +18,6 @@ public record PostListResponse(
                 int commentCount,
                 int likeCount,
                 boolean isBookmarked,
+                boolean isPinned,
                 LocalDateTime createdAt) {
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
@@ -2,6 +2,7 @@ package com.venueon.post.application.service;
 
 import com.venueon.common.annotation.UseCase;
 import com.venueon.post.application.port.in.CreatePostUseCase;
+import com.venueon.post.application.port.in.PostPinUseCase;
 import com.venueon.post.application.port.in.PostBookmarkUseCase;
 import com.venueon.post.application.port.in.PostLikeUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @UseCase
 @RequiredArgsConstructor
 @Transactional
-public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, PostBookmarkUseCase {
+public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, PostBookmarkUseCase, PostPinUseCase {
 
         private final PostRepositoryPort postRepositoryPort;
         private final UserRepositoryPort userRepositoryPort;
@@ -70,7 +71,7 @@ public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, P
                 User user = userRepositoryPort.findByEmail(targetEmail)
                                 .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + targetEmail));
 
-                Post post = postRepositoryPort.findById(postId)
+                postRepositoryPort.findById(postId)
                                 .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
 
                 if (postRepositoryPort.existsBookmark(postId, user.getId())) {
@@ -78,5 +79,14 @@ public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, P
                 } else {
                         postRepositoryPort.saveBookmark(postId, user.getId());
                 }
+        }
+
+        @Override
+        public void togglePin(Long postId) {
+                Post post = postRepositoryPort.findById(postId)
+                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+
+                post.togglePin();
+                postRepositoryPort.save(post);
         }
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostCommandService.java
@@ -2,7 +2,7 @@ package com.venueon.post.application.service;
 
 import com.venueon.common.annotation.UseCase;
 import com.venueon.post.application.port.in.CreatePostUseCase;
-import com.venueon.post.application.port.in.PostPinUseCase;
+import com.venueon.post.application.port.in.PostAdminUseCase;
 import com.venueon.post.application.port.in.PostBookmarkUseCase;
 import com.venueon.post.application.port.in.PostLikeUseCase;
 import com.venueon.post.application.port.in.dto.CreatePostRequest;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @UseCase
 @RequiredArgsConstructor
 @Transactional
-public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, PostBookmarkUseCase, PostPinUseCase {
+public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, PostBookmarkUseCase, PostAdminUseCase {
 
         private final PostRepositoryPort postRepositoryPort;
         private final UserRepositoryPort userRepositoryPort;
@@ -87,6 +87,15 @@ public class PostCommandService implements CreatePostUseCase, PostLikeUseCase, P
                                 .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
 
                 post.togglePin();
+                postRepositoryPort.save(post);
+        }
+
+        @Override
+        public void toggleNotice(Long postId) {
+                Post post = postRepositoryPort.findById(postId)
+                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+
+                post.toggleNotice();
                 postRepositoryPort.save(post);
         }
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
@@ -56,6 +56,7 @@ public class PostQueryService implements GetPostQuery {
                 post.getLikeCount(),
                 isBookmarked,
                 post.isPinned(),
+                post.isNotice(),
                 post.getCreatedAt());
         });
     }
@@ -78,6 +79,7 @@ public class PostQueryService implements GetPostQuery {
                         post.getLikeCount(),
                         true, // 북마크 목록이므로 무조건 true
                         post.isPinned(),
+                        post.isNotice(),
                         post.getCreatedAt()));
     }
 }

--- a/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
@@ -55,6 +55,7 @@ public class PostQueryService implements GetPostQuery {
                 post.getCommentCount(),
                 post.getLikeCount(),
                 isBookmarked,
+                post.isPinned(),
                 post.getCreatedAt());
         });
     }
@@ -76,6 +77,7 @@ public class PostQueryService implements GetPostQuery {
                         post.getCommentCount(),
                         post.getLikeCount(),
                         true, // 북마크 목록이므로 무조건 true
+                        post.isPinned(),
                         post.getCreatedAt()));
     }
 }

--- a/backend/src/main/java/com/venueon/post/domain/model/Post.java
+++ b/backend/src/main/java/com/venueon/post/domain/model/Post.java
@@ -59,7 +59,18 @@ public class Post {
     }
 
     public void togglePin() {
+        if (this.isNotice) {
+            return; // 공지사항은 고정 해제 불가능
+        }
         this.isPinned = !this.isPinned;
     }
 
+    public void toggleNotice() {
+        this.isNotice = !this.isNotice;
+        if (this.isNotice) {
+            this.isPinned = true;
+        } else {
+            this.isPinned = false; // 공지 해제 시 고정도 함께 해제
+        }
+    }
 }

--- a/backend/src/main/java/com/venueon/post/domain/model/Post.java
+++ b/backend/src/main/java/com/venueon/post/domain/model/Post.java
@@ -62,7 +62,4 @@ public class Post {
         this.isPinned = !this.isPinned;
     }
 
-    public void setNotice(boolean isNotice) {
-        this.isNotice = isNotice;
-    }
 }

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -154,6 +154,31 @@
   color: #EF4444;
 }
 
+.adminButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #F9FAFB;
+  border: 1px solid #E5E7EB;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  color: #4B5563;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.adminButton:hover {
+  background-color: #F3F4F6;
+  color: #111827;
+}
+
+.adminButton.active {
+  background-color: #E0E7FF;
+  border-color: #6366F1;
+  color: #4F46E5;
+}
+
 .bodySection {
   margin-bottom: 32px;
 }

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -74,6 +74,10 @@
   margin-bottom: 12px;
 }
 
+.detailPostType {
+  color: #4F46E5;
+}
+
 .detailMeta {
   display: flex;
   align-items: center;
@@ -177,6 +181,18 @@
   background-color: #E0E7FF;
   border-color: #6366F1;
   color: #4F46E5;
+}
+
+.adminButton.noticeActive {
+  background-color: #E0F2FE;
+  border-color: #0284C7;
+  color: #0369A1;
+}
+
+.adminButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: #F3F4F6;
 }
 
 .bodySection {

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -18,6 +18,7 @@ interface PostListResponse {
   likeCount: number;
   isBookmarked: boolean;
   isPinned: boolean;
+  isNotice: boolean;
   createdAt: string;
 }
 
@@ -108,14 +109,13 @@ export default function CommunityPostContainer({ communityId }: Props) {
         body: JSON.stringify({
           postId: selectedPostId,
           content: value,
-          parentId: null // 나중에 대댓글 구현 시 확장
+          parentId: null
         }),
       });
 
       if (!response.ok) throw new Error('댓글 등록 실패');
 
       showToast('댓글 등록 완료', 'success');
-      // 댓글 목록 갱신
       fetchComments(selectedPostId);
     } catch (error) {
       console.error(error);
@@ -141,7 +141,6 @@ export default function CommunityPostContainer({ communityId }: Props) {
 
       if (!response.ok) throw new Error('좋아요 처리 실패');
 
-      // 게시글 목록 새로고침 (로딩 표시 없이 데이터만 갱신)
       fetchPosts(true);
     } catch (error) {
       console.error(error);
@@ -162,13 +161,13 @@ export default function CommunityPostContainer({ communityId }: Props) {
       if (!response.ok) throw new Error('북마크 처리 실패');
 
       showToast('북마크 상태가 변경되었습니다.', 'success');
-      // 게시글 목록 새로고침 (아이콘 상태 반영)
       fetchPosts(true);
     } catch (error) {
       console.error(error);
       showToast('북마크 처리 실패', 'error');
     }
   };
+
   const handlePinToggle = async () => {
     if (!selectedPostId) return;
 
@@ -187,6 +186,24 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   };
 
+  const handleNoticeToggle = async () => {
+    if (!selectedPostId) return;
+
+    try {
+      const response = await fetch(`/api/posts/${selectedPostId}/notice`, {
+        method: 'PATCH',
+      });
+
+      if (!response.ok) throw new Error('공지 처리 실패');
+
+      showToast('공지 상태가 변경되었습니다.', 'success');
+      fetchPosts(true);
+    } catch (error) {
+      console.error(error);
+      showToast('공지 처리 실패', 'error');
+    }
+  };
+
   const handleCommentLikeToggle = async (commentId: number) => {
     try {
       const response = await fetch(`/api/comments/${commentId}/like`, {
@@ -200,7 +217,6 @@ export default function CommunityPostContainer({ communityId }: Props) {
 
       if (!response.ok) throw new Error('댓글 좋아요 실패');
 
-      // 댓글 목록만 새로고침 (로딩 표시 없이 데이터만 갱신)
       if (selectedPostId) {
         fetchComments(selectedPostId, true);
       }
@@ -220,12 +236,22 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   }, [selectedPostId]);
 
+  const postTypeToKorean = (type: string) => {
+    switch (type) {
+      case 'NOTICE': return '공지';
+      case 'FREE': return '자유';
+      case 'QUESTION': return '질문';
+      case 'INFO': return '정보';
+      default: return '일반';
+    }
+  };
+
   const selectedPost = posts.find(p => p.id === selectedPostId) || null;
 
   return (
     <div className={styles.container}>
 
-      {/* 1. 좌측: 리스트 영역 (너비 고정) */}
+      {/* 1. 좌측: 리스트 영역 */}
       <div className={styles.leftSidebar}>
         <div className={styles.searchRow}>
           <div className={styles.searchInputWrapper}>
@@ -238,13 +264,9 @@ export default function CommunityPostContainer({ communityId }: Props) {
 
         <div className={styles.postList}>
           {isLoading ? (
-            <div className={styles.loadingOrEmpty}>
-              데이터를 불러오는 중입니다...
-            </div>
+            <div className={styles.loadingOrEmpty}>데이터를 불러오는 중입니다...</div>
           ) : posts.length === 0 ? (
-            <div className={styles.loadingOrEmpty}>
-              게시글이 없습니다.
-            </div>
+            <div className={styles.loadingOrEmpty}>게시글이 없습니다.</div>
           ) : (
             posts.map(post => (
               <CommunityPostItem
@@ -255,12 +277,13 @@ export default function CommunityPostContainer({ communityId }: Props) {
                 selected={post.id === selectedPostId}
                 onClick={() => setSelectedPostId(post.id)}
                 isPinned={post.isPinned}
+                isNotice={post.isNotice}
+                type={post.type}
               />
             ))
           )}
         </div>
 
-        {/* 좌측 리스트 페이징 영역 */}
         {totalPages > 1 && (
           <div className={styles.paginationWrapper}>
             <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
@@ -268,15 +291,14 @@ export default function CommunityPostContainer({ communityId }: Props) {
         )}
       </div>
 
-      {/* 2. 우측: 디테일 영역 (나머지 공간 전부 차지) */}
+      {/* 2. 우측: 디테일 영역 */}
       <div className={styles.rightDetail}>
         {selectedPost ? (
           <>
-            {/* 2-1. 상세 상단 헤더 */}
             <div className={styles.detailHeader}>
               <div>
                 <h2 className={styles.detailTitle}>
-                  {selectedPost.title}
+                  <span className={styles.detailPostType}>[{postTypeToKorean(selectedPost.type)}]</span> {selectedPost.title}
                 </h2>
                 <div className={styles.detailMeta}>
                   <span>{new Date(selectedPost.createdAt).toLocaleDateString()} / {new Date(selectedPost.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
@@ -302,7 +324,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
                   </svg>
                   <span>{selectedPost.likeCount}</span>
                 </button>
-                 <button
+                <button
                   className={styles.bookmarkButton}
                   onClick={handleBookmarkToggle}
                   title="북마크"
@@ -324,34 +346,37 @@ export default function CommunityPostContainer({ communityId }: Props) {
                 <button
                   className={`${styles.adminButton} ${selectedPost.isPinned ? styles.active : ''}`}
                   onClick={handlePinToggle}
-                  title="상단 고정"
+                  title={selectedPost.isNotice ? "공지사항은 고정 해제가 불가능합니다" : "상단 고정"}
+                  disabled={selectedPost.isNotice}
                 >
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <line x1="12" y1="17" x2="12" y2="22" /><path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.79-.9A2 2 0 0 1 15 10.76V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3v4.76a2 2 0 0 1-1.11 1.79l-1.79.9A2 2 0 0 0 5 15.24Z" />
                   </svg>
                 </button>
-                <button className={styles.optionButton} type="button">
-                  •••
+                <button
+                  className={`${styles.adminButton} ${selectedPost.isNotice ? styles.noticeActive : ''}`}
+                  onClick={handleNoticeToggle}
+                  title="공지 설정"
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="m3 11 18-5v12L3 14v-3z" /><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+                  </svg>
                 </button>
+                <button className={styles.optionButton} type="button">•••</button>
               </div>
             </div>
 
-            {/* 2-2. 작성자 및 본문 영역 */}
             <div className={styles.bodySection}>
               <div className={styles.authorWrapper}>
                 <UserProfile name={selectedPost.authorNickname} size="medium" />
               </div>
               <div className={styles.contentWrapper}>
                 {selectedPost.content?.split('\n').map((line, index) => (
-                  <React.Fragment key={index}>
-                    {line}
-                    <br />
-                  </React.Fragment>
+                  <React.Fragment key={index}>{line}<br /></React.Fragment>
                 ))}
               </div>
             </div>
 
-            {/* 2-3. 댓글 입력 영역 */}
             <div className={styles.commentInputWrapper}>
               <CommentInput
                 onSubmit={handleCommentSubmit}
@@ -360,7 +385,6 @@ export default function CommunityPostContainer({ communityId }: Props) {
               />
             </div>
 
-            {/* 2-4. 댓글 리스트 영역 */}
             <div className={styles.commentList}>
               {isCommentsLoading ? (
                 <div className={styles.commentStatus}>댓글을 불러오는 중...</div>
@@ -382,12 +406,9 @@ export default function CommunityPostContainer({ communityId }: Props) {
             </div>
           </>
         ) : (
-          <div className={styles.emptyDetail}>
-            선택된 게시물이 없습니다.
-          </div>
+          <div className={styles.emptyDetail}>선택된 게시물이 없습니다.</div>
         )}
       </div>
-
     </div>
   );
 }

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -17,6 +17,7 @@ interface PostListResponse {
   commentCount: number;
   likeCount: number;
   isBookmarked: boolean;
+  isPinned: boolean;
   createdAt: string;
 }
 
@@ -44,6 +45,7 @@ interface Props {
 
 export default function CommunityPostContainer({ communityId }: Props) {
   const { showToast } = useUIStore();
+
   const [posts, setPosts] = useState<PostListResponse[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -167,6 +169,23 @@ export default function CommunityPostContainer({ communityId }: Props) {
       showToast('북마크 처리 실패', 'error');
     }
   };
+  const handlePinToggle = async () => {
+    if (!selectedPostId) return;
+
+    try {
+      const response = await fetch(`/api/posts/${selectedPostId}/pin`, {
+        method: 'PATCH',
+      });
+
+      if (!response.ok) throw new Error('고정 처리 실패');
+
+      showToast('고정 상태가 변경되었습니다.', 'success');
+      fetchPosts(true);
+    } catch (error) {
+      console.error(error);
+      showToast('고정 처리 실패', 'error');
+    }
+  };
 
   const handleCommentLikeToggle = async (commentId: number) => {
     try {
@@ -235,6 +254,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
                 date={new Date(post.createdAt).toLocaleDateString() + ' / ' + new Date(post.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                 selected={post.id === selectedPostId}
                 onClick={() => setSelectedPostId(post.id)}
+                isPinned={post.isPinned}
               />
             ))
           )}
@@ -282,7 +302,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
                   </svg>
                   <span>{selectedPost.likeCount}</span>
                 </button>
-                <button
+                 <button
                   className={styles.bookmarkButton}
                   onClick={handleBookmarkToggle}
                   title="북마크"
@@ -299,6 +319,15 @@ export default function CommunityPostContainer({ communityId }: Props) {
                     strokeLinejoin="round"
                   >
                     <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+                  </svg>
+                </button>
+                <button
+                  className={`${styles.adminButton} ${selectedPost.isPinned ? styles.active : ''}`}
+                  onClick={handlePinToggle}
+                  title="상단 고정"
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="12" y1="17" x2="12" y2="22" /><path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.79-.9A2 2 0 0 1 15 10.76V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3v4.76a2 2 0 0 1-1.11 1.79l-1.79.9A2 2 0 0 0 5 15.24Z" />
                   </svg>
                 </button>
                 <button className={styles.optionButton} type="button">

--- a/frontend/src/app/community/components/CommunityPostItem.module.css
+++ b/frontend/src/app/community/components/CommunityPostItem.module.css
@@ -30,24 +30,47 @@
   align-self: stretch;
 }
 
-.noticeBadge {
-  background-color: #fee2e2;
-  color: #ef4444;
-  font-size: 10px;
-  font-weight: 700;
-  padding: 2px 6px;
-  border-radius: 4px;
+.noticeBadge, .pinBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
   white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.noticeBadge {
+  background-color: #E0F2FE; /* Sky 100 */
+  color: #0284C7;            /* Sky 600 */
+  border: 1px solid #BAE6FD; /* Sky 200 */
 }
 
 .pinBadge {
-  background-color: #f3f4f6;
-  color: #374151;
-  font-size: 10px;
+  background-color: #E0E7FF;
+  color: #4F46E5;
+  border: 1px solid #C7D2FE;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  flex: 1;
+  min-width: 0;
+}
+
+.postType {
+  font-size: 14px;
   font-weight: 700;
-  padding: 2px 6px;
-  border-radius: 4px;
+  color: #4F46E5; /* 포인트 보라색 */
   white-space: nowrap;
+}
+
+.selected .postType {
+  color: #C7D2FE; /* 선택 시 더 밝은 보라색 */
 }
 
 /* --------- 제목 --------- */
@@ -55,7 +78,7 @@
   font: var(--text-body-bold);            /* 700 14px/150% */
   color: var(--color-text-gray-900);      /* #111827 */
   margin: 0;
-  align-self: stretch;
+  flex: 1;
 
   /* 2줄 말줄임 */
   display: -webkit-box;

--- a/frontend/src/app/community/components/CommunityPostItem.module.css
+++ b/frontend/src/app/community/components/CommunityPostItem.module.css
@@ -22,6 +22,34 @@
   background: var(--color-text-gray-900); /* #111827 */
 }
 
+/* --------- 타이틀 래퍼 --------- */
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  align-self: stretch;
+}
+
+.noticeBadge {
+  background-color: #fee2e2;
+  color: #ef4444;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.pinBadge {
+  background-color: #f3f4f6;
+  color: #374151;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
 /* --------- 제목 --------- */
 .title {
   font: var(--text-body-bold);            /* 700 14px/150% */

--- a/frontend/src/app/community/components/CommunityPostItem.tsx
+++ b/frontend/src/app/community/components/CommunityPostItem.tsx
@@ -17,6 +17,8 @@ export interface CommunityPostItemProps {
   selected?: boolean;
   /** 클릭 핸들러 */
   onClick?: () => void;
+  /** 상단 고정 여부 */
+  isPinned?: boolean;
 }
 
 export default function CommunityPostItem({
@@ -26,6 +28,7 @@ export default function CommunityPostItem({
   avatarUrl,
   selected = false,
   onClick,
+  isPinned = false,
 }: CommunityPostItemProps) {
   const rootClass = selected
     ? `${styles.item} ${styles.selected}`
@@ -33,7 +36,10 @@ export default function CommunityPostItem({
 
   return (
     <div className={rootClass} onClick={onClick} role="button" tabIndex={0}>
-      <p className={styles.title}>{title}</p>
+      <div className={styles.titleWrapper}>
+        {isPinned && <span className={styles.pinBadge}>고정</span>}
+        <p className={styles.title}>{title}</p>
+      </div>
 
       <div className={styles.meta}>
         <UserProfile name={username} imageUrl={avatarUrl} size="medium" />

--- a/frontend/src/app/community/components/CommunityPostItem.tsx
+++ b/frontend/src/app/community/components/CommunityPostItem.tsx
@@ -19,6 +19,10 @@ export interface CommunityPostItemProps {
   onClick?: () => void;
   /** 상단 고정 여부 */
   isPinned?: boolean;
+  /** 공지 여부 */
+  isNotice?: boolean;
+  /** 게시글 타입 (말머리) */
+  type?: string;
 }
 
 export default function CommunityPostItem({
@@ -29,6 +33,8 @@ export default function CommunityPostItem({
   selected = false,
   onClick,
   isPinned = false,
+  isNotice = false,
+  type = 'FREE',
 }: CommunityPostItemProps) {
   const rootClass = selected
     ? `${styles.item} ${styles.selected}`
@@ -37,8 +43,31 @@ export default function CommunityPostItem({
   return (
     <div className={rootClass} onClick={onClick} role="button" tabIndex={0}>
       <div className={styles.titleWrapper}>
-        {isPinned && <span className={styles.pinBadge}>고정</span>}
-        <p className={styles.title}>{title}</p>
+        {isNotice && (
+          <span className={styles.noticeBadge}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m3 11 18-5v12L3 14v-3z" /><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+            </svg>
+            공지
+          </span>
+        )}
+        {isPinned && !isNotice && (
+          <span className={styles.pinBadge}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="12" y1="17" x2="12" y2="22" /><path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.79-.9A2 2 0 0 1 15 10.76V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3v4.76a2 2 0 0 1-1.11 1.79l-1.79.9A2 2 0 0 0 5 15.24Z" />
+            </svg>
+            고정
+          </span>
+        )}
+        <div className={styles.titleRow}>
+          <span className={styles.postType}>[{
+            type === 'NOTICE' ? '공지' : 
+            type === 'FREE' ? '자유' : 
+            type === 'QUESTION' ? '질문' : 
+            type === 'INFO' ? '정보' : '일반'
+          }]</span>
+          <p className={styles.title}>{title}</p>
+        </div>
       </div>
 
       <div className={styles.meta}>


### PR DESCRIPTION
1. 주요 구현 내용
공지사항(Notice) 및 상단 고정(Pin) 기능 추가: 게시글별 공지/고정 상태를 토글할 수 있는 API 및 UI 구현.

정렬 로직 고도화: 게시글 목록 조회 시 공지사항 > 상단 고정글 > 최신순의 3단계 우선순위로 정렬되도록 DB 쿼리 구현.

비즈니스 규칙 적용:
공지글 설정 시 자동으로 상단 고정 활성화.
공지글 해제 시 상단 고정도 함께 해제하여 일관성 유지.
공지글 상태에서는 임의로 상단 고정을 해제할 수 없도록 UI 및 도메인 로직 방어.

UI/UX 개선:
게시글 목록 및 상세 페이지 제목에 말머리(글 타입) 텍스트 명시.

2. 추후 과제 (TODO)
권한 부여(Authorization) 적용: 현재는 기능 구현 중심으로 전 사용자가 접근 가능하므로, 이후 작업에서 호스트 및 관리자(Admin) 권한 체크 로직을 API 핸들러 및 UseCase에 통합할 예정입니다.

VO-651 VO-652