### PR TITLE
refactor: 이벤트/홈뷰 리스트 렌더링 최적화 및 빌드 에러 수정 (#825)

### DIFF
--- a/backend/src/main/java/com/venueon/common/adapter/in/web/FileUploadController.java
+++ b/backend/src/main/java/com/venueon/common/adapter/in/web/FileUploadController.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  * → /upload/event-thumbnail/{yyyy}/{MM}/{uuid}.{ext} 로 저장
  *
  * 폴더 구조: 카테고리 1차 분류 + 연/월 2차 분류 + UUID 파일명
- * @see docs/이미지_업로드_관리_전략.md §2
+ * @see "docs/이미지_업로드_관리_전략.md §2"
  */
 @RestController
 @RequestMapping("/files")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -164,7 +164,7 @@ export default function Home() {
                       title={event.title}
                       eventId={event.id}
                       isWishlistedProp={wishlistSet.has(event.id)}
-                      imageUrl={event.thumbnailUrl ? `${BACKEND_URL}/upload/${event.thumbnailUrl}` : ''}
+                      imageUrl={event.thumbnailUrl ? `/upload/${event.thumbnailUrl}` : ''}
                       organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 실제 이름으로 변경
                       dateTime={format(new Date(event.startDate), 'yyyy년 M월 d일 a h시')}
                       location={event.isOnline ? '온라인' : event.location}


### PR DESCRIPTION
## 📌 관련 이슈
* close #825

## ✨ 작업 내용
* **렌더링 성능 최적화 (성능 개선)**
  * `frontend/src/app/page.tsx` 및 `frontend/src/app/events/page.tsx`
  * 이벤트 카드 리스트(.map)를 렌더링할 때 내부에서 `new Date().getTime()`이 반복적으로 실행되는 비효율적인 구조를 개선했습니다.
  * 계산 로직을 반복문 외부로 분리(선언)하여 1회만 계산하도록 불필요한 연산을 최적화했습니다.

* **이미지 경로 표기 오류 수정**
  * `app/page.tsx` 내부에서 삭제된 변수인 `BACKEND_URL`을 여전히 참조하고 있어 빌드 에러가 나던 이슈를 해결했습니다.
  * 프록시에서 처리될 수 있도록 문자열에서 해당 변수 부분을 제거하고 `/upload/...` 상대 경로로 올바르게 참조하도록 수정했습니다.

* **백엔드 Javadoc 주석 문법 수정**
  * `FileUploadController.java`의 `@see` Javadoc 태그 문법에 쌍따옴표가 누락 되어있던 IDE 경고(Syntax Error)를 수정했습니다.

## 📸 스크린샷 (선택)
- 기능상 변경이 없으므로 생략합니다.

## 💬 리뷰 요구사항 (선택)
- 메인 홈페이지(`app/page.tsx`)와 이벤트 리스트 페이지(`app/events/page.tsx`) 모두 컴포넌트 렌더링 성능 최적화를 적용했으니 참고해 주세요!
- 백엔드 Javadoc 수정은 매우 간단한 문법 교체입니다.
