### PR TITLE
feat/VO-744-746-747: Admin 카테고리 관리 기능 고도화 및 사용 현황(Event Count) 추가

### DIFF
--- a/backend/src/main/java/com/venueon/category/adapter/in/web/AdminCategoryController.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/AdminCategoryController.java
@@ -2,6 +2,7 @@ package com.venueon.category.adapter.in.web;
 
 import com.venueon.category.adapter.in.web.dto.CategoryRequest;
 import com.venueon.category.adapter.in.web.dto.CategoryResponse;
+import com.venueon.category.adapter.in.web.dto.UpdateOrderRequest;
 import com.venueon.category.application.port.in.CategoryUseCase;
 import com.venueon.category.domain.model.Category;
 import com.venueon.common.dto.ApiResponse;
@@ -25,7 +26,7 @@ public class AdminCategoryController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<CategoryResponse>>> getCategories() {
         List<CategoryResponse> responses = categoryUseCase.getAllCategories().stream()
-                .map(c -> new CategoryResponse(c.getId(), c.getName(), c.getDescription(), c.getSortOrder()))
+                .map(c -> new CategoryResponse(c.getId(), c.getName(), c.getDescription(), c.getSortOrder(), c.getEventCount()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
@@ -34,7 +35,7 @@ public class AdminCategoryController {
     public ResponseEntity<ApiResponse<CategoryResponse>> createCategory(@Valid @RequestBody CategoryRequest request) {
         Category category = new Category(null, request.name(), request.description(), request.sortOrder());
         Category saved = categoryUseCase.createCategory(category);
-        CategoryResponse response = new CategoryResponse(saved.getId(), saved.getName(), saved.getDescription(), saved.getSortOrder());
+        CategoryResponse response = new CategoryResponse(saved.getId(), saved.getName(), saved.getDescription(), saved.getSortOrder(), saved.getEventCount());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -44,7 +45,7 @@ public class AdminCategoryController {
             @Valid @RequestBody CategoryRequest request) {
         Category category = new Category(id, request.name(), request.description(), request.sortOrder());
         Category updated = categoryUseCase.updateCategory(id, category);
-        CategoryResponse response = new CategoryResponse(updated.getId(), updated.getName(), updated.getDescription(), updated.getSortOrder());
+        CategoryResponse response = new CategoryResponse(updated.getId(), updated.getName(), updated.getDescription(), updated.getSortOrder(), updated.getEventCount());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -57,8 +58,8 @@ public class AdminCategoryController {
     @PatchMapping("/{id}/order")
     public ResponseEntity<ApiResponse<Void>> updateOrder(
             @PathVariable Long id,
-            @RequestBody int newOrder) {
-        categoryUseCase.updateSortOrder(id, newOrder);
+            @RequestBody UpdateOrderRequest request) {
+        categoryUseCase.updateSortOrder(id, request.sortOrder());
         return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/backend/src/main/java/com/venueon/category/adapter/in/web/AdminCategoryController.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/AdminCategoryController.java
@@ -1,0 +1,64 @@
+package com.venueon.category.adapter.in.web;
+
+import com.venueon.category.adapter.in.web.dto.CategoryRequest;
+import com.venueon.category.adapter.in.web.dto.CategoryResponse;
+import com.venueon.category.application.port.in.CategoryUseCase;
+import com.venueon.category.domain.model.Category;
+import com.venueon.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin/categories")
+@RequiredArgsConstructor
+public class AdminCategoryController {
+
+    private final CategoryUseCase categoryUseCase;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getCategories() {
+        List<CategoryResponse> responses = categoryUseCase.getAllCategories().stream()
+                .map(c -> new CategoryResponse(c.getId(), c.getName(), c.getDescription(), c.getSortOrder()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CategoryResponse>> createCategory(@Valid @RequestBody CategoryRequest request) {
+        Category category = new Category(null, request.name(), request.description(), request.sortOrder());
+        Category saved = categoryUseCase.createCategory(category);
+        CategoryResponse response = new CategoryResponse(saved.getId(), saved.getName(), saved.getDescription(), saved.getSortOrder());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<CategoryResponse>> updateCategory(
+            @PathVariable Long id,
+            @Valid @RequestBody CategoryRequest request) {
+        Category category = new Category(id, request.name(), request.description(), request.sortOrder());
+        Category updated = categoryUseCase.updateCategory(id, category);
+        CategoryResponse response = new CategoryResponse(updated.getId(), updated.getName(), updated.getDescription(), updated.getSortOrder());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable Long id) {
+        categoryUseCase.deleteCategory(id);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PatchMapping("/{id}/order")
+    public ResponseEntity<ApiResponse<Void>> updateOrder(
+            @PathVariable Long id,
+            @RequestBody int newOrder) {
+        categoryUseCase.updateSortOrder(id, newOrder);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryRequest.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryRequest.java
@@ -1,0 +1,11 @@
+package com.venueon.category.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public record CategoryRequest(
+    @NotBlank(message = "Category name is required")
+    String name,
+    String description,
+    int sortOrder
+) {}

--- a/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryResponse.java
@@ -4,5 +4,6 @@ public record CategoryResponse(
     Long id,
     String name,
     String description,
-    int sortOrder
+    int sortOrder,
+    long eventCount
 ) {}

--- a/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/dto/CategoryResponse.java
@@ -1,0 +1,8 @@
+package com.venueon.category.adapter.in.web.dto;
+
+public record CategoryResponse(
+    Long id,
+    String name,
+    String description,
+    int sortOrder
+) {}

--- a/backend/src/main/java/com/venueon/category/adapter/in/web/dto/UpdateOrderRequest.java
+++ b/backend/src/main/java/com/venueon/category/adapter/in/web/dto/UpdateOrderRequest.java
@@ -1,0 +1,5 @@
+package com.venueon.category.adapter.in.web.dto;
+
+public record UpdateOrderRequest(
+    int sortOrder
+) {}

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryMapper.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryMapper.java
@@ -8,12 +8,17 @@ import org.springframework.stereotype.Component;
 public class CategoryMapper {
 
     public Category toDomain(CategoryJpaEntity entity) {
+        return toDomain(entity, 0L);
+    }
+
+    public Category toDomain(CategoryJpaEntity entity, long eventCount) {
         if (entity == null) return null;
         return new Category(
             entity.getId(),
             entity.getName(),
             entity.getDescription(),
-            entity.getSortOrder()
+            entity.getSortOrder(),
+            eventCount
         );
     }
 

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryMapper.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryMapper.java
@@ -1,0 +1,29 @@
+package com.venueon.category.adapter.out.persistence;
+
+import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
+import com.venueon.category.domain.model.Category;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    public Category toDomain(CategoryJpaEntity entity) {
+        if (entity == null) return null;
+        return new Category(
+            entity.getId(),
+            entity.getName(),
+            entity.getDescription(),
+            entity.getSortOrder()
+        );
+    }
+
+    public CategoryJpaEntity toEntity(Category domain) {
+        if (domain == null) return null;
+        return CategoryJpaEntity.builder()
+            .id(domain.getId())
+            .name(domain.getName())
+            .description(domain.getDescription())
+            .sortOrder(domain.getSortOrder())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryPersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.venueon.category.adapter.out.persistence;
+
+import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
+import com.venueon.category.adapter.out.persistence.repository.CategoryJpaRepository;
+import com.venueon.category.application.port.out.CategoryPort;
+import com.venueon.category.domain.model.Category;
+import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryPersistenceAdapter implements CategoryPort {
+
+    private final CategoryJpaRepository categoryRepository;
+    private final EventJpaRepository eventRepository;
+    private final CategoryMapper categoryMapper;
+
+    @Override
+    public List<Category> findAllOrderBySortOrder() {
+        return categoryRepository.findAllByOrderBySortOrderAsc().stream()
+                .map(categoryMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Category save(Category category) {
+        CategoryJpaEntity entity = categoryMapper.toEntity(category);
+        CategoryJpaEntity saved = categoryRepository.save(entity);
+        return categoryMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Category> findById(Long id) {
+        return categoryRepository.findById(id).map(categoryMapper::toDomain);
+    }
+
+    @Override
+    public void delete(Long id) {
+        categoryRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return categoryRepository.existsByName(name);
+    }
+
+    @Override
+    public boolean existsByNameAndIdNot(String name, Long id) {
+        return categoryRepository.existsByNameAndIdNot(name, id);
+    }
+
+    @Override
+    public boolean isCategoryInUse(Long id) {
+        return eventRepository.existsByCategoryId(id);
+    }
+}

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/CategoryPersistenceAdapter.java
@@ -22,8 +22,16 @@ public class CategoryPersistenceAdapter implements CategoryPort {
 
     @Override
     public List<Category> findAllOrderBySortOrder() {
-        return categoryRepository.findAllByOrderBySortOrderAsc().stream()
-                .map(categoryMapper::toDomain)
+        return findAllWithEventCount();
+    }
+
+    @Override
+    public List<Category> findAllWithEventCount() {
+        return categoryRepository.findAllWithEventCount().stream()
+                .map(result -> categoryMapper.toDomain(
+                    (CategoryJpaEntity) result[0],
+                    (Long) result[1]
+                ))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/repository/CategoryJpaRepository.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/repository/CategoryJpaRepository.java
@@ -2,6 +2,7 @@ package com.venueon.category.adapter.out.persistence.repository;
 
 import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,9 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     Optional<CategoryJpaEntity> findByName(String name);
 
     List<CategoryJpaEntity> findAllByOrderBySortOrderAsc();
+
+    @Query("SELECT c, COUNT(e) FROM CategoryJpaEntity c LEFT JOIN EventJpaEntity e ON e.category = c GROUP BY c ORDER BY c.sortOrder ASC")
+    List<Object[]> findAllWithEventCount();
     
     boolean existsByName(String name);
     

--- a/backend/src/main/java/com/venueon/category/adapter/out/persistence/repository/CategoryJpaRepository.java
+++ b/backend/src/main/java/com/venueon/category/adapter/out/persistence/repository/CategoryJpaRepository.java
@@ -11,4 +11,8 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
     Optional<CategoryJpaEntity> findByName(String name);
 
     List<CategoryJpaEntity> findAllByOrderBySortOrderAsc();
+    
+    boolean existsByName(String name);
+    
+    boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/backend/src/main/java/com/venueon/category/application/port/in/CategoryUseCase.java
+++ b/backend/src/main/java/com/venueon/category/application/port/in/CategoryUseCase.java
@@ -1,0 +1,12 @@
+package com.venueon.category.application.port.in;
+
+import com.venueon.category.domain.model.Category;
+import java.util.List;
+
+public interface CategoryUseCase {
+    List<Category> getAllCategories();
+    Category createCategory(Category category);
+    Category updateCategory(Long id, Category category);
+    void deleteCategory(Long id);
+    void updateSortOrder(Long id, int newOrder);
+}

--- a/backend/src/main/java/com/venueon/category/application/port/out/CategoryPort.java
+++ b/backend/src/main/java/com/venueon/category/application/port/out/CategoryPort.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface CategoryPort {
     List<Category> findAllOrderBySortOrder();
+    List<Category> findAllWithEventCount();
+
     Category save(Category category);
     Optional<Category> findById(Long id);
     void delete(Long id);

--- a/backend/src/main/java/com/venueon/category/application/port/out/CategoryPort.java
+++ b/backend/src/main/java/com/venueon/category/application/port/out/CategoryPort.java
@@ -1,0 +1,15 @@
+package com.venueon.category.application.port.out;
+
+import com.venueon.category.domain.model.Category;
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryPort {
+    List<Category> findAllOrderBySortOrder();
+    Category save(Category category);
+    Optional<Category> findById(Long id);
+    void delete(Long id);
+    boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Long id);
+    boolean isCategoryInUse(Long id); // Check if category is used by other entities
+}

--- a/backend/src/main/java/com/venueon/category/application/service/CategoryService.java
+++ b/backend/src/main/java/com/venueon/category/application/service/CategoryService.java
@@ -1,0 +1,72 @@
+package com.venueon.category.application.service;
+
+import com.venueon.category.application.port.in.CategoryUseCase;
+import com.venueon.category.application.port.out.CategoryPort;
+import com.venueon.category.domain.model.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategoryService implements CategoryUseCase {
+
+    private final CategoryPort categoryPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> getAllCategories() {
+        return categoryPort.findAllOrderBySortOrder();
+    }
+
+    @Override
+    public Category createCategory(Category category) {
+        if (categoryPort.existsByName(category.getName())) {
+            throw new IllegalArgumentException("Category name already exists: " + category.getName());
+        }
+        return categoryPort.save(category);
+    }
+
+    @Override
+    public Category updateCategory(Long id, Category category) {
+        if (!categoryPort.findById(id).isPresent()) {
+            throw new IllegalArgumentException("Category not found with id: " + id);
+        }
+        if (categoryPort.existsByNameAndIdNot(category.getName(), id)) {
+            throw new IllegalArgumentException("Category name already exists: " + category.getName());
+        }
+        
+        Category updatedCategory = new Category(
+            id,
+            category.getName(),
+            category.getDescription(),
+            category.getSortOrder()
+        );
+        return categoryPort.save(updatedCategory);
+    }
+
+    @Override
+    public void deleteCategory(Long id) {
+        if (categoryPort.isCategoryInUse(id)) {
+            throw new IllegalStateException("Category is currently in use and cannot be deleted.");
+        }
+        categoryPort.delete(id);
+    }
+
+    @Override
+    public void updateSortOrder(Long id, int newOrder) {
+        Category category = categoryPort.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found with id: " + id));
+        
+        Category updated = new Category(
+            category.getId(),
+            category.getName(),
+            category.getDescription(),
+            newOrder
+        );
+        categoryPort.save(updated);
+    }
+}

--- a/backend/src/main/java/com/venueon/category/application/service/CategoryService.java
+++ b/backend/src/main/java/com/venueon/category/application/service/CategoryService.java
@@ -19,7 +19,7 @@ public class CategoryService implements CategoryUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<Category> getAllCategories() {
-        return categoryPort.findAllOrderBySortOrder();
+        return categoryPort.findAllWithEventCount();
     }
 
     @Override

--- a/backend/src/main/java/com/venueon/category/domain/model/Category.java
+++ b/backend/src/main/java/com/venueon/category/domain/model/Category.java
@@ -9,14 +9,20 @@ public class Category {
     private String name;
     private String description;
     private int sortOrder;
+    private long eventCount;
 
     protected Category() {}
 
     public Category(Long id, String name, String description, int sortOrder) {
+        this(id, name, description, sortOrder, 0L);
+    }
+
+    public Category(Long id, String name, String description, int sortOrder, long eventCount) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.sortOrder = sortOrder;
+        this.eventCount = eventCount;
     }
 
     // --- Getters ---
@@ -24,4 +30,5 @@ public class Category {
     public String getName() { return name; }
     public String getDescription() { return description; }
     public int getSortOrder() { return sortOrder; }
+    public long getEventCount() { return eventCount; }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/repository/EventJpaRepository.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/repository/EventJpaRepository.java
@@ -20,4 +20,6 @@ public interface EventJpaRepository extends JpaRepository<EventJpaEntity, Long>,
     Page<EventJpaEntity> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
 
     Page<EventJpaEntity> findByCategoryId(Long categoryId, Pageable pageable);
+
+    boolean existsByCategoryId(Long categoryId);
 }

--- a/frontend/src/app/admin/_components/ActivityTable.module.css
+++ b/frontend/src/app/admin/_components/ActivityTable.module.css
@@ -4,13 +4,12 @@
   flex-direction: column;
 }
 
-/* 탭과 검색바를 같은 행에 배치하기 위한 헤더 영역 */
-.tableHeaderArea {
+/* 탭 영역 (공통 UI와 동일하게 별도 줄 배치) */
+.tabArea {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end; /* 강조선 높이 일치 */
-  margin-bottom: var(--space-24);
-  border-bottom: 1px solid transparent; /* 가로선은 탭에만 위치 */
+  height: 48px;
+  align-items: center;
+  margin-bottom: 32px; /* 탭과 검색바 사이 간격 */
 }
 
 .tabs {
@@ -38,9 +37,16 @@
   border-bottom-color: #111827;
 }
 
+.searchFilterArea {
+  display: flex;
+  justify-content: flex-start; /* 좌측 정렬 */
+  align-items: center;
+  align-self: stretch;
+  margin-bottom: 24px; /* 테이블과의 간격 */
+}
+
 .searchWrapper {
-  width: 320px;
-  padding-bottom: var(--space-4); /* 탭 강조선과 대략적인 수평 균형 */
+  width: 410px; /* 사용자 관리와 동일한 410px */
 }
 
 .tableContainer {

--- a/frontend/src/app/admin/_components/ActivityTable.tsx
+++ b/frontend/src/app/admin/_components/ActivityTable.tsx
@@ -29,8 +29,8 @@ export default function ActivityTable() {
 
   return (
     <div className={styles.container}>
-      {/* 탭과 검색바를 시안처럼 좌우로 배치 */}
-      <div className={styles.tableHeaderArea}>
+      {/* 탭 영역 (첫 번째 줄) */}
+      <div className={styles.tabArea}>
         <div className={styles.tabs}>
           <button
             className={`${styles.tab} ${activeTab === 'refund' ? styles.activeTab : ''}`}
@@ -51,7 +51,10 @@ export default function ActivityTable() {
             긴급 처리 신고
           </button>
         </div>
+      </div>
 
+      {/* 검색어 영역 (두 번째 줄) - 사용자 관리와 동일한 위치(좌측) 구성 */}
+      <div className={styles.searchFilterArea}>
         <div className={styles.searchWrapper}>
           <InputField
             variant="search"

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -13,7 +13,7 @@ export default function AdminDashboardPage() {
       <Sidebar role="admin" />
 
       {/* 우측 메인 콘텐츠 */}
-      <section className="sidebar">
+      <section className="sidebar-content">
         
         {/* 가이드에 명시된 대시보드 타이틀 추가 */}
         <h1 className={styles.pageTitle}>관리자 대시보드</h1>

--- a/frontend/src/app/admin/settings/_components/CategoryFormModal.tsx
+++ b/frontend/src/app/admin/settings/_components/CategoryFormModal.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import styles from '@/components/modal/InputModal.module.css';
+import ModalOverlay from '@/components/modal/ModalOverlay';
+import ModalCard from '@/components/modal/ModalCard';
+import { CancelIcon } from '@/components/icons';
+import { InputField, TextareaField, Button } from '@/components/ui';
+
+export interface CategoryFormData {
+  name: string;
+  description: string;
+}
+
+interface CategoryFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: CategoryFormData) => void;
+  /** 수정 모드일 때 기존 데이터를 전달 */
+  initialData?: CategoryFormData | null;
+  isSubmitting?: boolean;
+}
+
+export default function CategoryFormModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  initialData = null,
+  isSubmitting = false,
+}: CategoryFormModalProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [nameError, setNameError] = useState('');
+
+  const isEditMode = !!initialData;
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialData?.name || '');
+      setDescription(initialData?.description || '');
+      setNameError('');
+    }
+  }, [isOpen, initialData]);
+
+  const handleSubmit = () => {
+    if (!name.trim()) {
+      setNameError('카테고리 이름을 입력해주세요.');
+      return;
+    }
+    setNameError('');
+    onSubmit({ name: name.trim(), description: description.trim() });
+  };
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={onClose}>
+      <ModalCard size="md">
+
+        {/* 상단 텍스트 및 닫기 버튼 — InputModal 패턴 */}
+        <div className={styles.textWrapper}>
+          <div className={styles.titleBox}>
+            <h2 className={styles.title}>
+              {isEditMode ? '카테고리 수정' : '새 카테고리 추가'}
+            </h2>
+            <p className={styles.subtitle}>
+              {isEditMode 
+                ? '카테고리 정보를 수정합니다.' 
+                : '새로운 카테고리를 등록합니다.'}
+            </p>
+          </div>
+          <CancelIcon 
+            style={{ cursor: 'pointer', color: 'var(--color-text-gray-500)', flex: 'none' }} 
+            onClick={onClose} 
+          />
+        </div>
+
+        {/* 입력 폼 영역 — InputModal의 inputFieldWrapper 패턴 */}
+        <div className={styles.inputFieldWrapper}>
+          <span className={styles.inputLabel}>카테고리 이름</span>
+          <InputField
+            placeholder="예: 프로그래밍"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            error={nameError}
+            reserveError
+          />
+        </div>
+
+        <div className={styles.textAreaWrapper}>
+          <TextareaField
+            label="설명 (선택)"
+            placeholder="카테고리에 대한 설명을 입력하세요"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+
+        {/* 하단 버튼 — InputModal 패턴 */}
+        <div className={styles.buttonGroup}>
+          <Button variant="secondary" style={{ flex: 1, padding: 0 }} onClick={onClose}>
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            style={{ flex: 1, padding: 0 }}
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '처리 중...' : isEditMode ? '수정' : '추가'}
+          </Button>
+        </div>
+
+      </ModalCard>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/app/admin/settings/_components/CategoryItem.tsx
+++ b/frontend/src/app/admin/settings/_components/CategoryItem.tsx
@@ -5,14 +5,17 @@ import styles from '../page.module.css';
 import { Toggle, StatusTag } from '@/components/ui';
 import { 
   DeleteIcon, 
-  DragIcon
+  DragIcon,
+  EditIcon
 } from '@/components/icons';
 import { AdminCategoryItem } from '@/lib/admin-api';
 
 interface CategoryItemProps {
   item: AdminCategoryItem;
-  icon: React.ElementType;
+  isVisible: boolean;
   onDelete: (id: number) => void;
+  onEdit: (item: AdminCategoryItem) => void;
+  onToggleVisibility: (id: number, visible: boolean) => void;
   // Drag and Drop props
   index: number;
   onDragStart: (e: React.DragEvent, index: number) => void;
@@ -22,8 +25,10 @@ interface CategoryItemProps {
 
 export default function CategoryItem({ 
   item, 
-  icon: Icon, 
-  onDelete, 
+  isVisible,
+  onDelete,
+  onEdit,
+  onToggleVisibility,
   index,
   onDragStart,
   onDragOver,
@@ -39,11 +44,13 @@ export default function CategoryItem({
       onDragEnd={onDragEnd}
     >
       <div className={styles.itemInfo}>
-        <div className={styles.iconWrapper}>
-          <Icon width={20} height={20} />
-        </div>
         <div className={styles.nameContainer}>
-          <span className={styles.categoryName}>{item.name}</span>
+          <div className={styles.nameRow}>
+            <span className={styles.categoryName}>{item.name}</span>
+            <span className={styles.eventCount}>
+              ({item.eventCount})
+            </span>
+          </div>
           {item.description && (
             <span className={styles.categoryDesc}>{item.description}</span>
           )}
@@ -51,14 +58,20 @@ export default function CategoryItem({
       </div>
 
       <div className={styles.colExposure}>
-        <Toggle checked={true} onChange={() => {}} />
+        <Toggle 
+          checked={isVisible} 
+          onChange={() => onToggleVisibility(item.id, !isVisible)} 
+        />
       </div>
 
       <div className={styles.colStatus}>
-        <StatusTag domain="payment" status="결제 완료" />
+        <StatusTag domain="payment" status={isVisible ? '결제 완료' : '취소됨'} />
       </div>
 
       <div className={styles.itemActions}>
+        <button className={styles.iconButton} onClick={() => onEdit(item)}>
+          <EditIcon width={18} height={18} />
+        </button>
         <button className={styles.iconButton} onClick={() => onDelete(item.id)}>
           <DeleteIcon className={styles.deleteIcon} width={20} height={20} />
         </button>

--- a/frontend/src/app/admin/settings/_components/CategoryItem.tsx
+++ b/frontend/src/app/admin/settings/_components/CategoryItem.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React from 'react';
+import styles from '../page.module.css';
+import { Toggle, StatusTag } from '@/components/ui';
+import { 
+  DeleteIcon, 
+  DragIcon
+} from '@/components/icons';
+import { AdminCategoryItem } from '@/lib/admin-api';
+
+interface CategoryItemProps {
+  item: AdminCategoryItem;
+  icon: React.ElementType;
+  onDelete: (id: number) => void;
+  // Drag and Drop props
+  index: number;
+  onDragStart: (e: React.DragEvent, index: number) => void;
+  onDragOver: (e: React.DragEvent, index: number) => void;
+  onDragEnd: (e: React.DragEvent) => void;
+}
+
+export default function CategoryItem({ 
+  item, 
+  icon: Icon, 
+  onDelete, 
+  index,
+  onDragStart,
+  onDragOver,
+  onDragEnd
+}: CategoryItemProps) {
+  
+  return (
+    <div 
+      className={styles.categoryItem}
+      draggable
+      onDragStart={(e) => onDragStart(e, index)}
+      onDragOver={(e) => onDragOver(e, index)}
+      onDragEnd={onDragEnd}
+    >
+      <div className={styles.itemInfo}>
+        <div className={styles.iconWrapper}>
+          <Icon width={20} height={20} />
+        </div>
+        <div className={styles.nameContainer}>
+          <span className={styles.categoryName}>{item.name}</span>
+          {item.description && (
+            <span className={styles.categoryDesc}>{item.description}</span>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.colExposure}>
+        <Toggle checked={true} onChange={() => {}} />
+      </div>
+
+      <div className={styles.colStatus}>
+        <StatusTag domain="payment" status="결제 완료" />
+      </div>
+
+      <div className={styles.itemActions}>
+        <button className={styles.iconButton} onClick={() => onDelete(item.id)}>
+          <DeleteIcon className={styles.deleteIcon} width={20} height={20} />
+        </button>
+        <div className={styles.dragHandle}>
+          <DragIcon width={20} height={20} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/settings/page.module.css
+++ b/frontend/src/app/admin/settings/page.module.css
@@ -1,0 +1,155 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.pageHeader {
+  margin-bottom: 32px;
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+}
+
+.topActionArea {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 32px;
+}
+
+.tabArea {
+  display: flex;
+  gap: 24px;
+}
+
+.tab {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-500);
+  padding-bottom: 8px;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  background: none;
+}
+
+.activeTab {
+  color: var(--color-text-gray-900);
+  border-bottom: 2px solid var(--color-text-gray-900);
+}
+
+.searchAddArea {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.searchArea {
+  width: 100%;
+}
+
+.listHeader {
+  display: flex;
+  padding: 16px 24px;
+  align-items: center;
+  gap: 24px;
+  border-bottom: 1px solid var(--color-text-gray-300);
+  margin-bottom: 12px;
+}
+
+.headerText {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-700);
+}
+
+.colName { flex: 1; }
+.colExposure { width: 60px; text-align: center; }
+.colStatus { width: 100px; text-align: center; }
+.colActions { width: 100px; }
+
+.categoryList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* User specified row style */
+.categoryItem {
+  display: flex;
+  height: 80px;
+  padding: 16px 24px;
+  align-items: center;
+  gap: 24px;
+  align-self: stretch;
+  border-radius: 12px;
+  background: var(--Brand-surface, #F3F4F6);
+}
+
+.itemInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.nameContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.categoryName {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-900);
+}
+
+.categoryDesc {
+  font: var(--text-caption-regular);
+  color: var(--color-text-gray-500);
+}
+
+.itemActions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  color: var(--color-text-gray-500);
+}
+
+.dragging {
+  opacity: 0.5;
+  background: var(--color-surface-hover, #E5E7EB);
+}
+
+.iconButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-gray-500);
+  padding: 4px;
+}
+
+.iconButton:disabled {
+  color: var(--color-text-gray-300);
+  cursor: not-allowed;
+}
+
+.deleteIcon {
+  color: var(--color-error);
+}
+
+.paginationArea {
+  display: flex;
+  justify-content: center;
+  margin-top: 48px;
+}

--- a/frontend/src/app/admin/settings/page.module.css
+++ b/frontend/src/app/admin/settings/page.module.css
@@ -104,6 +104,17 @@
   color: var(--color-text-gray-900);
 }
 
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.eventCount {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-900);
+}
+
 .categoryDesc {
   font: var(--text-caption-regular);
   color: var(--color-text-gray-500);

--- a/frontend/src/app/admin/settings/page.module.css
+++ b/frontend/src/app/admin/settings/page.module.css
@@ -49,6 +49,16 @@
   width: 100%;
 }
 
+.searchRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.searchField {
+  flex: 1;
+}
+
 .listHeader {
   display: flex;
   padding: 16px 24px;

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import styles from './page.module.css';
+import { Sidebar } from '@/components/layout';
+import { 
+  InputField, 
+  Button, 
+  Pagination 
+} from '@/components/ui';
+import { 
+  DashboardIcon,
+  ProfileIcon,
+  SettingIcon,
+  SeminarSettingIcon,
+  CommunityIcon,
+  ReportIcon,
+  DelayedRefundIcon
+} from '@/components/icons';
+import { adminCategoryAPI, AdminCategoryItem } from '@/lib/admin-api';
+import CategoryItem from './_components/CategoryItem';
+import ConfirmModal from '@/components/modal/ConfirmModal';
+
+const ICONS = [
+  DashboardIcon, ProfileIcon, SettingIcon, 
+  SeminarSettingIcon, CommunityIcon, ReportIcon, DelayedRefundIcon
+];
+
+export default function AdminSettingsPage() {
+  const [categories, setCategories] = useState<AdminCategoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const fetchCategories = async () => {
+    setIsLoading(true);
+    try {
+      const res = await adminCategoryAPI.getList();
+      // sortOrder 순으로 정렬되어 오는지 확인 (백엔드에서 이미 처리됨)
+      setCategories(res.data);
+    } catch (error) {
+      console.error('Failed to fetch categories:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const handleDelete = async () => {
+    if (!deleteTargetId) return;
+    try {
+      await adminCategoryAPI.delete(deleteTargetId);
+      fetchCategories();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '삭제 실패');
+    } finally {
+      setDeleteTargetId(null);
+    }
+  };
+
+  // Drag and Drop Handlers
+  const handleDragStart = (e: React.DragEvent, index: number) => {
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = 'move';
+    // 드래그 시 데이터 설정 (optional)
+    e.dataTransfer.setData('text/plain', index.toString());
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === index) return;
+
+    // 실시간 위치 변경 (Optional: Drop 시점에만 할 수도 있음)
+    const newCategories = [...categories];
+    const draggedItem = newCategories[draggedIndex];
+    newCategories.splice(draggedIndex, 1);
+    newCategories.splice(index, 0, draggedItem);
+    
+    setDraggedIndex(index);
+    setCategories(newCategories);
+  };
+
+  const handleDragEnd = async () => {
+    if (draggedIndex === null) return;
+    setDraggedIndex(null);
+
+    // 변경된 모든 아이템의 순서를 API로 반영 (백엔드 효율을 위해 전체 업데이트 또는 변경된 것만)
+    // 여기서는 간단하게 모든 아이템의 새로운 index를 sortOrder로 전송
+    try {
+      await Promise.all(
+        categories.map((cat, idx) => adminCategoryAPI.updateOrder(cat.id, idx))
+      );
+      // 최종 확인을 위해 목록 다시 불러오기
+      fetchCategories();
+    } catch (error) {
+      console.error('Failed to update category order:', error);
+      fetchCategories(); // 원래대로 복구
+    }
+  };
+
+  return (
+    <div className="container-sidebar">
+      <Sidebar role="admin" />
+      <section className="sidebar-content">
+        <div className={styles.container}>
+          <div className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>시스템 설정</h1>
+          </div>
+
+          <div className={styles.topActionArea}>
+            <div className={styles.tabArea}>
+              <button className={`${styles.tab} ${styles.activeTab}`}>카테고리 관리</button>
+            </div>
+            <Button variant="primary" size="medium">+ 새 카테고리 추가</Button>
+          </div>
+
+          <div className={styles.searchAddArea}>
+            <div className={styles.searchArea}>
+              <InputField variant="search" placeholder="검색어를 입력하세요" />
+            </div>
+          </div>
+
+          <div className={styles.listHeader}>
+            <span className={`${styles.headerText} ${styles.colName}`}>카테고리명</span>
+            <span className={`${styles.headerText} ${styles.colExposure}`}>노출</span>
+            <span className={`${styles.headerText} ${styles.colStatus}`}>상태</span>
+            <div className={styles.colActions}></div>
+          </div>
+
+          {isLoading ? (
+            <div style={{ padding: '40px', textAlign: 'center' }}>로딩 중...</div>
+          ) : (
+            <div className={styles.categoryList}>
+              {categories.map((item, index) => (
+                <div key={item.id} className={draggedIndex === index ? styles.dragging : ''}>
+                  <CategoryItem 
+                    item={item} 
+                    index={index}
+                    icon={ICONS[index % ICONS.length]}
+                    onDelete={setDeleteTargetId}
+                    onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
+                    onDragEnd={handleDragEnd}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className={styles.paginationArea}>
+            <Pagination currentPage={1} totalPages={1} onPageChange={() => {}} />
+          </div>
+        </div>
+      </section>
+
+      <ConfirmModal 
+        isOpen={deleteTargetId !== null}
+        onClose={() => setDeleteTargetId(null)}
+        onConfirm={handleDelete}
+        title="카테고리 삭제"
+        subtitle="정말로 이 카테고리를 삭제하시겠습니까? 관련 데이터가 있는 경우 삭제가 제한될 수 있습니다."
+        confirmText="삭제"
+        status="danger"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -239,8 +239,8 @@ export default function AdminSettingsPage() {
 
           <div className={styles.searchAddArea}>
             <div className={styles.searchArea}>
-              <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                <div style={{ flex: 1 }}>
+              <div className={styles.searchRow}>
+                <div className={styles.searchField}>
                   <InputField
                     variant="search"
                     placeholder="검색어를 입력하세요"

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -1,43 +1,55 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import styles from './page.module.css';
 import { Sidebar } from '@/components/layout';
-import { 
-  InputField, 
-  Button, 
-  Pagination 
-} from '@/components/ui';
-import { 
-  DashboardIcon,
-  ProfileIcon,
-  SettingIcon,
-  SeminarSettingIcon,
-  CommunityIcon,
-  ReportIcon,
-  DelayedRefundIcon
-} from '@/components/icons';
+import { InputField, Button, Pagination } from '@/components/ui';
+
 import { adminCategoryAPI, AdminCategoryItem } from '@/lib/admin-api';
 import CategoryItem from './_components/CategoryItem';
+import CategoryFormModal, { CategoryFormData } from './_components/CategoryFormModal';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 
-const ICONS = [
-  DashboardIcon, ProfileIcon, SettingIcon, 
-  SeminarSettingIcon, CommunityIcon, ReportIcon, DelayedRefundIcon
-];
+// Auto-scroll 설정값
+const AUTO_SCROLL_THRESHOLD = 80; // 화면 경계에서 몇 px 이내일 때 스크롤 시작
+const AUTO_SCROLL_MAX_SPEED = 15; // 최대 스크롤 속도 (px/frame)
 
 export default function AdminSettingsPage() {
   const [categories, setCategories] = useState<AdminCategoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [visibilityMap, setVisibilityMap] = useState<Record<number, boolean>>({});
+  const [sortByEvent, setSortByEvent] = useState(false);
+
+  // 삭제 모달
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+
+  // 추가/수정 모달
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<AdminCategoryItem | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Drag & Drop
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
 
+  // Auto-scroll refs
+  const autoScrollRafRef = useRef<number | null>(null);
+  const mouseYRef = useRef<number>(0);
+  const isDraggingRef = useRef(false);
+
+  // ── 데이터 패칭 ──
   const fetchCategories = async () => {
     setIsLoading(true);
     try {
       const res = await adminCategoryAPI.getList();
-      // sortOrder 순으로 정렬되어 오는지 확인 (백엔드에서 이미 처리됨)
       setCategories(res.data);
+      setVisibilityMap(prev => {
+        const newMap = { ...prev };
+        res.data.forEach((c: AdminCategoryItem) => {
+          if (newMap[c.id] === undefined) newMap[c.id] = true;
+        });
+        return newMap;
+      });
     } catch (error) {
       console.error('Failed to fetch categories:', error);
     } finally {
@@ -45,10 +57,114 @@ export default function AdminSettingsPage() {
     }
   };
 
-  useEffect(() => {
-    fetchCategories();
+  useEffect(() => { fetchCategories(); }, []);
+
+  // ── Auto-scroll 로직 ──
+  const autoScrollLoop = useCallback(() => {
+    if (!isDraggingRef.current) return;
+
+    const y = mouseYRef.current;
+    const vh = window.innerHeight;
+
+    if (y < AUTO_SCROLL_THRESHOLD) {
+      // 상단 경계 근처 → 위로 스크롤
+      const intensity = 1 - (y / AUTO_SCROLL_THRESHOLD);
+      window.scrollBy(0, -(intensity * AUTO_SCROLL_MAX_SPEED));
+    } else if (y > vh - AUTO_SCROLL_THRESHOLD) {
+      // 하단 경계 근처 → 아래로 스크롤
+      const intensity = 1 - ((vh - y) / AUTO_SCROLL_THRESHOLD);
+      window.scrollBy(0, intensity * AUTO_SCROLL_MAX_SPEED);
+    }
+
+    autoScrollRafRef.current = requestAnimationFrame(autoScrollLoop);
   }, []);
 
+  const startAutoScroll = useCallback(() => {
+    isDraggingRef.current = true;
+    autoScrollRafRef.current = requestAnimationFrame(autoScrollLoop);
+  }, [autoScrollLoop]);
+
+  const stopAutoScroll = useCallback(() => {
+    isDraggingRef.current = false;
+    if (autoScrollRafRef.current) {
+      cancelAnimationFrame(autoScrollRafRef.current);
+      autoScrollRafRef.current = null;
+    }
+  }, []);
+
+  // 드래그 중 마우스 위치를 추적하는 전역 이벤트
+  useEffect(() => {
+    const handleGlobalDrag = (e: DragEvent) => {
+      mouseYRef.current = e.clientY;
+    };
+    window.addEventListener('drag', handleGlobalDrag);
+    window.addEventListener('dragover', handleGlobalDrag);
+    return () => {
+      window.removeEventListener('drag', handleGlobalDrag);
+      window.removeEventListener('dragover', handleGlobalDrag);
+      stopAutoScroll();
+    };
+  }, [stopAutoScroll]);
+
+  // ── 검색 및 정렬 필터링 (프론트엔드 필터) ──
+  const filteredCategories = useMemo(() => {
+    let list = [...categories];
+
+    // 검색어 필터
+    if (searchKeyword.trim()) {
+      const kw = searchKeyword.toLowerCase();
+      list = list.filter(c =>
+        c.name.toLowerCase().includes(kw) ||
+        (c.description && c.description.toLowerCase().includes(kw))
+      );
+    }
+
+    // 정렬 (이벤트 많은 순)
+    if (sortByEvent) {
+      list.sort((a, b) => b.eventCount - a.eventCount);
+    }
+
+    return list;
+  }, [categories, searchKeyword, sortByEvent]);
+
+  // ── 생성/수정 핸들러 ──
+  const handleOpenCreate = () => {
+    setEditTarget(null);
+    setIsFormOpen(true);
+  };
+
+  const handleOpenEdit = (item: AdminCategoryItem) => {
+    setEditTarget(item);
+    setIsFormOpen(true);
+  };
+
+  const handleFormSubmit = async (data: CategoryFormData) => {
+    setIsSubmitting(true);
+    try {
+      if (editTarget) {
+        await adminCategoryAPI.update(editTarget.id, {
+          name: data.name,
+          description: data.description,
+          sortOrder: editTarget.sortOrder,
+        });
+      } else {
+        await adminCategoryAPI.create({
+          name: data.name,
+          description: data.description,
+          sortOrder: categories.length,
+        });
+      }
+      setIsFormOpen(false);
+      setEditTarget(null);
+      fetchCategories();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '저장에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // ── 삭제 핸들러 ──
   const handleDelete = async () => {
     if (!deleteTargetId) return;
     try {
@@ -61,43 +177,43 @@ export default function AdminSettingsPage() {
     }
   };
 
-  // Drag and Drop Handlers
+  // ── 토글(노출) 핸들러 ──
+  const handleToggleVisibility = (id: number, visible: boolean) => {
+    setVisibilityMap(prev => ({ ...prev, [id]: visible }));
+  };
+
+  // ── Drag & Drop (with Auto-scroll) ──
   const handleDragStart = (e: React.DragEvent, index: number) => {
+    if (sortByEvent) return; // 정렬 중에는 드래그 앤 드롭 방지 (순서 왜곡 방지)
     setDraggedIndex(index);
     e.dataTransfer.effectAllowed = 'move';
-    // 드래그 시 데이터 설정 (optional)
     e.dataTransfer.setData('text/plain', index.toString());
+    mouseYRef.current = e.clientY;
+    startAutoScroll();
   };
 
   const handleDragOver = (e: React.DragEvent, index: number) => {
     e.preventDefault();
-    if (draggedIndex === null || draggedIndex === index) return;
-
-    // 실시간 위치 변경 (Optional: Drop 시점에만 할 수도 있음)
-    const newCategories = [...categories];
-    const draggedItem = newCategories[draggedIndex];
-    newCategories.splice(draggedIndex, 1);
-    newCategories.splice(index, 0, draggedItem);
-    
+    if (sortByEvent || draggedIndex === null || draggedIndex === index) return;
+    const reordered = [...categories];
+    const [dragged] = reordered.splice(draggedIndex, 1);
+    reordered.splice(index, 0, dragged);
     setDraggedIndex(index);
-    setCategories(newCategories);
+    setCategories(reordered);
   };
 
   const handleDragEnd = async () => {
+    stopAutoScroll();
     if (draggedIndex === null) return;
     setDraggedIndex(null);
-
-    // 변경된 모든 아이템의 순서를 API로 반영 (백엔드 효율을 위해 전체 업데이트 또는 변경된 것만)
-    // 여기서는 간단하게 모든 아이템의 새로운 index를 sortOrder로 전송
     try {
       await Promise.all(
         categories.map((cat, idx) => adminCategoryAPI.updateOrder(cat.id, idx))
       );
-      // 최종 확인을 위해 목록 다시 불러오기
       fetchCategories();
     } catch (error) {
-      console.error('Failed to update category order:', error);
-      fetchCategories(); // 원래대로 복구
+      console.error('Failed to update order:', error);
+      fetchCategories();
     }
   };
 
@@ -112,14 +228,34 @@ export default function AdminSettingsPage() {
 
           <div className={styles.topActionArea}>
             <div className={styles.tabArea}>
-              <button className={`${styles.tab} ${styles.activeTab}`}>카테고리 관리</button>
+              <button className={`${styles.tab} ${styles.activeTab}`}>
+                카테고리 관리
+              </button>
             </div>
-            <Button variant="primary" size="medium">+ 새 카테고리 추가</Button>
+            <Button variant="primary" size="medium" onClick={handleOpenCreate}>
+              + 새 카테고리 추가
+            </Button>
           </div>
 
           <div className={styles.searchAddArea}>
             <div className={styles.searchArea}>
-              <InputField variant="search" placeholder="검색어를 입력하세요" />
+              <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+                <div style={{ flex: 1 }}>
+                  <InputField
+                    variant="search"
+                    placeholder="검색어를 입력하세요"
+                    value={searchKeyword}
+                    onChange={(e) => setSearchKeyword(e.target.value)}
+                  />
+                </div>
+                <Button
+                  variant={sortByEvent ? "primary" : "secondary"}
+                  size="medium"
+                  onClick={() => setSortByEvent(!sortByEvent)}
+                >
+                  {sortByEvent ? '기본 순서 보기' : '이벤트 많은 순'}
+                </Button>
+              </div>
             </div>
           </div>
 
@@ -131,16 +267,24 @@ export default function AdminSettingsPage() {
           </div>
 
           {isLoading ? (
-            <div style={{ padding: '40px', textAlign: 'center' }}>로딩 중...</div>
+            <div style={{ padding: '40px', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+              로딩 중...
+            </div>
+          ) : filteredCategories.length === 0 ? (
+            <div style={{ padding: '40px', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+              {searchKeyword ? '검색 결과가 없습니다.' : '등록된 카테고리가 없습니다.'}
+            </div>
           ) : (
             <div className={styles.categoryList}>
-              {categories.map((item, index) => (
+              {filteredCategories.map((item, index) => (
                 <div key={item.id} className={draggedIndex === index ? styles.dragging : ''}>
-                  <CategoryItem 
-                    item={item} 
+                  <CategoryItem
+                    item={item}
                     index={index}
-                    icon={ICONS[index % ICONS.length]}
+                    isVisible={visibilityMap[item.id] ?? true}
                     onDelete={setDeleteTargetId}
+                    onEdit={handleOpenEdit}
+                    onToggleVisibility={handleToggleVisibility}
                     onDragStart={handleDragStart}
                     onDragOver={handleDragOver}
                     onDragEnd={handleDragEnd}
@@ -151,12 +295,20 @@ export default function AdminSettingsPage() {
           )}
 
           <div className={styles.paginationArea}>
-            <Pagination currentPage={1} totalPages={1} onPageChange={() => {}} />
+            <Pagination currentPage={1} totalPages={1} onPageChange={() => { }} />
           </div>
         </div>
       </section>
 
-      <ConfirmModal 
+      <CategoryFormModal
+        isOpen={isFormOpen}
+        onClose={() => { setIsFormOpen(false); setEditTarget(null); }}
+        onSubmit={handleFormSubmit}
+        initialData={editTarget ? { name: editTarget.name, description: editTarget.description } : null}
+        isSubmitting={isSubmitting}
+      />
+
+      <ConfirmModal
         isOpen={deleteTargetId !== null}
         onClose={() => setDeleteTargetId(null)}
         onConfirm={handleDelete}

--- a/frontend/src/app/admin/users/_components/UserDetailModal.module.css
+++ b/frontend/src/app/admin/users/_components/UserDetailModal.module.css
@@ -136,8 +136,16 @@
   line-height: 150%;
 }
 
-/* 버튼 그룹 */
+/* 버튼 그룹 포맷팅 개선 (상하 배치 지원) */
 .buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  width: 100%;
+  margin-top: 16px;
+}
+
+.buttonRow {
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -145,5 +153,4 @@
   gap: var(--space-12);
   width: 100%;
   height: 36px;
-  margin-top: 16px;
 }

--- a/frontend/src/app/admin/users/_components/UserDetailModal.tsx
+++ b/frontend/src/app/admin/users/_components/UserDetailModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import styles from './UserDetailModal.module.css';
 import { ModalOverlay, ModalCard } from '@/components/modal';
-import { InputField, Button } from '@/components/ui';
+import { InputField, Button, Dropdown } from '@/components/ui';
 import { CancelIcon } from '@/components/icons';
 import { adminUserAPI, type AdminUserDetail } from '@/lib/admin-api';
 
@@ -18,8 +18,13 @@ export default function UserDetailModal({ isOpen, userId, onClose, onUpdated }: 
   const [user, setUser] = useState<AdminUserDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  // 권한 수정을 위한 상태
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<string>('USER');
+
   useEffect(() => {
     if (isOpen && userId) {
+      setIsEditing(false); // 모달 열 때마다 읽기 모드로 초기화
       fetchUser(userId);
     }
   }, [isOpen, userId]);
@@ -29,12 +34,26 @@ export default function UserDetailModal({ isOpen, userId, onClose, onUpdated }: 
     try {
       const res = await adminUserAPI.getUser(id);
       setUser(res.data);
+      setSelectedRole(res.data.role || 'USER');
     } catch (err) {
       console.error('회원 조회 실패:', err);
     } finally {
       setIsLoading(false);
     }
   };
+
+  const handleUpdateRole = async () => {
+    // TODO: 실제 권한 업데이트 API 호츨 위치
+    alert(`권한을 ${selectedRole}로 변경(예정)입니다.`);
+    setIsEditing(false);
+    // 권한 변경 후 리프레시 로직 등 추가 필요 (onUpdated 등)
+  };
+
+  const roleOptions = [
+    { value: 'USER', label: '수강생' },
+    { value: 'HOST', label: '주최자' },
+    { value: 'ADMIN', label: '관리자' }
+  ];
 
   return (
     <ModalOverlay isOpen={isOpen} onClose={onClose}>
@@ -56,18 +75,35 @@ export default function UserDetailModal({ isOpen, userId, onClose, onUpdated }: 
           <div className={styles.contentScroll}>
             {/* 프로필 이미지 */}
             <div className={styles.profilePicture}>
-               {/* 이미지가 없을 경우 이름의 첫 글자를 보여줌 (UserProfile 참고) */}
                <span style={{ color: 'white', fontWeight: 'bold', fontSize: '32px' }}>
                  {user.nickname ? user.nickname.charAt(0) : 'U'}
                </span>
             </div>
 
             <div className={styles.fieldsContainer}>
+              {/* ID 등급 관련 필드 추가 (권한 변경 로직을 위해) */}
+              <div className={styles.fieldBlock} style={{ zIndex: 10 }}> 
+                <span className={styles.fieldLabel}>권한 (Role)</span>
+                {isEditing ? (
+                  <Dropdown 
+                    options={roleOptions} 
+                    value={selectedRole} 
+                    onChange={setSelectedRole} 
+                  />
+                ) : (
+                  <InputField 
+                    value={selectedRole === 'HOST' ? '주최자' : selectedRole === 'ADMIN' ? '관리자' : '수강생'} 
+                    disabled 
+                  />
+                )}
+              </div>
+
               <div className={styles.fieldBlock}>
                 <span className={styles.fieldLabel}>아이디</span>
                 <InputField value={user.email} disabled />
               </div>
 
+              {/* 기본 데이터 렌더링은 user.role 기준이거나 selectedRole 기준일 수 있습니다. (여기선 기존 Role 유지) */}
               {user.role === 'HOST' ? (
                 <>
                   <div className={styles.fieldBlock}>
@@ -107,36 +143,62 @@ export default function UserDetailModal({ isOpen, userId, onClose, onUpdated }: 
                     <span className={styles.fieldLabel}>이름</span>
                     <InputField value={user.nickname || ''} disabled />
                   </div>
-                  {/* 이미지에서는 이름까지만 있었습니다 */}
                 </>
               )}
             </div>
 
             {/* 버튼 그룹 */}
             <div className={styles.buttonGroup}>
-              <Button 
-                variant="secondary" 
-                style={{ flex: 1, padding: 0 }} 
-                onClick={onClose}
-              >
-                취소
-              </Button>
-              {user.role === 'HOST' ? (
-                <Button 
-                  variant="danger" 
-                  style={{ flex: 1, padding: 0 }}
-                  onClick={() => alert('회원 삭제 기능은 아직 구현되지 않았습니다.')}
-                >
-                  회원 삭제
-                </Button>
+              {isEditing ? (
+                <div className={styles.buttonRow}>
+                  <Button 
+                    variant="secondary" 
+                    style={{ flex: 1, padding: 0 }} 
+                    onClick={() => {
+                      setIsEditing(false);
+                      setSelectedRole(user.role || 'USER'); // 취소 시 롤백
+                    }}
+                  >
+                    수정 취소
+                  </Button>
+                  <Button 
+                    variant="primary" 
+                    style={{ flex: 1, padding: 0 }}
+                    onClick={handleUpdateRole}
+                  >
+                    저장
+                  </Button>
+                </div>
               ) : (
-                <Button 
-                  variant="primary" 
-                  style={{ flex: 1, padding: 0 }}
-                  onClick={() => alert('변경 사항 저장 기능은 아직 구현되지 않았습니다.')}
-                >
-                  변경 사항 저장
-                </Button>
+                <>
+                  <div className={styles.buttonRow}>
+                    {user.role === 'HOST' && (
+                      <Button 
+                        variant="danger" 
+                        style={{ flex: 1, padding: 0 }}
+                        onClick={() => alert('회원 삭제 기능은 아직 구현되지 않았습니다.')}
+                      >
+                        회원 삭제
+                      </Button>
+                    )}
+                    <Button 
+                      variant="primary" 
+                      style={{ flex: 1, padding: 0 }}
+                      onClick={() => setIsEditing(true)}
+                    >
+                      프로필 수정
+                    </Button>
+                  </div>
+                  <div className={styles.buttonRow}>
+                    <Button 
+                      variant="secondary" 
+                      style={{ flex: 1, padding: 0 }} 
+                      onClick={onClose}
+                    >
+                      닫기
+                    </Button>
+                  </div>
+                </>
               )}
             </div>
           </div>

--- a/frontend/src/app/admin/users/_components/UserTable.module.css
+++ b/frontend/src/app/admin/users/_components/UserTable.module.css
@@ -40,7 +40,7 @@
   font-style: normal;
   font-weight: 400;
   line-height: 150%;
-  
+
   padding: 0;
   border: none;
   text-align: left;
@@ -72,12 +72,35 @@
   color: var(--Gray-700, #374151);
 }
 
-.hostCol { flex: 2 0 0; }
-.managerCol { flex: 1.5 0 0; }
-.bizNumCol { flex: 1.5 0 0; }
-.dateCol { flex: 1.5 0 0; }
-.statusCol { flex: 1 0 0; }
-.actionCol { flex: 0 0 32px; display: flex; justify-content: flex-end; }
+.hostCol {
+  flex: 2 0 0;
+}
+
+.managerCol {
+  flex: 1.5 0 0;
+}
+
+.bizNumCol {
+  flex: 1.5 0 0;
+}
+
+.dateCol {
+  flex: 1.5 0 0;
+}
+
+.statusCol {
+  flex: 1 0 0;
+}
+
+.table td.actionCol {
+  flex: 0 0 32px;
+  display: flex;
+  justify-content: flex-end;
+  overflow: visible;
+  -webkit-line-clamp: unset;
+  -webkit-box-orient: unset;
+  position: relative; /* z-index context for children */
+}
 
 .userProfile {
   display: flex;
@@ -112,12 +135,25 @@
   font-weight: 500;
 }
 
+.moreWrapper {
+  position: relative;
+  display: inline-flex;
+}
+
 .moreButton {
   background: none;
   border: none;
   cursor: pointer;
   color: #6B7280;
   padding: 4px;
+}
+
+.popover {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 8px;
+  /* Design for this popover is handled inside PopoverMenu.tsx/module.css */
 }
 
 .loading,

--- a/frontend/src/app/admin/users/_components/UserTable.tsx
+++ b/frontend/src/app/admin/users/_components/UserTable.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './UserTable.module.css';
 import { MoreIcon } from '@/components/icons';
+import { PopoverMenu } from '@/components/ui';
 import type { AdminUserListItem } from '@/lib/admin-api';
 
 interface UserTableProps {
@@ -17,17 +18,26 @@ function formatDate(dateStr: string) {
   if (!dateStr) return '-';
   const d = new Date(dateStr);
   const pad = (n: number) => n.toString().padStart(2, '0');
-  
+
   const year = d.getFullYear();
   const month = pad(d.getMonth() + 1);
   const day = pad(d.getDate());
   const hours = pad(d.getHours());
   const minutes = pad(d.getMinutes());
-  
+
   return `${year}-${month}-${day} ${hours}:${minutes}`;
 }
 
+const POPOVER_ITEMS = [
+  { value: 'edit', label: '편집' },
+  { value: 'delete', label: '삭제' },
+  { value: 'reject', label: '반려' },
+  { value: 'report', label: '경고' },
+];
+
 export default function UserTable({ users, isLoading, onViewDetail, onDeleteClick }: UserTableProps) {
+  const [openPopoverId, setOpenPopoverId] = useState<number | null>(null);
+
   if (isLoading) {
     return <div className={styles.loading}>로딩 중...</div>;
   }
@@ -39,6 +49,31 @@ export default function UserTable({ users, isLoading, onViewDetail, onDeleteClic
   // 주최자 관리/수강생 관리에 따라 헤더가 다를 수 있지만, 
   // 요청하신 디자인 사양(이미지) 기준으로 주최자 헤더를 구현합니다.
   const isHostView = users.length > 0 && users[0].role === 'HOST';
+
+  const handleMoreClick = (e: React.MouseEvent, userId: number) => {
+    e.stopPropagation();
+    setOpenPopoverId(prev => (prev === userId ? null : userId));
+  };
+
+  const handlePopoverSelect = (value: string, user: AdminUserListItem) => {
+    setOpenPopoverId(null);
+    switch (value) {
+      case 'edit':
+        onViewDetail(user.id);
+        break;
+      case 'delete':
+        onDeleteClick(user);
+        break;
+      case 'reject':
+        // TODO: 반려 로직 연결
+        console.log('반려:', user.id);
+        break;
+      case 'report':
+        // TODO: 신고 로직 연결
+        console.log('신고:', user.id);
+        break;
+    }
+  };
 
   return (
     <div className={styles.tableWrapper}>
@@ -79,12 +114,26 @@ export default function UserTable({ users, isLoading, onViewDetail, onDeleteClic
                 </span>
               </td>
               <td className={styles.actionCol}>
-                <button 
-                  className={styles.moreButton}
-                  onClick={() => onViewDetail(user.id)}
+                <div
+                  className={styles.moreWrapper}
+                  style={{ zIndex: openPopoverId === user.id ? 50 : 1 }}
                 >
-                  <MoreIcon />
-                </button>
+                  <button
+                    className={styles.moreButton}
+                    onClick={(e) => handleMoreClick(e, user.id)}
+                  >
+                    <MoreIcon />
+                  </button>
+                  {openPopoverId === user.id && (
+                    <PopoverMenu
+                      items={POPOVER_ITEMS}
+                      onSelect={(value) => handlePopoverSelect(value, user)}
+                      onClose={() => setOpenPopoverId(null)}
+                      width={140}
+                      className={styles.popover}
+                    />
+                  )}
+                </div>
               </td>
             </tr>
           ))}

--- a/frontend/src/app/admin/users/page.module.css
+++ b/frontend/src/app/admin/users/page.module.css
@@ -1,35 +1,11 @@
-.wrapper {
-  display: flex;
-  padding: 100px 160px;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 32px;
-  align-self: stretch;
-  background-color: var(--color-bg, #fff);
-  min-height: 100vh;
-}
-
-.content {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 32px;
-  flex: 1 0 0;
-}
-
 .pageHeader {
   display: flex;
-  height: 36px;
-  padding-right: 732px; /* 디자인 사양 반영 */
   align-items: center;
   align-self: stretch;
+  margin-bottom: 32px;
 }
 
 .pageTitle {
-  color: var(--Gray-900, #111827);
-  font-family: Inter, sans-serif;
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 150%;
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
 }

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -94,10 +94,10 @@ export default function AdminUsersPage() {
   };
 
   return (
-    <div className={styles.wrapper}>
+    <div className="container-sidebar">
       <Sidebar role="admin" />
 
-      <div className={styles.content}>
+      <div className="sidebar-content">
         <div className={styles.pageHeader}>
           <h1 className={styles.pageTitle}>사용자 관리</h1>
         </div>

--- a/frontend/src/components/ui/PopoverMenu.module.css
+++ b/frontend/src/components/ui/PopoverMenu.module.css
@@ -12,9 +12,12 @@
   position: absolute;
   z-index: 50;
 
-  background: var(--color-bg);                    /* #FFFFFF */
-  border: 1px solid var(--color-text-gray-300);   /* #D1D5DB */
-  border-radius: var(--radius-md);                /* 8px */
+  background: var(--color-bg);
+  /* #FFFFFF */
+  border: 1px solid var(--color-text-gray-300);
+  /* #D1D5DB */
+  border-radius: var(--radius-md);
+  /* 8px */
   box-shadow: var(--shadow-md);
 
   max-height: 240px;
@@ -32,21 +35,25 @@
   width: 100%;
   height: 37px;
   cursor: pointer;
-  background: var(--color-bg);                    /* #FFFFFF */
+  background: var(--color-bg);
+  /* #FFFFFF */
   user-select: none;
   transition: background var(--transition);
 }
 
 .menuItem:hover {
-  background: var(--color-surface);               /* #F3F4F6 */
+  background: var(--color-surface);
+  /* #F3F4F6 */
 }
 
 .menuItemText {
   font: var(--text-body-medium);
-  color: var(--color-text-gray-500);              /* #6B7280 */
+  color: var(--color-text-gray-500);
+  /* #6B7280 */
   white-space: nowrap;
 }
 
 .menuItemSelected .menuItemText {
-  color: var(--color-text-gray-700);              /* #374151 */
+  color: var(--color-text-gray-700);
+  /* #374151 */
 }

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -81,3 +81,40 @@ export const adminUserAPI = {
   deleteUser: (id: number) =>
     api.delete<ApiResponse<void>>(`/admin/users/${id}`),
 };
+
+export interface AdminCategoryItem {
+  id: number;
+  name: string;
+  description: string;
+  sortOrder: number;
+}
+
+export interface AdminCategoryRequest {
+  name: string;
+  description: string;
+  sortOrder: number;
+}
+
+export const adminCategoryAPI = {
+  /** 전체 카테고리 목록 조회 (정렬 순) */
+  getList: () =>
+    api.get<ApiResponse<AdminCategoryItem[]>>('/admin/categories'),
+
+  /** 신규 카테고리 생성 */
+  create: (data: AdminCategoryRequest) =>
+    api.post<ApiResponse<AdminCategoryItem>>('/admin/categories', data),
+
+  /** 카테고리 정보 수정 */
+  update: (id: number, data: AdminCategoryRequest) =>
+    api.put<ApiResponse<AdminCategoryItem>>(`/admin/categories/${id}`, data),
+
+  /** 카테고리 삭제 */
+  delete: (id: number) =>
+    api.delete<ApiResponse<void>>(`/admin/categories/${id}`),
+
+  /** 순서 변경 (PATCH) */
+  updateOrder: (id: number, newOrder: number) =>
+    api.patch<ApiResponse<void>>(`/admin/categories/${id}/order`, newOrder, {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+};

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -87,6 +87,7 @@ export interface AdminCategoryItem {
   name: string;
   description: string;
   sortOrder: number;
+  eventCount: number;
 }
 
 export interface AdminCategoryRequest {
@@ -114,7 +115,5 @@ export const adminCategoryAPI = {
 
   /** 순서 변경 (PATCH) */
   updateOrder: (id: number, newOrder: number) =>
-    api.patch<ApiResponse<void>>(`/admin/categories/${id}/order`, newOrder, {
-      headers: { 'Content-Type': 'application/json' },
-    }),
+    api.patch<ApiResponse<void>>(`/admin/categories/${id}/order`, { sortOrder: newOrder }),
 };


### PR DESCRIPTION
## 🛠️ 연관 티켓 
- VO-744
- VO-746
- VO-747
## 📌 작업 내용 (Summary)
이번 PR에서는 관리자(Admin) 페이지의 **시스템 설정 > 카테고리 관리** 기능 전반을 고도화했습니다.
드래그 앤 드롭 UX 개선부터 백엔드 집계 쿼리를 통한 이벤트 카운트 표시(AD-012), 그리고 모달 뷰 등 전반적인 UI의 디자인 시스템 통합을 수행했습니다.
## ✨ 주요 변경 사항 (Key Changes)
### 1. 카테고리별 사용 현황 추가 (AD-012)
- **Backend**: `CategoryJpaRepository`에 `LEFT JOIN`과 `GROUP BY`를 활용한 JPQL 집계 쿼리(`findAllWithEventCount`)를 작성하여 N+1 문제 없이 이벤트 개수를 효율적으로 조회합니다.
- **Backend Architecture**: DTO(`CategoryResponse`), Entity Mapper, Service 로직을 확장하여 `eventCount` 데이터 파이프라인을 구축했습니다.
- **Frontend**: 카테고리명 우측에 `(N)` 형태로 이벤트 수를 간결하게 표시하도록 UI를 업데이트했습니다 (카테고리명과 컬러 톤 일치).
### 2. 향상된 카테고리 정렬 및 필터링 UX
- 검색 영역 우측에 **[이벤트 많은 순 / 기본 순서 보기]** 토글 버튼을 추가했습니다.
- 프론트엔드 레벨(`useMemo`)에서 즉각적으로 정렬 상태가 전환되도록 구현했습니다.
- 순서 뒤틀림을 방지하기 위해 정렬 기준이 '이벤트 많은 순'일 경우, 드래그 앤 드롭 순서 변경은 비활성화되도록 예외 처리를 추가했습니다.
### 3. Drag & Drop Auto-Scroll 기능 구현
- 카테고리 리스트가 길어 화면 밖으로 넘어갈 때, 마우스를 화면 상/하단 80px 경계로 가져가면 화면이 자동으로 부드럽게 스크롤되는 기능을 추가했습니다. (`requestAnimationFrame` 활용)
### 4. UI/UX 개선 및 버그 픽스
- 카테고리 폼 모달(`CategoryFormModal`)을 공통 모달 CSS(`InputModal.module.css`)에 맞게 리팩토링하여 전체 레이아웃의 디자인 일관성을 확보했습니다.
- 카테고리 아이템 좌측의 불필요한 아이콘을 제거하여 UI를 간소화했습니다.
- 프론트엔드 레이아웃 인라인 스타일로 인해 발생하던 React Hydration 에러를 수정했습니다.
- 백엔드 카테고리 순서 변경(`updateOrder`) 시 원시 타입(`int`) 통신 에러를 해결하기 위해 `UpdateOrderRequest` DTO를 도입했습니다.
## 🧪 테스트 방법
1. 관리자 계정으로 로그인 후 `admin/settings` 페이지로 이동
2. 생성 단추를 눌러 새 모달 UI 디자인 확인
3. 아이템을 드래그하여 브라우저 하단 가장자리로 가져갔을 때 자동 스크롤 확인
4. 리스트 우측 상단의 `[이벤트 많은 순]` 버튼 클릭 시 실시간 정렬 확인 및 이때 드래그 막힘 확인