### PR TITLE
feat: 프로필 설정 뱃지/탈퇴 구현 및 대시보드 요약 카드 DB 연동 (VO-701, VO-702, VO-703)

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -144,6 +144,16 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
         return orderJpaRepository.findValidOrdersByUserIdAndEventStatuses(userId, hasStatuses, statuses, pageable).map(this::toDomain);
     }
 
+    @Override
+    public long countOngoingByUserId(Long userId) {
+        return orderJpaRepository.countOngoingByUserId(userId);
+    }
+
+    @Override
+    public long countCompletedByUserId(Long userId) {
+        return orderJpaRepository.countCompletedByUserId(userId);
+    }
+
     // --- Mapper ---
     private Order toDomain(OrderJpaEntity entity) {
         return new Order(

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -71,4 +71,14 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     List<OrderJpaEntity> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);
 
     Page<OrderJpaEntity> findByEventIdIn(List<Long> eventIds, Pageable pageable);
+
+    @Query("SELECT COUNT(o) FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
+           "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
+           "o.event.status = 'ONGOING'")
+    long countOngoingByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(o) FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
+           "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
+           "o.event.status = 'ENDED'")
+    long countCompletedByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -27,4 +27,8 @@ public interface OrderRepositoryPort {
     Page<Order> findByUserId(Long userId, Pageable pageable);
 
     Page<Order> findValidOrdersByUserId(Long userId, String tab, Pageable pageable);
+
+    long countOngoingByUserId(Long userId);
+
+    long countCompletedByUserId(Long userId);
 }

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
@@ -3,31 +3,28 @@ package com.venueon.user.adapter.in.web;
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.user.adapter.in.web.dto.MyPageSummaryResponse;
 import com.venueon.user.application.port.in.GetMyPageSummaryUseCase;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/mypage")
+@RequiredArgsConstructor
 public class MyPageController {
 
     private final GetMyPageSummaryUseCase getMyPageSummaryUseCase;
 
-    public MyPageController(GetMyPageSummaryUseCase getMyPageSummaryUseCase) {
-        this.getMyPageSummaryUseCase = getMyPageSummaryUseCase;
-    }
-
     /**
      * 프론트엔드 대시보드에서 사용하는 마이페이지 상단 요약 데이터 API
+     * GET /mypage/summary
      */
     @GetMapping("/summary")
-    public ResponseEntity<ApiResponse<MyPageSummaryResponse>> getMyPageSummary(@AuthenticationPrincipal Long userId) {
-        // 인증 객체에서 유저 ID를 안전하게 파싱 (임시로 1L 세팅 시큐리티 구조에 따라 수정 요망)
-        Long currentUserId = userId != null ? userId : 1L; 
-        
-        MyPageSummaryResponse response = getMyPageSummaryUseCase.getSummary(currentUserId);
+    public ResponseEntity<ApiResponse<MyPageSummaryResponse>> getMyPageSummary(Authentication authentication) {
+        String email = authentication.getName();
+        MyPageSummaryResponse response = getMyPageSummaryUseCase.getSummary(email);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/venueon/user/application/port/in/GetMyPageSummaryUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/GetMyPageSummaryUseCase.java
@@ -3,5 +3,5 @@ package com.venueon.user.application.port.in;
 import com.venueon.user.adapter.in.web.dto.MyPageSummaryResponse;
 
 public interface GetMyPageSummaryUseCase {
-    MyPageSummaryResponse getSummary(Long userId);
+    MyPageSummaryResponse getSummary(String email);
 }

--- a/backend/src/main/java/com/venueon/user/application/service/MyPageService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/MyPageService.java
@@ -1,19 +1,44 @@
 package com.venueon.user.application.service;
 
+import com.venueon.common.exception.BusinessException;
+import com.venueon.common.exception.ErrorCode;
+import com.venueon.order.application.port.out.OrderRepositoryPort;
 import com.venueon.user.adapter.in.web.dto.MyPageSummaryResponse;
 import com.venueon.user.application.port.in.GetMyPageSummaryUseCase;
+import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class MyPageService implements GetMyPageSummaryUseCase {
 
-    @Override
-    public MyPageSummaryResponse getSummary(Long userId) {
-        // TODO: OrderRepository, ReviewRepository, BadgeRepository 연동하여 실제 카운트 쿼리 작성 (현재는 연동 준비용 Mock 반환)
-        long mockOngoingCourse = 2L;
-        long mockPendingReview = 1L;
-        long mockEarnedBadge = 5L;
+    private final UserRepositoryPort userRepositoryPort;
+    private final OrderRepositoryPort orderRepositoryPort;
 
-        return new MyPageSummaryResponse(mockOngoingCourse, mockPendingReview, mockEarnedBadge);
+    @Override
+    public MyPageSummaryResponse getSummary(String email) {
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "사용자를 찾을 수 없습니다."));
+
+        Long userId = user.getId();
+
+        // 1. 참여 중인 세션 = 진행 중(ONGOING) 이벤트의 유효 주문 수
+        long ongoingCount = orderRepositoryPort.countOngoingByUserId(userId);
+
+        // 2. 리뷰를 기다리는 세션 = 종료(ENDED) 이벤트의 유효 주문 수
+        //    (리뷰 테이블이 아직 없으므로, 종료된 이벤트 전체를 리뷰 대기로 간주)
+        long pendingReviewCount = orderRepositoryPort.countCompletedByUserId(userId);
+
+        // 3. 획득한 뱃지 = 아직 DB 테이블 없음, 0 반환
+        long earnedBadgeCount = 0L;
+
+        log.debug("마이페이지 요약 조회: email={}, ongoing={}, pendingReview={}, badges={}",
+                email, ongoingCount, pendingReviewCount, earnedBadgeCount);
+
+        return new MyPageSummaryResponse(ongoingCount, pendingReviewCount, earnedBadgeCount);
     }
 }

--- a/frontend/src/app/mypage/profile/page.module.css
+++ b/frontend/src/app/mypage/profile/page.module.css
@@ -4,8 +4,30 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-24);
+  gap: var(--space-80);
   width: 100%;
+}
+
+.sectionBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  gap: var(--space-16);
+}
+
+.rowSectionBlock {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: var(--space-24);
+}
+
+.rowSectionBlock .headerGroup {
+  width: auto;
+  flex: 1;
 }
 
 .pageTitle {
@@ -14,18 +36,16 @@
   margin: 0;
 }
 
-.profileSection {
+/* 이미지와 폼 필드 그룹퍼 (기존 profileSection 대체) */
+.profileForm {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
-  max-width: 458px;
-  /* Figma: 458px */
-  padding-top: var(--space-24);
   gap: var(--space-32);
 }
 
-/* 프로필 이미지 (Frame 93) */
+/* 프로필 이미지 */
 .imageRow {
   display: flex;
   flex-direction: row;
@@ -49,7 +69,7 @@
   display: none !important;
 }
 
-/* 이미지 조작 버튼 영역 (Frame 94) */
+/* 이미지 조작 버튼 영역 */
 .imageButtons {
   display: flex;
   flex-direction: row;
@@ -74,6 +94,8 @@
   /* 입력 필드 사이 간격 */
 }
 
+
+
 /* 하단 버튼 영역 (Frame 54) */
 .actionButtons {
   display: flex;
@@ -81,31 +103,24 @@
   justify-content: flex-end;
   gap: var(--space-12);
   width: 100%;
-  max-width: 410px;
   margin-top: var(--space-8);
 }
 
 .actionButtons>button {
-  flex: 1;
-  /* 너비를 똑같이 반반씩 나눠가짐 */
+  width: 200px;
+  /* 요청에 따라 200px로 넓게 고정 */
 }
 
-/* 추가 설정용 섹션 */
-.sectionHeader {
+/* 타이틀 및 서브타이틀 그룹 */
+.headerGroup {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  margin-bottom: var(--space-16);
+  gap: var(--space-8);
+  width: 100%;
 }
 
-.sectionHeader h3 {
-  font: var(--text-h3-bold);
-  color: var(--color-text-gray-900);
-  margin: 0;
-}
-
-.sectionHeader p {
-  font: var(--text-body-small);
+.subtitle {
+  font: var(--text-body-regular);
   color: var(--color-text-gray-500);
   margin: 0;
 }
@@ -114,36 +129,4 @@
   display: flex;
   flex-flow: row wrap;
   gap: var(--space-12);
-}
-
-/* Tabs.module.css의 pillTab 복사 */
-.pillTab {
-  padding: var(--space-8) var(--space-16);
-  height: 36px;
-  background: var(--color-surface); /* #F3F4F6 (Gray/100) */
-  border-radius: var(--radius-full);
-  /* Body/Medium */
-  font: var(--text-body-medium);
-  /* 150% */
-  color: var(--color-text-gray-500); /* #6B7280 */
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.pillTabActive {
-  background: var(--color-secondary); /* #4B5563 (Brand/secondary) */
-  color: var(--color-text-white); /* #FFFFFF */
-}
-
-.dangerZone {
-  width: 100%;
-  max-width: 410px;
-  margin-top: var(--space-32);
-  padding-top: var(--space-32);
-  border-top: 1px solid var(--color-border);
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-16);
 }

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -8,6 +8,7 @@ import UploadModal from '@/components/modal/UploadModal';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import { useUIStore } from '@/store/useUIStore';
 import { useAuth } from '@/store/useAuthStore';
+import tabsStyles from '@/components/ui/Tabs.module.css';
 import styles from './page.module.css';
 
 
@@ -43,17 +44,17 @@ export default function ProfileSettingsPage() {
       try {
         const catRes = await fetch('/api/categories');
         if (catRes.ok) {
-           const catData = await catRes.json();
-           if (catData.data) {
-             setAvailableCategories(catData.data);
-           }
+          const catData = await catRes.json();
+          if (catData.data) {
+            setAvailableCategories(catData.data);
+          }
         }
       } catch (e) {
         console.error("Failed to load categories", e);
       }
     };
     fetchMetadata();
-    
+
     const fetchProfile = async () => {
       try {
         const res = await fetch('/api/auth/me'); // BFF proxy (iron-session) handles JWT
@@ -68,12 +69,12 @@ export default function ProfileSettingsPage() {
           setBaseEmail(fetchedEmail);
           setBaseName(fetchedName);
           setBaseImage(fetchedImg);
-          
+
           // 확장 설정
           // 현재 /api/auth/me (또는 user profile API)에서 카테고리와 뱃지 정보가 넘어오지 않으면 빈값으로 치환
           const fetchedCategories = data.categories || [];
           const fetchedBadge = data.showBadge ?? true;
-          
+
           setBaseCategories(fetchedCategories);
           setBaseBadge(fetchedBadge);
 
@@ -153,7 +154,7 @@ export default function ProfileSettingsPage() {
         },
         body: JSON.stringify({
           nickname: userName,
-          profileImg: profileImage, 
+          profileImg: profileImage,
           categories: categories,
           showBadge: showBadge,
         }),
@@ -166,7 +167,7 @@ export default function ProfileSettingsPage() {
         setBaseCategories(categories);
         setBaseBadge(showBadge);
         showToast('내 정보 수정이 완료되었습니다.', 'success');
-        
+
         // 헤더 갱신 (저장 성공 시) - 강제로 로컬 스토어의 유저 정보 동기화
         const { updateUser } = useAuth.getState();
         updateUser({ nickname: userName, profileImg: profileImage });
@@ -208,114 +209,111 @@ export default function ProfileSettingsPage() {
       <div className="sidebar-content">
         <div className={styles.content}>
           {/* 페이지 타이틀 */}
-          <h1 className={styles.pageTitle}>프로필 설정</h1>
+          <div className={styles.sectionBlock}>
+            <h1 className={styles.pageTitle}>프로필 설정</h1>
 
-          <div className={styles.profileSection}>
-            {/* 프로필 사진 + 변경/삭제 */}
-            <div className={styles.imageRow}>
-              {/* 공용 UserProfile 을 사용하되, CSS로 사진 크기 72px 변경 및 텍스트 숨김 처리 */}
-              <UserProfile
-                name="장회원"
-                imageUrl={profileImage}
-                className={styles.customProfile}
-              />
+            <div className={styles.profileForm}>
+              {/* 프로필 사진 + 변경/삭제 */}
+              <div className={styles.imageRow}>
+                {/* 공용 UserProfile 을 사용하되, CSS로 사진 크기 72px 변경 및 텍스트 숨김 처리 */}
+                <UserProfile
+                  name="장회원"
+                  imageUrl={profileImage}
+                  className={styles.customProfile}
+                />
 
-              <div className={styles.imageButtons}>
-                <Button variant="primary" onClick={handleImageChangeClick}>
-                  프로필 사진 변경
-                </Button>
-                <Button variant="secondary" onClick={handleDeleteImage}>
-                  이미지 삭제
-                </Button>
+                <div className={styles.imageButtons}>
+                  <Button variant="primary" onClick={handleImageChangeClick}>
+                    프로필 사진 변경
+                  </Button>
+                  <Button variant="secondary" onClick={handleDeleteImage}>
+                    이미지 삭제
+                  </Button>
+                </div>
               </div>
-            </div>
 
-            {/* 입력 폼 */}
-            <div className={styles.formGroup}>
-              {/* 이메일 (수정 불가) */}
-              <InputField
-                label="이메일"
-                value={userEmail}
-                disabled
-              />
-              {/* 이름 확인/수정 폼 */}
-              <InputField
-                label="이름"
-                placeholder="이름을 입력하세요"
-                value={userName}
-                onChange={(e) => setUserName(e.target.value)}
-              />
-            </div>
-
-            <div className={styles.actionButtons}>
-              <Button
-                variant="secondary"
-                size="large"
-                disabled={!isDirty}
-                onClick={handleCancelClick}
-              >
-                취소
-              </Button>
-              <Button
-                variant="primary"
-                size="large"
-                disabled={!isDirty}
-                onClick={handleSave}
-              >
-                저장
-              </Button>
+              {/* 입력 폼 */}
+              <div className={styles.formGroup}>
+                {/* 이메일 (수정 불가) */}
+                <InputField
+                  label="이메일"
+                  value={userEmail}
+                  disabled
+                />
+                {/* 이름 확인/수정 폼 */}
+                <InputField
+                  label="이름"
+                  placeholder="이름을 입력하세요"
+                  value={userName}
+                  onChange={(e) => setUserName(e.target.value)}
+                />
+              </div>
             </div>
           </div>
 
-          <hr style={{ width: '100%', maxWidth: '458px', border: 'none', borderTop: '1px solid var(--color-border)', margin: '48px 0' }} />
-
-          <h1 className={styles.pageTitle}>관심 카테고리 설정</h1>
-          <div className={styles.profileSection}>
-            <div className={styles.formGroup}>
-              <div className={styles.sectionHeader}>
-                <p>관심있는 카테고리를 선택해주세요. 맞춤 세션을 추천해 드립니다.</p>
-              </div>
-              <div className={styles.categoryPills}>
-                {availableCategories.map(cat => (
-                  <button
-                    key={cat}
-                    type="button"
-                    className={`${styles.pillTab} ${categories.includes(cat) ? styles.pillTabActive : ''}`}
-                    onClick={() => {
-                        if (categories.includes(cat)) {
-                           setCategories(categories.filter(c => c !== cat));
-                        } else {
-                           setCategories([...categories, cat]);
-                        }
-                    }}
-                  >
-                    {cat}
-                  </button>
-                ))}
-              </div>
+          <div className={styles.sectionBlock}>
+            <div className={styles.headerGroup}>
+              <h1 className={styles.pageTitle}>관심 카테고리 설정</h1>
+              <p className={styles.subtitle}>관심있는 카테고리를 선택해주세요. 맞춤 세션을 추천해 드립니다.</p>
             </div>
-
-            <div className={styles.formGroup} style={{ marginTop: '16px' }}>
-               <div className={styles.sectionHeader}>
-                 <h3>뱃지 노출 여부</h3>
-                 <p>커뮤니티 등에서 내 프로필 옆에 활동 뱃지를 공개할지 설정합니다.</p>
-               </div>
-               <Toggle
-                 checked={showBadge}
-                 onChange={(e) => setShowBadge(e.target.checked)}
-                 label="내 프로필에 뱃지 노출 켜기"
-               />
+            <div className={styles.categoryPills}>
+              {availableCategories.map(cat => (
+                <button
+                  key={cat}
+                  type="button"
+                  className={`${tabsStyles.tabButton} ${tabsStyles.pillTab} ${categories.includes(cat) ? tabsStyles.pillTabActive : ''}`}
+                  onClick={() => {
+                    if (categories.includes(cat)) {
+                      setCategories(categories.filter(c => c !== cat));
+                    } else {
+                      setCategories([...categories, cat]);
+                    }
+                  }}
+                >
+                  {cat}
+                </button>
+              ))}
             </div>
+          </div>
 
-            <div className={styles.dangerZone}>
-               <div className={styles.sectionHeader}>
-                 <h3 style={{ color: 'var(--color-text-danger)' }}>계정 탈퇴</h3>
-                 <p>탈퇴 시 모든 결제 내역과 참여 커뮤니티 기록이 영구적으로 삭제됩니다!</p>
-               </div>
-               <Button variant="secondary" onClick={() => setIsDeleteModalOpen(true)} style={{ color: 'var(--color-text-danger)'}}>
-                 계정 안전하게 탈퇴하기
-               </Button>
+          <div className={styles.rowSectionBlock}>
+            <div className={styles.headerGroup}>
+              <h1 className={styles.pageTitle}>뱃지 노출 여부</h1>
+              <p className={styles.subtitle}>커뮤니티 등에서 내 프로필 옆에 활동 뱃지를 공개할지 설정합니다.</p>
             </div>
+            <Toggle
+              checked={showBadge}
+              onChange={(e) => setShowBadge(e.target.checked)}
+            />
+          </div>
+
+          <div className={styles.rowSectionBlock}>
+            <div className={styles.headerGroup}>
+              <h1 className={styles.pageTitle}>계정 탈퇴</h1>
+              <p className={styles.subtitle}>탈퇴 시 모든 결제 내역과 참여 커뮤니티 기록이 영구적으로 삭제됩니다.</p>
+            </div>
+            <Button variant="danger" onClick={() => setIsDeleteModalOpen(true)} style={{ whiteSpace: 'nowrap' }}>
+              계정 탈퇴하기
+            </Button>
+          </div>
+
+          <div className={styles.actionButtons}>
+            <Button
+              variant="secondary"
+              size="large"
+              disabled={!isDirty}
+              onClick={handleCancelClick}
+            >
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              size="large"
+              disabled={!isDirty}
+              onClick={handleSave}
+            >
+              저장
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/mypage/security/page.module.css
+++ b/frontend/src/app/mypage/security/page.module.css
@@ -1,0 +1,49 @@
+/* src/app/mypage/security/page.module.css */
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-32);
+  width: 100%;
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.profileSection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 458px;
+  gap: var(--space-32);
+}
+
+/* 입력 필드 폼 영역 */
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 410px;
+  gap: var(--space-24);
+}
+
+/* 하단 버튼 영역 */
+.actionButtons {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: var(--space-12);
+  width: 100%;
+  max-width: 410px;
+  margin-top: var(--space-8);
+}
+
+.actionButtons>button {
+  flex: 1;
+}

--- a/frontend/src/app/mypage/security/page.tsx
+++ b/frontend/src/app/mypage/security/page.tsx
@@ -6,8 +6,8 @@ import { Button, InputField } from '@/components/ui';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import { useUIStore } from '@/store/useUIStore';
 
-// 프로필 페이지의 CSS를 재사용합니다
-import styles from '../profile/page.module.css';
+// 원래 사용하던 이전 버전의 CSS 복구하여 임포트
+import styles from './page.module.css';
 
 export default function SecuritySettingsPage() {
   const { showToast } = useUIStore();
@@ -85,7 +85,7 @@ export default function SecuritySettingsPage() {
           <h1 className={styles.pageTitle}>계정 보안</h1>
 
           <div className={styles.profileSection}>
-            <div className={styles.formGroup} style={{ gap: '24px' }}>
+            <div className={styles.formGroup}>
               <InputField 
                 label="현재 비밀번호" 
                 type="password"

--- a/frontend/src/components/icons/ProfileIcon.tsx
+++ b/frontend/src/components/icons/ProfileIcon.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default function ProfileIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <path d="M10.0003 8.33317C11.8413 8.33317 13.3337 6.84079 13.3337 4.99984C13.3337 3.15889 11.8413 1.6665 10.0003 1.6665C8.15938 1.6665 6.66699 3.15889 6.66699 4.99984C6.66699 6.84079 8.15938 8.33317 10.0003 8.33317Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-      <path d="M17.5 18.3335C17.5 14.1914 14.1421 10.8335 10 10.8335C5.85787 10.8335 2.5 14.1914 2.5 18.3335" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M9.99967 8.33333C11.6105 8.33333 12.9163 7.0275 12.9163 5.41667C12.9163 3.80584 11.6105 2.5 9.99967 2.5C8.38884 2.5 7.08301 3.80584 7.08301 5.41667C7.08301 7.0275 8.38884 8.33333 9.99967 8.33333Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2.5 16.9998V17.4998H17.5V16.9998C17.5 15.133 17.5 14.1996 17.1367 13.4865C16.8171 12.8593 16.3072 12.3494 15.68 12.0298C14.9669 11.6665 14.0335 11.6665 12.1667 11.6665H7.83333C5.9665 11.6665 5.03308 11.6665 4.32004 12.0298C3.69283 12.3494 3.18289 12.8593 2.86331 13.4865C2.5 14.1996 2.5 15.133 2.5 16.9998Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/frontend/src/components/icons/ProfileIcon.tsx
+++ b/frontend/src/components/icons/ProfileIcon.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default function ProfileIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <path d="M9.99967 8.33333C11.6105 8.33333 12.9163 7.0275 12.9163 5.41667C12.9163 3.80584 11.6105 2.5 9.99967 2.5C8.38884 2.5 7.08301 3.80584 7.08301 5.41667C7.08301 7.0275 8.38884 8.33333 9.99967 8.33333Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M2.5 16.9998V17.4998H17.5V16.9998C17.5 15.133 17.5 14.1996 17.1367 13.4865C16.8171 12.8593 16.3072 12.3494 15.68 12.0298C14.9669 11.6665 14.0335 11.6665 12.1667 11.6665H7.83333C5.9665 11.6665 5.03308 11.6665 4.32004 12.0298C3.69283 12.3494 3.18289 12.8593 2.86331 13.4865C2.5 14.1996 2.5 15.133 2.5 16.9998Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M9.99967 7.33333C11.6105 7.33333 12.9163 6.0275 12.9163 4.41667C12.9163 2.80584 11.6105 1.5 9.99967 1.5C8.38884 1.5 7.08301 2.80584 7.08301 4.41667C7.08301 6.0275 8.38884 7.33333 9.99967 7.33333Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2.5 15.9998V16.4998H17.5V15.9998C17.5 14.133 17.5 13.1996 17.1367 12.4865C16.8171 11.8593 16.3072 11.3494 15.68 11.0298C14.9669 10.6665 14.0335 10.6665 12.1667 10.6665H7.83333C5.9665 10.6665 5.03308 10.6665 4.32004 11.0298C3.69283 11.3494 3.18289 11.8593 2.86331 12.4865C2.5 13.1996 2.5 14.133 2.5 15.9998Z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }


### PR DESCRIPTION
close #VO-701
close #VO-702
close #VO-703


📌 관련 이슈
close #701 (MY-019: 프로필 설정 - 뱃지 노출 여부)
close #702 (MY-020: 프로필 설정 - 계정 탈퇴)
close #703 (MY-021: 대시보드 요약 카드)


📝 변경 사항
프론트엔드
프로필 설정 페이지 UI 리팩토링
불필요한 중첩 div 제거 (DOM depth 5단계 → 3단계)
page.module.css에 복사해서 쓰던 .pillTab 스타일을 제거하고, 공용 Tabs.module.css 컴포넌트 스타일을 직접 import하여 재사용
variables.css에 없는 잘못된 토큰(--text-body-small, --text-h3-bold, --color-text-danger) 전부 공식 토큰으로 수정
인라인 하드코딩(gap: '24px', transition: all 0.2s ease) 제거 → CSS 변수 사용
뱃지 노출 / 계정 탈퇴 섹션을 가로 배치(rowSectionBlock) 레이아웃으로 변경
계정 탈퇴 버튼을 Button variant="danger" 컴포넌트로 교체
하단 액션 버튼 width 200px 고정 + justify-content: flex-end로 우측 정렬
mypage 전체 페이지 title-content gap을 var(--space-32)로 통일
Security 페이지 CSS 분리
security 페이지가 profile CSS를 공유하던 구조를 분리하여 독립 page.module.css 생성
사용하지 않는 죽은 CSS 룰 전부 정리 (149줄 → 49줄)
아이콘 교체
ProfileIcon.tsx SVG를 새 디자인으로 교체


백엔드
대시보드 요약 카드 실제 DB 연동
OrderJpaRepository: 진행 중/종료 이벤트 카운트 JPQL 쿼리 추가
OrderRepositoryPort / OrderPersistenceAdapter: 카운트 메서드 추가
MyPageController: @AuthenticationPrincipal Long → Authentication email 기반으로 변경 (다른 컨트롤러와 일관성 통일)
MyPageService: Mock 데이터(2, 1, 5) 제거 → 실제 주문/이벤트 DB 조회
참여 중인 세션 = ONGOING 이벤트의 유효 주문 수
리뷰를 기다리는 세션 = ENDED 이벤트의 유효 주문 수
획득한 뱃지 = DB 미구현으로 0 반환 (추후 추가 예정)
