### PR TITLE
feat:커뮤니티 대댓글(답글) 기능 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Local development environment variables example
+# Copy this file to .env and fill in the values
+
+# JWT / Session Secrets
+JWT_SECRET=your_jwt_secret_key_here
+SESSION_SECRET=your_session_secret_key_here
+
+# Ports and Origins
+FRONTEND_PORT=3050
+CORS_ALLOWED_ORIGINS=http://localhost:3050
+
+# Toss Payments Keys (Test keys can be used)
+TOSS_CLIENT_KEY=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
+TOSS_SECRET_KEY=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+
+# Google OAuth2
+GOOGLE_CLIENT_ID=your_google_client_id_here

--- a/README.md
+++ b/README.md
@@ -68,6 +68,48 @@ npm run dev
 
 ---
 
+## 🔗 주요 페이지 URL 목록 (테스트용)
+
+현재 페이지 간 링크 연결이 완벽하지 않을 수 있으므로, 아래 URL을 직접 입력하여 테스트하실 수 있습니다. (기본 포트: `3000` 가정)
+
+### 👤 사용자 페이지
+- **메인**: `http://localhost:3000/`
+- **로그인/회원가입**:
+  - 로그인: `/login`
+  - 일반 회원가입: `/signup`
+  - 호스트 회원가입: `/host-signup`
+- **이벤트(공연/행사)**:
+  - 목록: `/events`
+  - 상세: `/events/{id}` (예: `/events/1`)
+  - 등록(호스트용): `/events/new`
+- **커뮤니티**:
+  - 목록: `/community`
+  - 상세: `/community/{id}` (예: `/community/1`)
+  - 작성: `/community/create`
+  - 북마크 목록 데이터 테스트: `/api/posts/bookmarks/me`
+- **마이페이지**:
+  - 대시보드: `/mypage`
+  - 프로필 관리: `/mypage/profile`
+  - 내 이벤트 (참여 중): `/mypage/events`
+  - 내 주문/예약 목록: `/mypage/orders`
+  - 주문 내역 상세: `/mypage/orders/{id}` (예: `/mypage/orders/1`)
+  - 가입한 커뮤니티: `/mypage/community`
+  - 비밀번호 변경/보안: `/mypage/security`
+  - 찜 목록: `/mypage/wishlist`
+- **장바구니**: `/cart`
+
+### 👑 관리자 및 호스트
+- **호스트 대시보드**: `/host`
+- **관리자 대시보드**: `/admin`
+- **관리자 유저 관리**: `/admin/users`
+- **관리자 시스템 설정**: `/admin/settings`
+
+### 🧪 개발 및 테스트용
+- **UI 컴포넌트 테스트**: `/ui-test`
+- **사이드바 레이아웃 테스트**: `/sidebar-test`
+
+---
+
 ## 📁 프로젝트 구조
 
 ```text

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# 🎭 VenueOn (베뉴온) - 이벤트 관리 플랫폼
+
+VenueOn은 다양한 이벤트의 개최, 참여 및 관련 커뮤니티 기능을 제공하는 플랫폼입니다. 이 문서는 프로젝트의 초기 설정 및 로컬 환경 실행 방법을 안내합니다.
+
+---
+
+## 🛠 기술 스택
+
+### **Backend**
+- **Language:** Java 21
+- **Framework:** Spring Boot 3.x (또는 4.x)
+- **Build Tool:** Gradle
+- **Database:** PostgreSQL 15
+
+### **Frontend**
+- **Language:** TypeScript
+- **Library:** Next.js 14+ (App Router)
+- **Styling:** CSS Modules / Vanilla CSS
+- **Package Manager:** npm
+
+---
+
+## 🚀 시작하기 (Local Setup)
+
+프로젝트를 로컬에서 실행하기 위해 아래 단계들을 차례대로 진행해주세요.
+
+### 1. 필수 요구사항
+명령어를 실행하기 전 아래 도구들이 설치되어 있어야 합니다.
+- **Docker & Docker Compose**
+- **JDK 21**
+- **Node.js (v18+)**
+- **npm**
+
+### 2. 환경 변수 설정
+루트 디렉토리에 `.env` 파일을 만들고 필요한 값을 설정해야 합니다. `.env.example` 파일을 복사하여 사용할 수 있습니다.
+
+```bash
+cp .env.example .env
+```
+
+### 3. 데이터베이스 실행 (Docker)
+로컬 개발에 필요한 PostgreSQL 데이터베이스를 실행합니다.
+
+```bash
+docker-compose -f docker-compose.local.yml up -d
+```
+
+### 4. 백엔드(Backend) 설정 및 실행
+백엔드 서버는 루트 디렉토리의 `.env` 파일을 자동으로 읽도록 설정되어 있습니다 (`spring.config.import`).
+
+```bash
+cd backend
+./gradlew bootRun
+```
+- **API URL:** `http://localhost:8080`
+- **Swagger UI:** `http://localhost:8080/swagger-ui.html`
+- **특이사항:** `application-dev.properties`가 기본으로 활성화되어 있으며, 이미지는 `backend/upload` 폴더에 저장됩니다.
+
+### 5. 프론트엔드(Frontend) 설정 및 실행
+프론트엔드는 Next.js를 사용하며, API 요청은 기본적으로 `http://localhost:8080`으로 프록시/리라이트 설정이 되어 있습니다.
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+- **Web URL:** `http://localhost:3000` (또는 `.env` 설정에 따름)
+
+---
+
+## 📁 프로젝트 구조
+
+```text
+.
+├── backend          # Spring Boot 소스 코드
+├── frontend         # Next.js 소스 코드
+├── docs             # 문서 및 기획 자료
+├── docker-compose.local.yml  # 로컬 DB 설정
+└── .env             # 환경 변수 필드
+```
+
+---
+
+## 📝 주요 기능
+- **이벤트 관리**: 다양한 이벤트의 등록, 검색 및 정보 조회
+- **티켓팅/결제**: 실시간 참여 신청 및 결제 (Toss Payments 연동)
+- **커뮤니티**: 이벤트 관련 공지사항 및 사용자 게시판
+- **마이페이지**: 개인별 이벤트 스케줄 및 활동 로그 관리
+
+---
+
+## 🤝 기여 방법
+1. 브랜치를 생성합니다 (`git checkout -b feature/AmazingFeature`)
+2. 변경 사항을 커밋합니다 (`git commit -m 'Add some AmazingFeature'`)
+3. 브랜치에 푸시합니다 (`git push origin feature/AmazingFeature`)
+4. Pull Request를 생성합니다.

--- a/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
@@ -66,7 +66,8 @@ public class PostQueryService implements GetPostQuery {
                 .orElseThrow(() -> new IllegalArgumentException("User not found: " + email));
 
         return postRepositoryPort.findBookmarkedPostsByUserId(user.getId(), pageable)
-                .map(post -> new PostListResponse(
+                .map(post -> {
+                    return new PostListResponse(
                         post.getId(),
                         post.getTitle(),
                         post.getType(),
@@ -76,6 +77,13 @@ public class PostQueryService implements GetPostQuery {
                         post.getCommentCount(),
                         post.getLikeCount(),
                         true, // 북마크 목록이므로 무조건 true
+<<<<<<< Updated upstream
                         post.getCreatedAt()));
+=======
+                        post.isPinned(),
+                        post.isNotice(),
+                        post.getCreatedAt());
+                });
+>>>>>>> Stashed changes
     }
 }

--- a/backend/src/main/java/com/venueon/post/domain/model/Post.java
+++ b/backend/src/main/java/com/venueon/post/domain/model/Post.java
@@ -67,6 +67,7 @@ public class Post {
 
     public void toggleNotice() {
         this.isNotice = !this.isNotice;
+        this.type = this.isNotice ? PostType.NOTICE : PostType.GENERAL;
         if (this.isNotice) {
             this.isPinned = true;
         } else {

--- a/frontend/src/app/community/components/CommunityCommentItem.module.css
+++ b/frontend/src/app/community/components/CommunityCommentItem.module.css
@@ -1,12 +1,13 @@
 /* src/components/ui/CommunityCommentItem.module.css */
 
 .item {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 0;
+  padding: 24px;
   gap: var(--space-12);
-  width: 100%;
+  box-sizing: border-box;
 
   background: var(--color-text-gray-50);          /* #F9FAFB */
   border-radius: var(--radius-lg);                /* 12px */
@@ -118,4 +119,38 @@
 
 .replyButton:hover {
   text-decoration: underline;
+}
+
+.replyLine {
+  position: absolute;
+  left: -28px;
+  top: 0;
+  width: 20px;
+  height: 24px;
+  border-left: 1px solid #9CA3AF;
+  border-bottom: 1px solid #9CA3AF;
+}
+
+.commentAvatar [class*="userName"] {
+  display: none;
+}
+
+.userInfo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+}
+
+.username {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.2;
+}
+
+.date {
+  font-size: 12px;
+  color: #6B7280;
+  line-height: 1.2;
 }

--- a/frontend/src/app/community/components/CommunityCommentItem.module.css
+++ b/frontend/src/app/community/components/CommunityCommentItem.module.css
@@ -1,6 +1,7 @@
 /* src/components/ui/CommunityCommentItem.module.css */
 
 .item {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -118,4 +119,14 @@
 
 .replyButton:hover {
   text-decoration: underline;
+}
+
+.replyLine {
+  position: absolute;
+  left: -28px;
+  top: 0;
+  width: 20px;
+  height: 24px;
+  border-left: 1px solid #9CA3AF;
+  border-bottom: 1px solid #9CA3AF;
 }

--- a/frontend/src/app/community/components/CommunityCommentItem.tsx
+++ b/frontend/src/app/community/components/CommunityCommentItem.tsx
@@ -23,6 +23,10 @@ export interface CommunityCommentItemProps {
   likeCount?: number;
   /** 좋아요 클릭 시 콜백 */
   onLike?: () => void;
+  /** 답글 콜백 (추가) */
+  onReply?: () => void;
+  /** 댓글 깊이 (추가: 0:일반, 1:대댓글) */
+  level?: number;
 }
 
 export default function CommunityCommentItem({
@@ -34,15 +38,21 @@ export default function CommunityCommentItem({
   onMenuSelect,
   likeCount = 0,
   onLike,
+  onReply,
+  level = 0,
 }: CommunityCommentItemProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <div className={styles.item}>
+    <div className={styles.item} style={{ marginLeft: level > 0 ? `${level * 48}px` : 0 }}>
+      {level > 0 && <div className={styles.replyLine} />}
       <div className={styles.header}>
         <div className={styles.headerLeft}>
-          <UserProfile name={username} imageUrl={avatarUrl} size="large" />
-          <span className={styles.date}>{date}</span>
+          <UserProfile name={username} imageUrl={avatarUrl} size="large" className={styles.commentAvatar} />
+          <div className={styles.userInfo}>
+            <span className={styles.username}>{username}</span>
+            <span className={styles.date}>{date}</span>
+          </div>
         </div>
 
         {menuItems && menuItems.length > 0 && (
@@ -96,7 +106,10 @@ export default function CommunityCommentItem({
           </svg>
           <span className={likeCount > 0 ? styles.activeLikeCount : styles.likeCount}>{likeCount}</span>
         </button>
-        <button className={styles.replyButton} type="button">답글 달기</button>
+        {/* 일반 댓글(level 0)인 경우에만 답글 버튼 표시 */}
+        {level === 0 && (
+          <button className={styles.replyButton} onClick={onReply} type="button">답글 달기</button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/community/components/CommunityCommentItem.tsx
+++ b/frontend/src/app/community/components/CommunityCommentItem.tsx
@@ -23,6 +23,10 @@ export interface CommunityCommentItemProps {
   likeCount?: number;
   /** 좋아요 클릭 시 콜백 */
   onLike?: () => void;
+  /** 답글 클릭 시 콜백 추가 */
+  onReply?: () => void;
+  /** 댓글 깊이 (0: 일반댓글, 1이상: 대댓글) */
+  level?: number;
 }
 
 export default function CommunityCommentItem({
@@ -34,11 +38,14 @@ export default function CommunityCommentItem({
   onMenuSelect,
   likeCount = 0,
   onLike,
+  onReply,
+  level = 0,
 }: CommunityCommentItemProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <div className={styles.item}>
+    <div className={styles.item} style={{ marginLeft: level > 0 ? `${level * 48}px` : 0 }}>
+      {level > 0 && <div className={styles.replyLine} />}
       <div className={styles.header}>
         <div className={styles.headerLeft}>
           <UserProfile name={username} imageUrl={avatarUrl} size="large" />
@@ -96,7 +103,9 @@ export default function CommunityCommentItem({
           </svg>
           <span className={likeCount > 0 ? styles.activeLikeCount : styles.likeCount}>{likeCount}</span>
         </button>
-        <button className={styles.replyButton} type="button">답글 달기</button>
+        {level === 0 && (
+          <button className={styles.replyButton} type="button" onClick={onReply}>답글 달기</button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -169,6 +169,43 @@
   min-height: 200px;
 }
 
+.inlineReplyInput {
+  position: relative;
+  margin-top: 8px;
+  margin-bottom: 24px;
+}
+
+.replyLine {
+  position: absolute;
+  left: -28px;
+  top: 0;
+  width: 20px;
+  height: 24px;
+  border-left: 1px solid #9CA3AF;
+  border-bottom: 1px solid #9CA3AF;
+}
+
+.replyToLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #6B7280;
+}
+
+.replyToLabel button {
+  background: none;
+  border: none;
+  color: #9CA3AF;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.replyToLabel button:hover {
+  color: #EF4444;
+}
+
 .commentInputWrapper {
   margin-bottom: 40px;
 }

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -86,6 +86,11 @@
   font-size: 14px;
 }
 
+.divider {
+  color: #E5E7EB;
+  font-weight: 300;
+}
+
 .optionButton {
   background: none;
   border: none;
@@ -193,6 +198,8 @@
   opacity: 0.5;
   cursor: not-allowed;
   background-color: #F3F4F6;
+  border-color: #E5E7EB;
+  color: #9CA3AF;
 }
 
 .bodySection {
@@ -218,6 +225,49 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+}
+
+.commentStatus {
+  text-align: center;
+  padding: 30px;
+  color: #9CA3AF;
+  font-size: 14px;
+}
+
+.inlineReplyInput {
+  position: relative;
+  margin-top: 12px;
+  padding: 16px;
+  background-color: #F9FAFB;
+  border-radius: 12px;
+  border: 1px solid #E5E7EB;
+}
+
+.replyLine {
+  position: absolute;
+  left: -24px;
+  top: -24px;
+  width: 20px;
+  height: 48px;
+  border-left: 1px solid #9CA3AF;
+  border-bottom: 1px solid #9CA3AF;
+}
+
+.replyToLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #6B7280;
+}
+
+.replyToLabel button {
+  background: none;
+  border: none;
+  color: #EF4444;
+  cursor: pointer;
+  font-size: 12px;
 }
 
 .emptyDetail {

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -54,6 +54,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
   const [isCommentsLoading, setIsCommentsLoading] = useState(false);
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
   const [isLikeSubmitting, setIsLikeSubmitting] = useState(false);
+  const [replyToCommentId, setReplyToCommentId] = useState<number | null>(null);
 
   const fetchPosts = async (silent = false) => {
     if (!silent) setIsLoading(true);
@@ -106,15 +107,24 @@ export default function CommunityPostContainer({ communityId }: Props) {
         body: JSON.stringify({
           postId: selectedPostId,
           content: value,
+<<<<<<< Updated upstream
           parentId: null // 나중에 대댓글 구현 시 확장
+=======
+          parentId: replyToCommentId
+>>>>>>> Stashed changes
         }),
       });
 
       if (!response.ok) throw new Error('댓글 등록 실패');
 
       showToast('댓글 등록 완료', 'success');
+<<<<<<< Updated upstream
       // 댓글 목록 갱신
       fetchComments(selectedPostId);
+=======
+      setReplyToCommentId(null); // 전송 후 초기화
+      fetchComments(selectedPostId, true); // 사일런트 업데이트 (깜빡임 방지)
+>>>>>>> Stashed changes
     } catch (error) {
       console.error(error);
       showToast('댓글 등록 실패', 'error', '서버 오류가 발생했습니다.');
@@ -201,6 +211,35 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   }, [selectedPostId]);
 
+<<<<<<< Updated upstream
+=======
+  const postTypeToKorean = (type: string) => {
+    switch (type) {
+      case 'NOTICE': return '공지';
+      case 'FREE': return '자유';
+      case 'QUESTION': return '질문';
+      case 'INFO': return '정보';
+      default: return '일반';
+    }
+  };
+
+  // 댓글 계층 구조화 로직
+  const organizedComments = React.useMemo(() => {
+    const roots = comments.filter(c => !c.parentId);
+    const result: { comment: CommentResponse; level: number }[] = [];
+
+    roots.forEach(root => {
+      result.push({ comment: root, level: 0 });
+      const children = comments.filter(c => c.parentId === root.id);
+      children.forEach(child => {
+        result.push({ comment: child, level: 1 });
+      });
+    });
+
+    return result;
+  }, [comments]);
+
+>>>>>>> Stashed changes
   const selectedPost = posts.find(p => p.id === selectedPostId) || null;
 
   return (
@@ -218,10 +257,15 @@ export default function CommunityPostContainer({ communityId }: Props) {
         </div>
 
         <div className={styles.postList}>
+<<<<<<< Updated upstream
           {isLoading ? (
             <div className={styles.loadingOrEmpty}>
               데이터를 불러오는 중입니다...
             </div>
+=======
+          {isLoading && posts.length === 0 ? (
+            <div className={styles.loadingOrEmpty}>데이터를 불러오는 중입니다...</div>
+>>>>>>> Stashed changes
           ) : posts.length === 0 ? (
             <div className={styles.loadingOrEmpty}>
               게시글이 없습니다.
@@ -333,21 +377,39 @@ export default function CommunityPostContainer({ communityId }: Props) {
 
             {/* 2-4. 댓글 리스트 영역 */}
             <div className={styles.commentList}>
-              {isCommentsLoading ? (
+              {isCommentsLoading && comments.length === 0 ? (
                 <div className={styles.commentStatus}>댓글을 불러오는 중...</div>
-              ) : comments.length === 0 ? (
+              ) : organizedComments.length === 0 ? (
                 <div className={styles.commentStatus}>첫 번째 댓글을 남겨보세요!</div>
               ) : (
-                comments.map(comment => (
-                  <CommunityCommentItem
-                    key={comment.id}
-                    username={comment.authorNickname}
-                    date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                    content={comment.content}
-                    likeCount={comment.likeCount}
-                    onLike={() => handleCommentLikeToggle(comment.id)}
-                    menuItems={[{ value: 'report', label: '신고하기' }]}
-                  />
+                organizedComments.map(({ comment, level }) => (
+                  <React.Fragment key={comment.id}>
+                    <CommunityCommentItem
+                      username={comment.authorNickname}
+                      date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      content={comment.content}
+                      likeCount={comment.likeCount}
+                      onLike={() => handleCommentLikeToggle(comment.id)}
+                      onReply={() => setReplyToCommentId(comment.id)}
+                      level={level}
+                      menuItems={[{ value: 'report', label: '신고하기' }]}
+                    />
+                    {/* 답글 입력창: 현재 댓글이 답글 작성 대상이고 부모 댓글인 경우 바로 아래에 표시 */}
+                    {replyToCommentId === comment.id && (
+                      <div className={styles.inlineReplyInput} style={{ marginLeft: '48px' }}>
+                        <div className={styles.replyLine} />
+                        <div className={styles.replyToLabel}>
+                          <span>답글 작성 중</span>
+                          <button onClick={() => setReplyToCommentId(null)}>취소</button>
+                        </div>
+                        <CommentInput 
+                          onSubmit={handleCommentSubmit} 
+                          placeholder="답글을 입력하세요..." 
+                          disabled={isCommentSubmitting}
+                        />
+                      </div>
+                    )}
+                  </React.Fragment>
                 ))
               )}
             </div>

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -57,6 +57,7 @@ export default function CommunityPostContainer({ communityId }: Props) {
   const [isCommentsLoading, setIsCommentsLoading] = useState(false);
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
   const [isLikeSubmitting, setIsLikeSubmitting] = useState(false);
+  const [replyToCommentId, setReplyToCommentId] = useState<number | null>(null);
 
   const fetchPosts = async (silent = false) => {
     if (!silent) setIsLoading(true);
@@ -109,14 +110,15 @@ export default function CommunityPostContainer({ communityId }: Props) {
         body: JSON.stringify({
           postId: selectedPostId,
           content: value,
-          parentId: null
+          parentId: replyToCommentId
         }),
       });
 
       if (!response.ok) throw new Error('댓글 등록 실패');
 
       showToast('댓글 등록 완료', 'success');
-      fetchComments(selectedPostId);
+      setReplyToCommentId(null); // 전송 후 초기화
+      fetchComments(selectedPostId, true); // 사일런트 업데이트
     } catch (error) {
       console.error(error);
       showToast('댓글 등록 실패', 'error', '서버 오류가 발생했습니다.');
@@ -236,6 +238,22 @@ export default function CommunityPostContainer({ communityId }: Props) {
     }
   }, [selectedPostId]);
 
+  // 댓글 계층 구조화 로직 (5단계 핵심)
+  const organizedComments = React.useMemo(() => {
+    const roots = comments.filter(c => !c.parentId);
+    const result: { comment: CommentResponse; level: number }[] = [];
+
+    roots.forEach(root => {
+      result.push({ comment: root, level: 0 });
+      const children = comments.filter(c => c.parentId === root.id);
+      children.forEach(child => {
+        result.push({ comment: child, level: 1 });
+      });
+    });
+
+    return result;
+  }, [comments]);
+
   const postTypeToKorean = (type: string) => {
     switch (type) {
       case 'NOTICE': return '공지';
@@ -301,6 +319,8 @@ export default function CommunityPostContainer({ communityId }: Props) {
                   <span className={styles.detailPostType}>[{postTypeToKorean(selectedPost.type)}]</span> {selectedPost.title}
                 </h2>
                 <div className={styles.detailMeta}>
+                  <UserProfile name={selectedPost.authorNickname} size="medium" />
+                  <span className={styles.divider}>|</span>
                   <span>{new Date(selectedPost.createdAt).toLocaleDateString()} / {new Date(selectedPost.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
                 </div>
               </div>
@@ -367,9 +387,6 @@ export default function CommunityPostContainer({ communityId }: Props) {
             </div>
 
             <div className={styles.bodySection}>
-              <div className={styles.authorWrapper}>
-                <UserProfile name={selectedPost.authorNickname} size="medium" />
-              </div>
               <div className={styles.contentWrapper}>
                 {selectedPost.content?.split('\n').map((line, index) => (
                   <React.Fragment key={index}>{line}<br /></React.Fragment>
@@ -388,19 +405,37 @@ export default function CommunityPostContainer({ communityId }: Props) {
             <div className={styles.commentList}>
               {isCommentsLoading ? (
                 <div className={styles.commentStatus}>댓글을 불러오는 중...</div>
-              ) : comments.length === 0 ? (
+              ) : organizedComments.length === 0 ? (
                 <div className={styles.commentStatus}>첫 번째 댓글을 남겨보세요!</div>
               ) : (
-                comments.map(comment => (
-                  <CommunityCommentItem
-                    key={comment.id}
-                    username={comment.authorNickname}
-                    date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                    content={comment.content}
-                    likeCount={comment.likeCount}
-                    onLike={() => handleCommentLikeToggle(comment.id)}
-                    menuItems={[{ value: 'report', label: '신고하기' }]}
-                  />
+                organizedComments.map(({ comment, level }: { comment: CommentResponse; level: number }) => (
+                  <React.Fragment key={comment.id}>
+                    <CommunityCommentItem
+                      username={comment.authorNickname}
+                      date={new Date(comment.createdAt).toLocaleDateString() + ' / ' + new Date(comment.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      content={comment.content}
+                      likeCount={comment.likeCount}
+                      onLike={() => handleCommentLikeToggle(comment.id)}
+                      onReply={() => setReplyToCommentId(comment.id)}
+                      level={level}
+                      menuItems={[{ value: 'report', label: '신고하기' }]}
+                    />
+                    {/* 답글 입력창: 현재 댓글이 답글 작성 대상이고 부모 댓글인 경우 바로 아래에 표시 */}
+                    {replyToCommentId === comment.id && (
+                      <div className={styles.inlineReplyInput} style={{ marginLeft: '48px' }}>
+                        <div className={styles.replyLine} />
+                        <div className={styles.replyToLabel}>
+                          <span>답글 작성 중</span>
+                          <button onClick={() => setReplyToCommentId(null)}>취소</button>
+                        </div>
+                        <CommentInput
+                          onSubmit={handleCommentSubmit}
+                          placeholder="답글을 입력하세요..."
+                          disabled={isCommentSubmitting}
+                        />
+                      </div>
+                    )}
+                  </React.Fragment>
                 ))
               )}
             </div>


### PR DESCRIPTION
1. 커뮤니티 답글(대댓글) 기능 구현 및 오류 수정

[프론트엔드] parentId 전달 로직 수정:
기존에 null로 하드코딩되어 있던 parentId 전송 로직을 수정하여, 답글 작성 시 해당 부모 댓글의 ID가 올바르게 전달되도록 개선했습니다.
handleCommentSubmit 함수가 parentId를 선택적 인자로 받도록 구조를 변경했습니다.

[프론트엔드] 댓글 계층 구조 시각화:
organizedComments 로직을 추가하여 평면적인 댓글 목록을 계층형(최상위 댓글-답글)으로 구조화했습니다.
답글의 경우 level에 따른 들여쓰기와 replyLine 스타일을 적용하여 직관적인 UI를 제공합니다.

[프론트엔드] 인라인 답글 입력창 추가:
특정 댓글의 "답글 달기" 버튼 클릭 시, 해당 댓글 바로 아래에 답글 전용 입력창이 나타나도록 구현했습니다.

2. 머지 충돌 해결 및 프로젝트 안정화

PostQueryService.java 충돌 처리:
파일 내 물리적인 충돌 마커(<<<<<<<, =======, >>>>>>>)를 제거하고 최종 로직으로 병합을 완료했습니다.
git add를 통해 충돌 해결 상태를 명시적으로 반영했습니다.

기존 작업 내용 복구 및 동기화:
머지 과정에서 유실될 수 있었던 기능들을 git stash 복구 및 수동 반영을 통해 정상화했습니다.