### PR TITLE
feat: 장바구니 일괄 결제 기능 구현 및 결제 프로세스 안정성 강화

### DIFF
--- a/backend/src/main/java/com/venueon/cart/adapter/out/persistence/CartPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/cart/adapter/out/persistence/CartPersistenceAdapter.java
@@ -42,6 +42,13 @@ public class CartPersistenceAdapter implements CartRepositoryPort {
     }
 
     @Override
+    public List<Cart> findAllByIds(List<Long> ids) {
+        return cartJpaRepository.findAllById(ids).stream()
+                .map(cartMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Optional<Cart> findByUserEmailAndSessionId(String userEmail, Long sessionId) {
         return cartJpaRepository.findByUserEmailAndEventSessionId(userEmail, sessionId)
                 .map(cartMapper::toDomain);

--- a/backend/src/main/java/com/venueon/cart/application/port/out/CartRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/cart/application/port/out/CartRepositoryPort.java
@@ -32,6 +32,11 @@ public interface CartRepositoryPort {
     boolean existsByUserEmailAndSessionId(String userEmail, Long sessionId);
 
     /**
+     * 여러 ID로 장바구니 항목 일괄 조회
+     */
+    List<Cart> findAllByIds(List<Long> ids);
+
+    /**
      * 장바구니 항목 저장
      */
     Cart save(Cart cart);

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/OrderController.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/OrderController.java
@@ -39,6 +39,22 @@ public class OrderController {
     }
 
     /**
+     * 장바구니 일괄 주문 생성 (PENDING 상태)
+     * POST /orders/batch
+     */
+    @PostMapping("/batch")
+    public ResponseEntity<ApiResponse<CreateBatchOrderResponse>> createBatchOrder(
+            Authentication authentication,
+            @Valid @RequestBody CreateBatchOrderRequest request) {
+
+        String email = authentication.getName();
+        Long userId = orderService.getUserIdByEmail(email);
+
+        CreateBatchOrderResponse response = orderService.createBatchOrder(userId, email, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * 토스 결제 승인 요청
      * POST /orders/{id}/confirm
      */

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateBatchOrderRequest.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateBatchOrderRequest.java
@@ -1,0 +1,21 @@
+package com.venueon.order.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateBatchOrderRequest {
+
+    @NotNull(message = "장바구니 항목 ID 목록은 필수입니다.")
+    @Size(min = 1, message = "최소 1개 이상의 장바구니 항목이 필요합니다.")
+    private List<Long> cartIds;
+
+    @NotBlank(message = "결제 수단은 필수입니다.")
+    private String paymentMethod;
+}

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateBatchOrderResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/CreateBatchOrderResponse.java
@@ -1,0 +1,20 @@
+package com.venueon.order.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateBatchOrderResponse {
+    private List<Long> orderIds;
+    private String tossOrderId;
+    private int totalAmount;
+    private String orderName;
+    private String customerName;
+    private String customerEmail;
+    private String tossClientKey;
+}

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -89,6 +89,13 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
     }
 
     @Override
+    public List<Order> findAllByTossOrderId(String tossOrderId) {
+        return orderJpaRepository.findAllByTossOrderId(tossOrderId).stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public List<Order> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses) {
         return orderJpaRepository.findByUserIdAndEventIdAndStatusIn(userId, eventId, statuses)
                 .stream()

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -66,6 +66,8 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
 
     java.util.Optional<OrderJpaEntity> findByTossOrderId(String tossOrderId);
 
+    List<OrderJpaEntity> findAllByTossOrderId(String tossOrderId);
+
     List<OrderJpaEntity> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
     
     List<OrderJpaEntity> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -16,6 +16,8 @@ public interface OrderRepositoryPort {
     
     Optional<Order> findByTossOrderId(String tossOrderId);
     
+    List<Order> findAllByTossOrderId(String tossOrderId);
+    
     List<Order> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
     
     List<Order> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.venueon.order.application.service;
 
+import com.venueon.cart.application.port.out.CartRepositoryPort;
+import com.venueon.cart.domain.model.Cart;
 import com.venueon.common.exception.BusinessException;
 import com.venueon.common.exception.ErrorCode;
 import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
@@ -11,7 +13,6 @@ import com.venueon.order.application.port.out.RefundSavePort;
 import com.venueon.order.domain.model.Order;
 import com.venueon.order.domain.model.OrderStatus;
 import com.venueon.order.adapter.in.web.dto.*;
-import com.venueon.order.application.port.in.RequestRefundUseCase;
 import com.venueon.event.application.port.out.SessionPort;
 import com.venueon.event.domain.model.EventSession;
 import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
@@ -25,8 +26,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -41,6 +44,7 @@ public class OrderService {
     private final RefundSavePort refundSavePort;
     private final RequestRefundUseCase requestRefundUseCase;
     private final SessionPort sessionPort;
+    private final CartRepositoryPort cartRepositoryPort;
 
     @Value("${toss.client-key}")
     private String tossClientKey;
@@ -127,22 +131,124 @@ public class OrderService {
     }
 
     /**
-     * 토스 결제 승인 요청
+     * 장바구니 일괄 주문 생성 (PENDING 상태)
+     * API 스펙: POST /orders/batch
+     */
+    @Transactional
+    public CreateBatchOrderResponse createBatchOrder(Long userId, String userEmail, CreateBatchOrderRequest request) {
+        // 1. 장바구니 항목 조회
+        List<Cart> carts = cartRepositoryPort.findAllByIds(request.getCartIds());
+        if (carts.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 2. 소유권 검증
+        for (Cart cart : carts) {
+            if (!cart.isOwnedBy(userEmail)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN);
+            }
+        }
+
+        // 3. 유저 조회
+        UserJpaEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+
+        // 4. 대표 tossOrderId 발급 (시간 기반 고유 값)
+        String batchTossOrderId = "venueon_batch_" + userId + "_" + System.currentTimeMillis();
+
+        // 5. 각 장바구니 항목별 Order 생성
+        List<Long> orderIds = new ArrayList<>();
+        int totalAmount = 0;
+        List<String> eventTitles = new ArrayList<>();
+
+        for (Cart cart : carts) {
+            // 세션 조회 및 검증
+            EventSession session = sessionPort.findById(cart.getSessionId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+            // 중복 주문 검증
+            List<Order> existingOrders = orderRepository.findByUserIdAndSessionIdAndStatusIn(
+                    userId, session.getId(),
+                    List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
+            if (!existingOrders.isEmpty()) {
+                throw new BusinessException(ErrorCode.ORDER_ALREADY_EXISTS);
+            }
+
+            // 정원 초과 검증
+            long currentAttendees = orderRepository.countBySessionIdAndStatusIn(
+                    session.getId(),
+                    List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
+            if (session.getMaxAttendees() > 0 && currentAttendees + cart.getQuantity() > session.getMaxAttendees()) {
+                throw new BusinessException(ErrorCode.EVENT_FULL);
+            }
+
+            // 주문 금액 계산
+            int itemAmount = session.getPrice() * cart.getQuantity();
+            totalAmount += itemAmount;
+
+            // Order 생성
+            Order pendingOrder = Order.createPending(
+                    userId, cart.getEventId(), session.getId(),
+                    cart.getQuantity(), itemAmount, request.getPaymentMethod());
+            Order savedOrder = orderRepository.save(pendingOrder);
+
+            // 동일한 batchTossOrderId 부여
+            savedOrder.updateTossOrderId(batchTossOrderId);
+
+            // 무료 주문인 경우 즉시 승인
+            if (savedOrder.getStatus() == OrderStatus.REGISTERED) {
+                session.incrementAttendees(savedOrder.getQuantity());
+                sessionPort.save(session, cart.getEventId());
+            }
+
+            savedOrder = orderRepository.save(savedOrder);
+            orderIds.add(savedOrder.getId());
+
+            if (!eventTitles.contains(cart.getEventTitle())) {
+                eventTitles.add(cart.getEventTitle());
+            }
+        }
+
+        // 6. 주문명 생성
+        String orderName = eventTitles.size() == 1
+                ? eventTitles.get(0)
+                : eventTitles.get(0) + " 외 " + (eventTitles.size() - 1) + "건";
+
+        log.info("일괄 주문 생성 완료: orderIds={}, tossOrderId={}, totalAmount={}",
+                orderIds, batchTossOrderId, totalAmount);
+
+        return CreateBatchOrderResponse.builder()
+                .orderIds(orderIds)
+                .tossOrderId(batchTossOrderId)
+                .totalAmount(totalAmount)
+                .orderName(orderName)
+                .customerName(user.getNickname())
+                .customerEmail(user.getEmail())
+                .tossClientKey(tossClientKey)
+                .build();
+    }
+
+    /**
+     * 토스 결제 승인 요청 (단건 + 일괄 주문 모두 지원)
      * API 스펙: POST /orders/{id}/confirm
      */
     @Transactional
     public ConfirmPaymentResponse confirmPayment(Long orderId, ConfirmPaymentRequest request) {
-        // 1. 주문 모델 조회
+        // 1. 대표 주문 모델 조회
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 금액 일치 검증
-        if (order.getAmount() != request.getAmount()) {
-            log.warn("금액 불일치: DB={}, request={}", order.getAmount(), request.getAmount());
+        // 2. 동일 tossOrderId를 가진 모든 주문 조회 (일괄 주문 지원)
+        List<Order> relatedOrders = orderRepository.findAllByTossOrderId(order.getTossOrderId());
+
+        // 3. 합산 금액 검증
+        int totalAmount = relatedOrders.stream().mapToInt(Order::getAmount).sum();
+        if (totalAmount != request.getAmount()) {
+            log.warn("금액 불일치: DB 합산={}, request={}", totalAmount, request.getAmount());
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
-        // 3. 토스 결제 승인 API 호출 (더미테스트용 키인 경우 패스)
+        // 4. 토스 결제 승인 API 호출 (더미테스트용 키인 경우 패스)
         if (!"dummy_key".equals(request.getPaymentKey())) {
             tossPaymentClient.confirmPayment(
                     request.getPaymentKey(),
@@ -150,36 +256,69 @@ public class OrderService {
                     request.getAmount());
         }
 
-        // 4. 도메인 모델 상태 업데이트 (PENDING → PAID)
-        order.confirmPayment(request.getPaymentKey());
+        // 5. 모든 관련 주문의 상태를 PAID로 전환 + 세션 참석자 업데이트
+        for (Order relatedOrder : relatedOrders) {
+            if (relatedOrder.getStatus() == OrderStatus.PENDING) {
+                relatedOrder.confirmPayment(request.getPaymentKey());
+                orderRepository.save(relatedOrder);
 
-        // 5. 세션 참석자 업데이트
-        int qty = order.getQuantity();
-        Long evtId = order.getEventId();
-        if (order.getSessionId() != null) {
-            sessionPort.findById(order.getSessionId()).ifPresent(session -> {
-                session.incrementAttendees(qty);
-                sessionPort.save(session, evtId);
-            });
+                // 세션 참석자 업데이트
+                if (relatedOrder.getSessionId() != null) {
+                    int qty = relatedOrder.getQuantity();
+                    Long evtId = relatedOrder.getEventId();
+                    sessionPort.findById(relatedOrder.getSessionId()).ifPresent(session -> {
+                        session.incrementAttendees(qty);
+                        sessionPort.save(session, evtId);
+                    });
+                }
+            }
         }
 
-        // 6. 도메인 모델 저장
-        order = orderRepository.save(order);
+        // 6. 일괄 주문(batch)인 경우 장바구니 항목 삭제
+        if (order.getTossOrderId() != null && order.getTossOrderId().startsWith("venueon_batch_")) {
+            try {
+                // 결제 완료된 주문들의 sessionId로 장바구니 항목을 찾아 삭제
+                String userEmail = userRepository.findById(order.getUserId())
+                        .map(UserJpaEntity::getEmail).orElse(null);
+                if (userEmail != null) {
+                    for (Order relatedOrder : relatedOrders) {
+                        if (relatedOrder.getSessionId() != null) {
+                            cartRepositoryPort.findByUserEmailAndSessionId(userEmail, relatedOrder.getSessionId())
+                                    .ifPresent(cart -> cartRepositoryPort.deleteById(cart.getId()));
+                        }
+                    }
+                }
+                log.info("결제 완료 후 장바구니 항목 삭제 완료");
+            } catch (Exception e) {
+                log.warn("장바구니 항목 삭제 중 오류 (결제는 정상 처리됨): {}", e.getMessage());
+            }
+        }
 
-        log.info("결제 승인 완료: orderId={}, paymentKey={}", orderId, request.getPaymentKey());
+        log.info("결제 승인 완료: orderId={}, paymentKey={}, relatedOrders={}",
+                orderId, request.getPaymentKey(), relatedOrders.size());
+
+        // 7. 반환할 주문 객체 최신화 (PAID 상태 반영)
+        // relatedOrders 리스트에서 현재 orderId와 일치하는 인스턴스를 찾거나, 상태를 직접 동기화
+        Order confirmedOrder = relatedOrders.stream()
+                .filter(o -> o.getId().equals(orderId))
+                .findFirst()
+                .orElse(order); // 만약 못 찾으면 기존 order 반환 (거의 일어날 수 없음)
 
         // 이벤트명(강의명) 조회
-        String orderName = eventRepository.findById(order.getEventId())
-                .map(com.venueon.event.adapter.out.persistence.entity.EventJpaEntity::getTitle)
+        String orderName = eventRepository.findById(confirmedOrder.getEventId())
+                .map(EventJpaEntity::getTitle)
                 .orElse("VenueOn 강의");
+        if (relatedOrders.size() > 1) {
+            orderName = orderName + " 외 " + (relatedOrders.size() - 1) + "건";
+        }
 
         return ConfirmPaymentResponse.builder()
-                .orderId(order.getId())
+                .orderId(confirmedOrder.getId())
                 .orderName(orderName)
-                .status(order.getStatus().name())
-                .amount(order.getAmount())
-                .paymentMethod(order.getPaymentMethod())
-                .paidAt(order.getPaidAt())
+                .status(confirmedOrder.getStatus().name())
+                .amount(totalAmount)
+                .paymentMethod(confirmedOrder.getPaymentMethod())
+                .paidAt(confirmedOrder.getPaidAt())
                 .build();
     }
 

--- a/frontend/src/app/cart/hooks/use-cart.ts
+++ b/frontend/src/app/cart/hooks/use-cart.ts
@@ -235,6 +235,19 @@ export const useCart = () => {
 
   const checkedItemsCount = processedCartItems.filter(item => item.checked).length;
 
+  // 체크된 세션들의 cartId(숫자) 목록 반환
+  const getCheckedCartIds = (): number[] => {
+    const ids: number[] = [];
+    cartItems.forEach(item => {
+      item.sessions?.forEach(session => {
+        if (session.checked) {
+          ids.push(Number(session.id));
+        }
+      });
+    });
+    return ids;
+  };
+
   return {
     cartItems: processedCartItems,
     loading,
@@ -244,6 +257,7 @@ export const useCart = () => {
     removeItem,
     toggleSelectAll,
     toggleSelectItem,
+    getCheckedCartIds,
     refresh: fetchItems
   };
 };

--- a/frontend/src/app/cart/page.tsx
+++ b/frontend/src/app/cart/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import styles from './cart.module.css';
 import Button from '@/components/ui/Button';
 import Checkbox from '@/components/ui/Checkbox';
@@ -17,8 +18,11 @@ export default function CartPage() {
     updateQuantity,
     removeItem,
     toggleSelectAll,
-    toggleSelectItem
+    toggleSelectItem,
+    getCheckedCartIds
   } = useCart();
+
+  const router = useRouter();
 
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
@@ -191,6 +195,16 @@ export default function CartPage() {
             variant="primary"
             size="large"
             className={styles.orderButton}
+            onClick={() => {
+              const cartIds = getCheckedCartIds();
+              if (cartIds.length === 0) {
+                alert('주문할 항목을 선택해주세요.');
+                return;
+              }
+              const params = new URLSearchParams();
+              params.set('cartIds', cartIds.join(','));
+              router.push(`/orders/checkout?${params.toString()}`);
+            }}
           >
             <span>주문하기</span>
             {checkedItemsCount > 0 && (

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -43,24 +43,41 @@ function CheckoutContent() {
         setLoading(true);
         setError(null);
 
-        const eventId = searchParams.get('eventId') || '1';
-        const quantity = searchParams.get('quantity') || '1';
-        const sessionId = searchParams.get('sessionId');
+        const cartIds = searchParams.get('cartIds');
+        const eventId = searchParams.get('eventId');
 
-        const requestBody: any = {
-          eventId: Number(eventId),
-          quantity: Number(quantity),
-          paymentMethod: 'CARD',
-        };
-        if (sessionId) {
-          requestBody.sessionId = Number(sessionId);
+        let res: Response;
+
+        if (cartIds) {
+          // 일괄 주문 모드 (장바구니에서 진입)
+          res = await fetch('/api/orders/batch', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              cartIds: cartIds.split(',').map(Number),
+              paymentMethod: 'CARD',
+            }),
+          });
+        } else {
+          // 단건 주문 모드 (기존 이벤트 상세에서 진입)
+          const quantity = searchParams.get('quantity') || '1';
+          const sessionId = searchParams.get('sessionId');
+
+          const requestBody: any = {
+            eventId: Number(eventId || '1'),
+            quantity: Number(quantity),
+            paymentMethod: 'CARD',
+          };
+          if (sessionId) {
+            requestBody.sessionId = Number(sessionId);
+          }
+
+          res = await fetch('/api/orders', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+          });
         }
-
-        const res = await fetch('/api/orders', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody),
-        });
 
         if (!res.ok) {
           const errorBody = await res.json().catch(() => null);
@@ -68,7 +85,23 @@ function CheckoutContent() {
         }
 
         const json = await res.json();
-        setOrderData(json.data);
+        // 단건과 일괄 응답 모두 동일한 형식으로 매핑
+        const data = json.data;
+        
+        // 일괄 주문인 경우 success 페이지에서 조회용으로 사용할 대표 orderId를 localStorage에 임시 저장
+        if (data.orderIds && data.orderIds.length > 0) {
+          localStorage.setItem('batchOrderId', data.orderIds[0].toString());
+        }
+
+        setOrderData({
+          orderId: data.orderId || (data.orderIds ? data.orderIds[0] : 0),
+          tossOrderId: data.tossOrderId,
+          amount: data.amount ?? data.totalAmount,
+          orderName: data.orderName,
+          customerName: data.customerName,
+          customerEmail: data.customerEmail,
+          tossClientKey: data.tossClientKey,
+        });
       } catch (err: any) {
         console.error('주문 생성 에러:', err);
         setError(err.message || '주문을 생성하는 중 오류가 발생했습니다.');
@@ -127,7 +160,7 @@ function CheckoutContent() {
         orderName: orderData.orderName,
         customerName: orderData.customerName,
         customerEmail: orderData.customerEmail,
-        successUrl: `${window.location.origin}/orders/checkout/success`,
+        successUrl: `${window.location.origin}/orders/checkout/success?backendOrderId=${orderData.orderId}`,
         failUrl: `${window.location.origin}/orders/checkout/fail`,
       });
     } catch (err) {
@@ -234,7 +267,7 @@ function CheckoutContent() {
           className={styles.submitBtn}
           onClick={() => {
             if (!orderData) return;
-            window.location.href = `/orders/checkout/success?paymentKey=dummy_key&orderId=${orderData.tossOrderId}&amount=${orderData.amount}`;
+            window.location.href = `/orders/checkout/success?paymentKey=dummy_key&orderId=${orderData.tossOrderId}&amount=${orderData.amount}&backendOrderId=${orderData.orderId}`;
           }}
           type="button"
           size="large"

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -80,6 +80,9 @@ function CheckoutContent() {
         }
 
         if (!res.ok) {
+          if (res.status === 401) {
+            throw new Error('주문은 로그인 후에 사용할 수 있습니다.');
+          }
           const errorBody = await res.json().catch(() => null);
           throw new Error(errorBody?.message || `주문 생성 실패 (${res.status})`);
         }

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -33,7 +33,7 @@ function CheckoutContent() {
   const [error, setError] = useState<string | null>(null);
   const orderCreated = useRef(false); // 중복 주문 생성 방지 플래그
 
-  // 1단계: 백엔드에 주문 생성 요청 (한 번만 실행)
+  // 1단계: 백엔드에 주문 생성 요청 (한  번만 실행)
   useEffect(() => {
     if (orderCreated.current) return; // 이미 주문 생성 요청한 경우 스킵
     orderCreated.current = true;
@@ -90,7 +90,7 @@ function CheckoutContent() {
         const json = await res.json();
         // 단건과 일괄 응답 모두 동일한 형식으로 매핑
         const data = json.data;
-        
+
         // 일괄 주문인 경우 success 페이지에서 조회용으로 사용할 대표 orderId를 localStorage에 임시 저장
         if (data.orderIds && data.orderIds.length > 0) {
           localStorage.setItem('batchOrderId', data.orderIds[0].toString());

--- a/frontend/src/app/orders/checkout/success/page.tsx
+++ b/frontend/src/app/orders/checkout/success/page.tsx
@@ -16,13 +16,9 @@ function CheckoutSuccessContent() {
   useEffect(() => {
     const confirmPayment = async () => {
       const paymentKey = searchParams.get('paymentKey');
-      const tossOrderId = searchParams.get('orderId');
+      const tossOrderId = searchParams.get('orderId'); // 토스가 보낸 결제 식별값 (venueon_batch_...)
       const amount = searchParams.get('amount');
-      const orderId = searchParams.get('orderId')?.match(/venueon_order_(\d+)_/)?.[1]
-        || new URLSearchParams(window.location.search).get('orderId');
-
-      // orderId가 URL에 별도 파라미터로 오는 경우 (우리 커스텀 파라미터)
-      const backendOrderId = new URLSearchParams(window.location.hash || window.location.search).get('orderId');
+      const backendOrderId = searchParams.get('backendOrderId'); // 우리가 보낸 내부 DB ID (숫자)
 
       if (!paymentKey || !tossOrderId || !amount) {
         setStatus('error');
@@ -30,9 +26,9 @@ function CheckoutSuccessContent() {
         return;
       }
 
-      // tossOrderId에서 백엔드 orderId 추출: venueon_order_{id}_{timestamp}
+      // 내부 orderId 식별 (쿼리 파라미터 backendOrderId 최우선)
       const match = tossOrderId.match(/venueon_order_(\d+)_/);
-      const extractedOrderId = match ? match[1] : backendOrderId;
+      let extractedOrderId = backendOrderId || (match ? match[1] : null);
 
       if (!extractedOrderId) {
         setStatus('error');


### PR DESCRIPTION
## 🚀 개요
장바구니에 담긴 여러 강의 세션을 한 번에 결제할 수 있는 일괄 결제 기능을 구현하고, 기존 결제 프로세스에서 발견된 안정성 이슈들을 해결했습니다.

## ✨ 주요 변경 사항

### 1. 백엔드 (Java/Spring Boot)
- **일괄 주문 생성 API 추가**: `POST /orders/batch` 엔드포인트를 통해 여러 `cartIds`를 받아 하나의 `tossOrderId`로 묶인 주문들을 생성합니다.
- **결제 승인 로직 고도화**: `OrderService.confirmPayment`가 단건 및 일괄 결제를 모두 지원하도록 수정했습니다.
- **자동 장바구니 관리**: 결제가 성공적으로 완료되면 관련 장바구니 항목이 자동으로 삭제되도록 구현했습니다.
- **응답 데이터 동기화**: 결제 승인 즉시 최신 주문 상태(`PAID`)가 응답에 반영되도록 로직을 개선했습니다.

### 2. 프론트엔드 (Next.js/React)
- **장바구니 연동**: 장바구니에서 선택된 항목들의 ID를 체크아웃 페이지로 전달하는 기능을 추가했습니다.
- **일괄 결제 흐름 구현**: 체크아웃 페이지에서 진입 경로(단건/일괄)에 따라 적절한 주문 생성 API를 호출하도록 분기 처리했습니다.
- **파라미터 충돌 해결**: 토스의 `orderId`와 내부 ID의 이름 충돌로 인한 403 에러를 해결하기 위해 내부 ID 파라미터명을 `backendOrderId`로 변경했습니다.
- **새로고침 안정성 확보**: 결제 성공 페이지에서 URL 파라미터를 활용하여, 페이지를 새로고침해도 주문 정보를 잃어버리지 않도록 개선했습니다.
- **사용자 경험 개선**: 로그인하지 않은 상태에서 주문 시도 시 "주문은 로그인 후에 사용할 수 있습니다."라는 안내 메시지가 노출되도록 처리했습니다.

## 📸 테스트 결과
- [x] 여러 장바구니 항목 일괄 결제 성공 및 상태 변경 확인
- [x] 결제 완료 후 장바구니에서 해당 항목 자동 삭제 확인
- [x] 성공 페이지 새로고침 시 데이터 유지 확인
- [x] 미로그인 유저 주문 시도 시 적절한 에러 메시지 노출 확인
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 10 46 34 AM" src="https://github.com/user-attachments/assets/0e2dc35c-ec8c-471d-b894-26b53f9d946e" />
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 10 46 50 AM" src="https://github.com/user-attachments/assets/a04f7478-5da0-44c1-8eec-12ae056b1c99" />
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 10 47 10 AM" src="https://github.com/user-attachments/asse
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 10 42 20 AM" src="https://github.com/user-attachments/assets/d5ca14ab-ba8a-40ed-a6b8-2c09a8a1e97a" />
ts/8fe092b5-0e1d-4f23-b9b3-a7dec38f1f2f" />

## 🔗 관련 이슈
- 본 PR은 장바구니 기반 일괄 수강 신청 기능을 완성합니다.