### PR TITLE
feat: 호스트 대시보드 통계 연동 및 수강생 관리 페이지 추가

### DIFF
--- a/backend/src/main/java/com/venueon/host/application/port/in/GetHostRecentOrdersUseCase.java
+++ b/backend/src/main/java/com/venueon/host/application/port/in/GetHostRecentOrdersUseCase.java
@@ -1,6 +1,9 @@
 package com.venueon.host.application.port.in;
 
+import com.venueon.host.dto.HostAttendeeResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -12,4 +15,8 @@ public interface GetHostRecentOrdersUseCase {
     List<HostRecentOrderResponse> getRecentOrders(Long hostId, int size);
 
     int getCurrentMonthRevenue(Long hostId);
+
+    long getTotalAttendees(Long hostId);
+
+    Page<HostAttendeeResponse> getAttendees(Long hostId, Long eventId, String name, Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/host/application/service/HostOrderService.java
+++ b/backend/src/main/java/com/venueon/host/application/service/HostOrderService.java
@@ -2,12 +2,15 @@ package com.venueon.host.application.service;
 
 import com.venueon.common.annotation.UseCase;
 import com.venueon.host.application.port.in.GetHostRecentOrdersUseCase;
+import com.venueon.host.dto.HostAttendeeResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
 import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
 import com.venueon.order.domain.model.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,5 +47,16 @@ public class HostOrderService implements GetHostRecentOrdersUseCase {
                 startDateTime,
                 endDateTime
         );
+    }
+
+    @Override
+    public long getTotalAttendees(Long hostId) {
+        return orderJpaRepository.countTotalAttendeesByHostId(hostId);
+    }
+
+    @Override
+    public Page<HostAttendeeResponse> getAttendees(Long hostId, Long eventId, String name, Pageable pageable) {
+        log.debug("호스트 수강생 목록 조회: hostId={}, eventId={}, name={}, page={}, size={}", hostId, eventId, name, pageable.getPageNumber(), pageable.getPageSize());
+        return orderJpaRepository.findAttendeesByHostId(hostId, eventId, name, pageable);
     }
 }

--- a/backend/src/main/java/com/venueon/host/dto/HostAttendeeResponse.java
+++ b/backend/src/main/java/com/venueon/host/dto/HostAttendeeResponse.java
@@ -1,0 +1,19 @@
+package com.venueon.host.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 호스트 수강생 목록 — 응답 DTO
+ *
+ * JPQL의 new 생성자 표현식으로 직접 생성됩니다.
+ * OrderJpaEntity → UserJpaEntity, EventJpaEntity를 조인하여 필요한 필드만 추출합니다.
+ */
+public record HostAttendeeResponse(
+        Long orderId,           // 주문 ID (고유 식별)
+        String userName,        // 수강생 이름 (nickname)
+        String userEmail,       // 수강생 이메일
+        String eventTitle,      // 수강 강의명
+        int amount,             // 결제 금액
+        LocalDateTime orderedAt,// 신청일시
+        String status           // 주문 상태 (PAID, REGISTERED 등)
+) {}

--- a/backend/src/main/java/com/venueon/host/dto/HostOrderSummaryResponse.java
+++ b/backend/src/main/java/com/venueon/host/dto/HostOrderSummaryResponse.java
@@ -4,5 +4,6 @@ package com.venueon.host.dto;
  * 호스트 대시보드 — 주문 요약 응답 DTO
  */
 public record HostOrderSummaryResponse(
-        int currentMonthRevenue
+        int currentMonthRevenue,
+        long totalAttendees
 ) {}

--- a/backend/src/main/java/com/venueon/host/presentation/HostOrderController.java
+++ b/backend/src/main/java/com/venueon/host/presentation/HostOrderController.java
@@ -2,10 +2,14 @@ package com.venueon.host.presentation;
 
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.host.application.port.in.GetHostRecentOrdersUseCase;
+import com.venueon.host.dto.HostAttendeeResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
 import com.venueon.host.dto.HostOrderSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +41,28 @@ public class HostOrderController {
     public ResponseEntity<ApiResponse<HostOrderSummaryResponse>> getOrderSummary(Authentication authentication) {
         Long hostId = hostAuthSupport.extractUserId(authentication);
         int currentMonthRevenue = getHostRecentOrdersUseCase.getCurrentMonthRevenue(hostId);
+        long totalAttendees = getHostRecentOrdersUseCase.getTotalAttendees(hostId);
 
-        return ResponseEntity.ok(ApiResponse.success(new HostOrderSummaryResponse(currentMonthRevenue)));
+        return ResponseEntity.ok(ApiResponse.success(new HostOrderSummaryResponse(currentMonthRevenue, totalAttendees)));
+    }
+
+    @GetMapping("/attendees")
+    public ResponseEntity<ApiResponse<Page<HostAttendeeResponse>>> getAttendees(
+            Authentication authentication,
+            @RequestParam(required = false) Long eventId,
+            @RequestParam(required = false) String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Long hostId = hostAuthSupport.extractUserId(authentication);
+        log.debug("GET /host/orders/attendees — hostId={}, eventId={}, name={}, page={}, size={}", hostId, eventId, name, page, size);
+
+        Page<HostAttendeeResponse> result = getHostRecentOrdersUseCase.getAttendees(
+                hostId,
+                eventId,
+                name,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "orderedAt"))
+        );
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -1,5 +1,6 @@
 package com.venueon.order.adapter.out.persistence.repository;
 
+import com.venueon.host.dto.HostAttendeeResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
 import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
 import com.venueon.order.domain.model.OrderStatus;
@@ -81,4 +82,35 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
            "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
            "o.event.status = 'ENDED'")
     long countCompletedByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(o) FROM OrderJpaEntity o " +
+           "JOIN o.event e " +
+           "WHERE e.creator.id = :hostId " +
+           "AND (o.status = 'PAID' OR o.status = 'REGISTERED')")
+    long countTotalAttendeesByHostId(@Param("hostId") Long hostId);
+
+    @Query("""
+            select new com.venueon.host.dto.HostAttendeeResponse(
+                o.id,
+                u.nickname,
+                u.email,
+                e.title,
+                o.amount,
+                coalesce(o.displayOrderedAt, o.orderedAt),
+                cast(o.status as string)
+            )
+            from OrderJpaEntity o
+            join o.user u
+            join o.event e
+            where e.creator.id = :hostId
+              and (o.status = 'PAID' or o.status = 'REGISTERED')
+              and (:eventId is null or e.id = :eventId)
+              and (:name is null or u.nickname like %:name%)
+            """)
+    Page<HostAttendeeResponse> findAttendeesByHostId(
+            @Param("hostId") Long hostId,
+            @Param("eventId") Long eventId,
+            @Param("name") String name,
+            Pageable pageable
+    );
 }

--- a/frontend/src/app/host/attendees/page.tsx
+++ b/frontend/src/app/host/attendees/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Sidebar from '@/components/layout/Sidebar';
+import { api } from '@/lib/api';
+import styles from '../page.module.css';
+
+interface Attendee {
+  orderId: number;
+  userName: string;
+  userEmail: string;
+  eventTitle: string;
+  amount: number;
+  orderedAt: string;
+  status: string;
+}
+
+interface PageData {
+  content: Attendee[];
+  totalElements: number;
+}
+
+interface HostEvent {
+  id: number;
+  title: string;
+}
+
+export default function HostAttendeesPage() {
+  const [attendees, setAttendees] = useState<Attendee[]>([]);
+  const [events, setEvents] = useState<HostEvent[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 필터 상태
+  const [selectedEventId, setSelectedEventId] = useState<string>('');
+  const [searchName, setSearchName] = useState<string>('');
+
+  // 내 강의 목록 가져오기 (드롭다운 용)
+  useEffect(() => {
+    async function fetchHostEvents() {
+      try {
+        const response = await api.get<{ status: string; data: { content: HostEvent[] } }>('/host/events?size=100');
+        setEvents(response.data.content || []);
+      } catch (error) {
+        console.error('Failed to fetch host events:', error);
+      }
+    }
+    fetchHostEvents();
+  }, []);
+
+  // 수강생 목록 가져오기 (필터 포함)
+  useEffect(() => {
+    async function fetchAttendees() {
+      setIsLoading(true);
+      try {
+        let url = '/host/orders/attendees?size=50';
+        if (selectedEventId) url += `&eventId=${selectedEventId}`;
+        if (searchName) url += `&name=${encodeURIComponent(searchName)}`;
+
+        const response = await api.get<{ status: string; data: PageData }>(url);
+        setAttendees(response.data.content || []);
+        setTotalCount(response.data.totalElements || 0);
+      } catch (error) {
+        console.error('Failed to fetch attendees:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchAttendees();
+  }, [selectedEventId, searchName]);
+
+  return (
+    <div className="container-sidebar">
+      <div className={styles.sidebarWrapper}>
+         <Sidebar role="host" />
+      </div>
+      
+      <div className="sidebar">
+        <div className={styles.dashboardWrapper}>
+          
+          <header className={styles.header}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
+                <Link href="/host" style={{ textDecoration: 'none', color: '#64748b' }}>← 대시보드로 돌아가기</Link>
+            </div>
+            <h1 className={styles.pageTitle}>총 누적 수강생 관리</h1>
+            <p className={styles.pageSubtitle}>현재까지 내 강의를 신청한 모든 수강생 목록입니다. (총 {totalCount}명)</p>
+          </header>
+
+          <section className={styles.sectionBox}>
+            {/* 필터 바 추가 */}
+            <div className={styles.filterBar}>
+              <div className={styles.filterGroup}>
+                <label style={{ fontSize: '0.875rem', fontWeight: '600', color: '#475569' }}>강의별 필터</label>
+                <select 
+                  className={styles.selectBox}
+                  value={selectedEventId}
+                  onChange={(e) => setSelectedEventId(e.target.value)}
+                >
+                  <option value="">모든 강의 보기</option>
+                  {events.map(event => (
+                    <option key={event.id} value={event.id}>{event.title}</option>
+                  ))}
+                </select>
+              </div>
+              <div className={styles.filterGroup}>
+                <label style={{ fontSize: '0.875rem', fontWeight: '600', color: '#475569' }}>수강생 이름 검색</label>
+                <input 
+                  type="text" 
+                  className={styles.searchBox}
+                  placeholder="수강생 이름을 입력하세요..."
+                  value={searchName}
+                  onChange={(e) => setSearchName(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className={styles.tableContainer}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>이름</th>
+                    <th>이메일</th>
+                    <th>수강 강의</th>
+                    <th>결제 금액</th>
+                    <th>신청일</th>
+                    <th>상태</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {attendees.map((item) => (
+                    <tr key={item.orderId}>
+                      <td style={{ fontWeight: '600' }}>{item.userName}</td>
+                      <td style={{ color: '#64748b' }}>{item.userEmail}</td>
+                      <td>{item.eventTitle}</td>
+                      <td>{item.amount.toLocaleString()}원</td>
+                      <td>{item.orderedAt.slice(0, 10)}</td>
+                      <td>
+                        <span className={styles.orderStatus} style={{ 
+                            background: item.status === 'PAID' ? '#dcfce7' : '#f1f5f9',
+                            color: item.status === 'PAID' ? '#16a34a' : '#64748b'
+                        }}>
+                          {item.status === 'PAID' ? '결제완료' : '신청완료'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                  {!isLoading && attendees.length === 0 && (
+                    <tr>
+                      <td colSpan={6} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                        검색 조건에 맞는 수강생 내역이 없습니다.
+                      </td>
+                    </tr>
+                  )}
+                  {isLoading && (
+                    <tr>
+                      <td colSpan={6} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                        수강생 목록을 불러오는 중입니다...
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/host/page.module.css
+++ b/frontend/src/app/host/page.module.css
@@ -29,11 +29,15 @@
 
 .summaryCard {
   background: white;
-  border-radius: 16px;
+  border-radius: 20px;
   padding: 24px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
-  transition: transform 0.2s, box-shadow 0.2s;
+  border: 1px solid #f1f5f9;
+  box-shadow: 0 4px 20px -5px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.2s;
+  text-decoration: none; /* 링크 밑줄 제거 */
+  color: inherit;         /* 기본 텍스트 색상 유지 */
+  display: block;        /* 전체 영역 클릭 가능하도록 */
+  cursor: pointer;
 }
 
 .summaryCard:hover {
@@ -64,13 +68,13 @@
 }
 
 .userIcon {
-  background: #dcfce7;
-  color: #16a34a;
+  background: #e1fae9; /* 연한 민트/그린 배경 */
+  color: #7c3aed;      /* 보라색 아이콘 */
 }
 
 .refundIcon {
-  background: #fee2e2;
-  color: #dc2626;
+  background: #fff1f2;
+  color: #f43f5e;
 }
 
 .cardTitle {
@@ -81,9 +85,10 @@
 }
 
 .cardValue {
-  font-size: 1.875rem;
-  font-weight: 700;
-  color: #0f172a;
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #020617; /* 더 진한 색상 */
+  letter-spacing: -0.02em;
 }
 
 /* Detail Sections */
@@ -256,4 +261,35 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* Filter Bar Styles */
+.filterBar {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 200px;
+}
+
+.selectBox, .searchBox {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  background-color: white;
+  color: #1e293b;
+}
+
+.selectBox:focus, .searchBox:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
 }

--- a/frontend/src/app/host/page.tsx
+++ b/frontend/src/app/host/page.tsx
@@ -16,6 +16,7 @@ interface RecentOrder {
 
 interface HostOrderSummary {
   currentMonthRevenue: number;
+  totalAttendees: number;
 }
 
 function getOrderStatusLabel(status: string) {
@@ -62,7 +63,7 @@ export default function HostDashboardPage() {
   const [stats, setStats] = useState({
     publishedCount: 0,
     draftCount: 0,
-    totalAttendees: 0, 
+    totalAttendees: 0,
     totalRevenue: 0,
     pendingRefunds: 0
   });
@@ -75,12 +76,13 @@ export default function HostDashboardPage() {
         const draftRes = await api.get<{ status: string; data: { totalElements: number } }>('/host/events/drafts?size=1');
         const recentOrdersRes = await api.get<{ status: string; data: RecentOrder[] }>('/host/orders/recent?size=5');
         const orderSummaryRes = await api.get<{ status: string; data: HostOrderSummary }>('/host/orders/summary');
-        
+
         setStats(prev => ({
           ...prev,
           publishedCount: publishedRes.data?.totalElements || 0,
           draftCount: draftRes.data?.totalElements || 0,
           totalRevenue: orderSummaryRes.data?.currentMonthRevenue || 0,
+          totalAttendees: orderSummaryRes.data?.totalAttendees || 0,
         }));
         setRecentOrders(recentOrdersRes.data || []);
       } catch (error) {
@@ -93,21 +95,21 @@ export default function HostDashboardPage() {
   return (
     <div className="container-sidebar">
       <div className={styles.sidebarWrapper}>
-        <button 
-          className={styles.mobileMenuButton} 
+        <button
+          className={styles.mobileMenuButton}
           onClick={() => setIsSidebarOpen(!isSidebarOpen)}
         >
           {isSidebarOpen ? '닫기 ✕' : '메뉴 열기 ☰'}
         </button>
-        
+
         <div className={`${styles.sidebarInner} ${isSidebarOpen ? styles.mobileOpen : styles.mobileClosed}`}>
           <Sidebar role="host" className={styles.responsiveHostSidebar} />
         </div>
       </div>
-      
+
       <div className="sidebar">
         <div className={styles.dashboardWrapper}>
-          
+
           <header className={styles.header}>
             <h1 className={styles.pageTitle}>호스트 대시보드</h1>
             <p className={styles.pageSubtitle}>환영합니다! 현재 개설하신 강의들의 현황을 한눈에 확인하세요.</p>
@@ -119,18 +121,18 @@ export default function HostDashboardPage() {
               <p className={styles.cardTitle}>이번 달 누적 매출</p>
               <h2 className={styles.cardValue}>{stats.totalRevenue.toLocaleString()}원</h2>
             </div>
-            
-            <div className={styles.summaryCard}>
+
+            <Link href="/host/events" className={styles.summaryCard}>
               <div className={`${styles.cardIcon} ${styles.eventIcon}`}>📊</div>
               <p className={styles.cardTitle}>진행/게시 중인 이벤트</p>
               <h2 className={styles.cardValue}>{stats.publishedCount}개</h2>
-            </div>
+            </Link>
 
-            <div className={styles.summaryCard}>
+            <Link href="/host/attendees" className={styles.summaryCard}>
               <div className={`${styles.cardIcon} ${styles.userIcon}`}>👥</div>
               <p className={styles.cardTitle}>총 누적 수강생</p>
               <h2 className={styles.cardValue}>{stats.totalAttendees}명</h2>
-            </div>
+            </Link>
 
             <div className={styles.summaryCard}>
               <div className={`${styles.cardIcon} ${styles.refundIcon}`}>⚠️</div>
@@ -145,7 +147,7 @@ export default function HostDashboardPage() {
                 <h3 className={styles.sectionTitle}>최근 주문 내역</h3>
                 <Link href="/host/payments" className={styles.viewAllBtn}>전체 보기 &gt;</Link>
               </div>
-              
+
               <div className={styles.tableContainer}>
                 <table className={styles.table}>
                   <thead>
@@ -188,21 +190,21 @@ export default function HostDashboardPage() {
                 <h3 className={styles.sectionTitle}>빠른 작업</h3>
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-                <Link href="/host/events/new" className="button" style={{ 
-                  background: '#1e293b', color: 'white', padding: '16px', borderRadius: '8px', 
-                  textAlign: 'center', textDecoration: 'none', fontWeight: '600' 
+                <Link href="/host/events/new" className="button" style={{
+                  background: '#1e293b', color: 'white', padding: '16px', borderRadius: '8px',
+                  textAlign: 'center', textDecoration: 'none', fontWeight: '600'
                 }}>
                   + 새로운 강의 개설하기
                 </Link>
-                <Link href="/host/events" className="button" style={{ 
-                  background: '#f1f5f9', color: '#1e293b', padding: '16px', borderRadius: '8px', 
-                  textAlign: 'center', textDecoration: 'none', fontWeight: '600' 
+                <Link href="/host/events" className="button" style={{
+                  background: '#f1f5f9', color: '#1e293b', padding: '16px', borderRadius: '8px',
+                  textAlign: 'center', textDecoration: 'none', fontWeight: '600'
                 }}>
                   내 강의 목록 관리
                 </Link>
-                <Link href="/host/requests" className="button" style={{ 
-                  background: '#f1f5f9', color: '#1e293b', padding: '16px', borderRadius: '8px', 
-                  textAlign: 'center', textDecoration: 'none', fontWeight: '600' 
+                <Link href="/host/requests" className="button" style={{
+                  background: '#f1f5f9', color: '#1e293b', padding: '16px', borderRadius: '8px',
+                  textAlign: 'center', textDecoration: 'none', fontWeight: '600'
                 }}>
                   운영팀에 요청하기
                 </Link>


### PR DESCRIPTION
VO-726

📖 개요
호스트 사용자가 자신의 강의 현황을 보다 직관적으로 파악하고, 수강생 명단을 효율적으로 관리할 수 있도록 대시보드 통계 기능을 고도화하고 전용 수강생 관리 페이지를 추가했습니다.

🛠️ 주요 변경 사항
1. 백엔드 (API 구현)

- 수강생 조회 API: 호스트가 개설한 강의의 수강생 목록을 조회하는 API를 추가했습니다.
> - 강의별 필터링, 수강생 이름 검색, 페이지네이션 기능을 지원합니다.
> - OrderJpaRepository에 JPQL을 활용한 복합 쿼리를 구현했습니다.
- 통계 데이터 확충: 대시보드용 요약 데이터에 '총 누적 수강생 수' 집계 로직을 추가했습니다.
- DTO 설계: 수강생 정보를 담는 HostAttendeeResponse 레코드를 신규 생성하고, 기존 통계용 DTO를 업데이트했습니다.

2. 프런트엔드 (UI/UX 개선)

- 수강생 관리 페이지 신규 구축 (/host/attendees):

> - 수강생 목록 테이블 UI를 구현했습니다.
> - 상단 필터(강의 선택, 이름 검색)를 통해 실시간 데이터 조회가 가능합니다.

- 호스트 대시보드 업데이트:

> - '총 누적 수강생' 지표에 실제 백엔드 데이터를 바인딩했습니다.
> - '진행 중인 이벤트'와 '총 수강생' 카드를 클릭 시 각각의 관리 페이지로 이동하도록 UX를 개선했습니다.

🧪 테스트 결과 (선택 사항)
 호스트 대시보드 통계 데이터 정상 출력 확인
 수강생 목록 필터링 및 검색 기능 동작 확인
 대시보드 카드 클릭 시 페이지 이동 정상 동작 확인