### PR TITLE
feat: 호스트 주문 관리 기능 강화 및 상세 페이지 구현

### DIFF
--- a/backend/src/main/java/com/venueon/host/application/port/in/GetHostRecentOrdersUseCase.java
+++ b/backend/src/main/java/com/venueon/host/application/port/in/GetHostRecentOrdersUseCase.java
@@ -1,6 +1,7 @@
 package com.venueon.host.application.port.in;
 
 import com.venueon.host.dto.HostAttendeeResponse;
+import com.venueon.host.dto.HostOrderDetailResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,4 +20,9 @@ public interface GetHostRecentOrdersUseCase {
     long getTotalAttendees(Long hostId);
 
     Page<HostAttendeeResponse> getAttendees(Long hostId, Long eventId, String name, Pageable pageable);
+
+    Page<HostRecentOrderResponse> getAllOrders(Long hostId, String status, Long eventId, Pageable pageable);
+
+    HostOrderDetailResponse getOrderDetail(Long hostId, Long orderId);
 }
+

--- a/backend/src/main/java/com/venueon/host/application/service/HostOrderService.java
+++ b/backend/src/main/java/com/venueon/host/application/service/HostOrderService.java
@@ -3,14 +3,18 @@ package com.venueon.host.application.service;
 import com.venueon.common.annotation.UseCase;
 import com.venueon.host.application.port.in.GetHostRecentOrdersUseCase;
 import com.venueon.host.dto.HostAttendeeResponse;
+import com.venueon.host.dto.HostOrderDetailResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
+import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
 import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
 import com.venueon.order.domain.model.OrderStatus;
+import com.venueon.event.adapter.out.persistence.entity.EventSessionJpaEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -59,4 +63,55 @@ public class HostOrderService implements GetHostRecentOrdersUseCase {
         log.debug("호스트 수강생 목록 조회: hostId={}, eventId={}, name={}, page={}, size={}", hostId, eventId, name, pageable.getPageNumber(), pageable.getPageSize());
         return orderJpaRepository.findAttendeesByHostId(hostId, eventId, name, pageable);
     }
+
+    @Override
+    public Page<HostRecentOrderResponse> getAllOrders(Long hostId, String status, Long eventId, Pageable pageable) {
+        log.debug("호스트 전체 주문 조회: hostId={}, status={}, eventId={}, page={}, size={}", hostId, status, eventId, pageable.getPageNumber(), pageable.getPageSize());
+
+        OrderStatus orderStatus = null;
+        if (status != null && !status.isBlank()) {
+            try {
+                orderStatus = OrderStatus.valueOf(status);
+            } catch (IllegalArgumentException e) {
+                log.warn("유효하지 않은 주문 상태: {}", status);
+            }
+        }
+        return orderJpaRepository.findAllOrdersByHostId(hostId, orderStatus, eventId, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public HostOrderDetailResponse getOrderDetail(Long hostId, Long orderId) {
+        log.debug("호스트 주문 상세 조회: hostId={}, orderId={}", hostId, orderId);
+
+        OrderJpaEntity order = orderJpaRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + orderId));
+
+        // 해당 호스트의 주문인지 검증
+        if (!order.getEvent().getCreator().getId().equals(hostId)) {
+            throw new SecurityException("해당 주문에 대한 접근 권한이 없습니다.");
+        }
+
+        EventSessionJpaEntity session = order.getSession();
+
+        return new HostOrderDetailResponse(
+                order.getId(),
+                order.getStatus().name(),
+                order.getQuantity(),
+                order.getAmount(),
+                order.getPaymentMethod(),
+                order.getDisplayOrderedAt() != null ? order.getDisplayOrderedAt() : order.getOrderedAt(),
+                order.getPaidAt(),
+                order.getUser().getNickname(),
+                order.getUser().getEmail(),
+                order.getUser().getPhone(),
+                order.getEvent().getId(),
+                order.getEvent().getTitle(),
+                order.getEvent().getThumbnailUrl(),
+                session != null ? session.getTitle() : null,
+                session != null ? session.getStartTime() : null,
+                session != null ? session.getEndTime() : null
+        );
+    }
 }
+

--- a/backend/src/main/java/com/venueon/host/dto/HostOrderDetailResponse.java
+++ b/backend/src/main/java/com/venueon/host/dto/HostOrderDetailResponse.java
@@ -1,0 +1,36 @@
+package com.venueon.host.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 호스트 주문 상세 조회 — 응답 DTO
+ *
+ * 주문 목록에서 특정 주문을 클릭했을 때 보여주는 상세 정보입니다.
+ * OrderJpaEntity + UserJpaEntity + EventJpaEntity + EventSessionJpaEntity를
+ * 조인하여 필요한 필드만 추출합니다.
+ */
+public record HostOrderDetailResponse(
+        // 주문 정보
+        Long orderId,
+        String status,
+        int quantity,
+        int amount,
+        String paymentMethod,
+        LocalDateTime orderedAt,
+        LocalDateTime paidAt,
+
+        // 주문자 정보
+        String userName,
+        String userEmail,
+        String userPhone,
+
+        // 강의 정보
+        Long eventId,
+        String eventTitle,
+        String eventThumbnailUrl,
+
+        // 세션 정보 (선택된 회차)
+        String sessionTitle,
+        LocalDateTime sessionStartTime,
+        LocalDateTime sessionEndTime
+) {}

--- a/backend/src/main/java/com/venueon/host/dto/HostRecentOrderResponse.java
+++ b/backend/src/main/java/com/venueon/host/dto/HostRecentOrderResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
  */
 public record HostRecentOrderResponse(
         Long orderId,
+        String userName,
         String eventTitle,
         int amount,
         LocalDateTime orderedAt,

--- a/backend/src/main/java/com/venueon/host/presentation/HostOrderController.java
+++ b/backend/src/main/java/com/venueon/host/presentation/HostOrderController.java
@@ -3,6 +3,7 @@ package com.venueon.host.presentation;
 import com.venueon.common.dto.ApiResponse;
 import com.venueon.host.application.port.in.GetHostRecentOrdersUseCase;
 import com.venueon.host.dto.HostAttendeeResponse;
+import com.venueon.host.dto.HostOrderDetailResponse;
 import com.venueon.host.dto.HostRecentOrderResponse;
 import com.venueon.host.dto.HostOrderSummaryResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,38 @@ public class HostOrderController {
         log.debug("GET /host/orders/recent — hostId={}, size={}", hostId, size);
 
         List<HostRecentOrderResponse> result = getHostRecentOrdersUseCase.getRecentOrders(hostId, size);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<HostRecentOrderResponse>>> getAllOrders(
+            Authentication authentication,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Long eventId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Long hostId = hostAuthSupport.extractUserId(authentication);
+        log.debug("GET /host/orders — hostId={}, status={}, eventId={}, page={}, size={}", hostId, status, eventId, page, size);
+
+        Page<HostRecentOrderResponse> result = getHostRecentOrdersUseCase.getAllOrders(
+                hostId,
+                status,
+                eventId,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "orderedAt"))
+        );
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<HostOrderDetailResponse>> getOrderDetail(
+            Authentication authentication,
+            @PathVariable Long orderId
+    ) {
+        Long hostId = hostAuthSupport.extractUserId(authentication);
+        log.debug("GET /host/orders/{} — hostId={}", orderId, hostId);
+
+        HostOrderDetailResponse result = getHostRecentOrdersUseCase.getOrderDetail(hostId, orderId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -37,17 +37,43 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     @Query("""
             select new com.venueon.host.dto.HostRecentOrderResponse(
                 o.id,
+                u.nickname,
                 e.title,
                 o.amount,
                 coalesce(o.displayOrderedAt, o.orderedAt),
                 cast(o.status as string)
             )
             from OrderJpaEntity o
+            join o.user u
             join o.event e
             where e.creator.id = :creatorId
             order by coalesce(o.displayOrderedAt, o.orderedAt) desc
             """)
     Page<HostRecentOrderResponse> findRecentOrdersByHostId(Long creatorId, Pageable pageable);
+
+    @Query("""
+            select new com.venueon.host.dto.HostRecentOrderResponse(
+                o.id,
+                u.nickname,
+                e.title,
+                o.amount,
+                coalesce(o.displayOrderedAt, o.orderedAt),
+                cast(o.status as string)
+            )
+            from OrderJpaEntity o
+            join o.user u
+            join o.event e
+            where e.creator.id = :creatorId
+              and (:status is null or o.status = :status)
+              and (:eventId is null or e.id = :eventId)
+            order by coalesce(o.displayOrderedAt, o.orderedAt) desc
+            """)
+    Page<HostRecentOrderResponse> findAllOrdersByHostId(
+            @Param("creatorId") Long creatorId,
+            @Param("status") OrderStatus status,
+            @Param("eventId") Long eventId,
+            Pageable pageable
+    );
 
     @Query("""
             select coalesce(sum(o.amount), 0)

--- a/frontend/src/app/host/payments/[id]/page.module.css
+++ b/frontend/src/app/host/payments/[id]/page.module.css
@@ -1,0 +1,237 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+.header {
+  margin-bottom: 32px;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.875rem;
+  color: #64748b;
+  text-decoration: none;
+  margin-bottom: 16px;
+  transition: color 0.15s;
+}
+
+.backLink:hover {
+  color: #4f46e5;
+}
+
+.pageTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.orderIdBadge {
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-top: 4px;
+}
+
+/* Status Badge */
+.statusBadge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.statusPaid { background: #dcfce7; color: #16a34a; }
+.statusRegistered { background: #dbeafe; color: #2563eb; }
+.statusCancelled { background: #fee2e2; color: #dc2626; }
+.statusRefunded { background: #ede9fe; color: #7c3aed; }
+.statusPending { background: #fef3c7; color: #d97706; }
+.statusDefault { background: #e2e8f0; color: #334155; }
+
+/* Detail Cards */
+.detailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.detailCard {
+  background: white;
+  border-radius: 16px;
+  padding: 28px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.detailCardFull {
+  grid-column: 1 / -1;
+}
+
+.cardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid #f1f5f9;
+}
+
+.cardIcon {
+  font-size: 1.25rem;
+}
+
+/* Info Row */
+.infoRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid #f8fafc;
+}
+
+.infoRow:last-child {
+  border-bottom: none;
+}
+
+.infoLabel {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.infoValue {
+  font-size: 0.875rem;
+  color: #1e293b;
+  font-weight: 500;
+  text-align: right;
+}
+
+.amountHighlight {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #4f46e5;
+}
+
+/* Event Link */
+.eventLink {
+  color: #4f46e5;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.15s;
+}
+
+.eventLink:hover {
+  color: #3730a3;
+  text-decoration: underline;
+}
+
+/* Loading */
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  color: #64748b;
+  font-size: 1rem;
+}
+
+.errorWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  color: #dc2626;
+  gap: 16px;
+}
+
+.errorWrapper a {
+  color: #4f46e5;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+/* Action Buttons */
+.actionSection {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 2px solid #f1f5f9;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.actionBtn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+}
+
+.primaryBtn {
+  background: #4f46e5;
+  color: white;
+}
+
+.primaryBtn:hover {
+  background: #4338ca;
+}
+
+.secondaryBtn {
+  background: white;
+  border-color: #e2e8f0;
+  color: #64748b;
+}
+
+.secondaryBtn:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.dangerBtn {
+  background: white;
+  border-color: #fee2e2;
+  color: #dc2626;
+}
+
+.dangerBtn:hover {
+  background: #fef2f2;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .detailGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .infoRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .infoValue {
+    text-align: left;
+  }
+  
+  .actionSection {
+    flex-direction: column;
+  }
+  
+  .actionBtn {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/host/payments/[id]/page.tsx
+++ b/frontend/src/app/host/payments/[id]/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+import Sidebar from '@/components/layout/Sidebar';
+import styles from './page.module.css';
+
+interface OrderDetail {
+  orderId: number;
+  status: string;
+  quantity: number;
+  amount: number;
+  paymentMethod: string | null;
+  orderedAt: string;
+  paidAt: string | null;
+  userName: string;
+  userEmail: string;
+  userPhone: string | null;
+  eventId: number;
+  eventTitle: string;
+  eventThumbnailUrl: string | null;
+  sessionTitle: string | null;
+  sessionStartTime: string | null;
+  sessionEndTime: string | null;
+}
+
+function getStatusLabel(status: string) {
+  switch (status) {
+    case 'PAID': return '결제완료';
+    case 'REGISTERED': return '신청완료';
+    case 'CANCELLED': return '주문취소';
+    case 'REFUNDED': return '환불완료';
+    case 'PENDING': return '결제대기';
+    default: return status;
+  }
+}
+
+function getStatusClass(status: string) {
+  switch (status) {
+    case 'PAID': return styles.statusPaid;
+    case 'REGISTERED': return styles.statusRegistered;
+    case 'CANCELLED': return styles.statusCancelled;
+    case 'REFUNDED': return styles.statusRefunded;
+    case 'PENDING': return styles.statusPending;
+    default: return styles.statusDefault;
+  }
+}
+
+function getPaymentMethodLabel(method: string | null) {
+  if (!method) return '-';
+  switch (method) {
+    case 'CARD': return '카드 결제';
+    case 'VIRTUAL_ACCOUNT': return '가상계좌(무통장입금)';
+    case 'TRANSFER': return '계좌이체';
+    case 'PHONE': return '휴대폰 결제';
+    case 'FREE': return '무료';
+    default: return method;
+  }
+}
+
+function formatDateTime(iso: string | null) {
+  if (!iso) return '-';
+  return iso.replace('T', ' ').slice(0, 16);
+}
+
+export default function HostOrderDetailPage() {
+  const params = useParams();
+  const orderId = params.id as string;
+
+  const [order, setOrder] = useState<OrderDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchOrderDetail() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get<{ status: string; data: OrderDetail }>(`/host/orders/${orderId}`);
+        if (response.data) {
+          setOrder(response.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch order detail:', err);
+        setError('주문 정보를 불러올 수 없습니다.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (orderId) {
+      fetchOrderDetail();
+    }
+  }, [orderId]);
+
+  if (loading) {
+    return (
+      <div className="container-sidebar">
+        <div className="sidebar"><Sidebar role="host" /></div>
+        <div className="main-content">
+          <div className={styles.loadingWrapper}>로딩 중...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !order) {
+    return (
+      <div className="container-sidebar">
+        <div className="sidebar"><Sidebar role="host" /></div>
+        <div className="main-content">
+          <div className={styles.errorWrapper}>
+            <p>{error || '주문을 찾을 수 없습니다.'}</p>
+            <Link href="/host/payments">← 목록으로 돌아가기</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container-sidebar">
+      <div className="sidebar">
+        <Sidebar role="host" />
+      </div>
+
+      <div className="main-content">
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <Link href="/host/payments" className={styles.backLink}>
+              ← 전체 주문 내역으로 돌아가기
+            </Link>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <h1 className={styles.pageTitle}>주문 상세</h1>
+                <span className={styles.orderIdBadge}>주문번호 #{order.orderId}</span>
+              </div>
+              <span className={`${styles.statusBadge} ${getStatusClass(order.status)}`}>
+                {getStatusLabel(order.status)}
+              </span>
+            </div>
+          </header>
+
+          <div className={styles.detailGrid}>
+            {/* 주문자 정보 */}
+            <div className={styles.detailCard}>
+              <h3 className={styles.cardTitle}>
+                <span className={styles.cardIcon}>👤</span>
+                주문자 정보
+              </h3>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>이름</span>
+                <span className={styles.infoValue}>{order.userName}</span>
+              </div>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>이메일</span>
+                <span className={styles.infoValue}>{order.userEmail}</span>
+              </div>
+              {order.userPhone && (
+                <div className={styles.infoRow}>
+                  <span className={styles.infoLabel}>연락처</span>
+                  <span className={styles.infoValue}>{order.userPhone}</span>
+                </div>
+              )}
+            </div>
+
+            {/* 결제 정보 */}
+            <div className={styles.detailCard}>
+              <h3 className={styles.cardTitle}>
+                <span className={styles.cardIcon}>💳</span>
+                결제 정보
+              </h3>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>결제 금액</span>
+                <span className={`${styles.infoValue} ${styles.amountHighlight}`}>
+                  {order.amount.toLocaleString()}원
+                </span>
+              </div>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>수량</span>
+                <span className={styles.infoValue}>{order.quantity}매</span>
+              </div>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>결제 수단</span>
+                <span className={styles.infoValue}>{getPaymentMethodLabel(order.paymentMethod)}</span>
+              </div>
+              {order.paidAt && (
+                <div className={styles.infoRow}>
+                  <span className={styles.infoLabel}>결제 일시</span>
+                  <span className={styles.infoValue}>{formatDateTime(order.paidAt)}</span>
+                </div>
+              )}
+            </div>
+
+            {/* 강의 정보 */}
+            <div className={`${styles.detailCard} ${styles.detailCardFull}`}>
+              <h3 className={styles.cardTitle}>
+                <span className={styles.cardIcon}>📚</span>
+                강의 정보
+              </h3>
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>강의명</span>
+                <span className={styles.infoValue}>
+                  <Link href={`/host/events/${order.eventId}`} className={styles.eventLink}>
+                    {order.eventTitle}
+                  </Link>
+                </span>
+              </div>
+              {order.sessionTitle && (
+                <div className={styles.infoRow}>
+                  <span className={styles.infoLabel}>선택 세션</span>
+                  <span className={styles.infoValue}>{order.sessionTitle}</span>
+                </div>
+              )}
+              {order.sessionStartTime && (
+                <div className={styles.infoRow}>
+                  <span className={styles.infoLabel}>세션 일정</span>
+                  <span className={styles.infoValue}>
+                    {formatDateTime(order.sessionStartTime)} ~ {formatDateTime(order.sessionEndTime)}
+                  </span>
+                </div>
+              )}
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>주문 일시</span>
+                <span className={styles.infoValue}>{formatDateTime(order.orderedAt)}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* 상태 관리 버튼 섹션 */}
+          <div className={styles.actionSection}>
+            {order.status === 'PENDING' && (
+              <button className={`${styles.actionBtn} ${styles.primaryBtn}`}>
+                입금 확인 완료
+              </button>
+            )}
+            {['PAID', 'REGISTERED', 'PENDING'].includes(order.status) && (
+              <button className={`${styles.actionBtn} ${styles.dangerBtn}`}>
+                주문 취소하기
+              </button>
+            )}
+            {order.status === 'PAID' && (
+              <button className={`${styles.actionBtn} ${styles.secondaryBtn}`}>
+                환불 승인
+              </button>
+            )}
+            <button className={`${styles.actionBtn} ${styles.secondaryBtn}`}>
+              메모 남기기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/host/payments/page.module.css
+++ b/frontend/src/app/host/payments/page.module.css
@@ -1,0 +1,179 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+.header {
+  margin-bottom: 32px;
+}
+
+.pageTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 8px;
+}
+
+.pageSubtitle {
+  color: #64748b;
+  font-size: 1rem;
+}
+
+.contentBox {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.filterBar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 24px;
+}
+
+.selectBox {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  background-color: white;
+  color: #1e293b;
+  min-width: 150px;
+}
+
+.selectBox:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
+}
+
+.tableContainer {
+  overflow-x: auto;
+  margin-bottom: 32px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  border-bottom: 2px solid #f1f5f9;
+}
+
+.table td {
+  padding: 16px;
+  font-size: 0.875rem;
+  color: #334155;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.orderStatus {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.orderStatusPaid {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.orderStatusRegistered {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.orderStatusCancelled {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.orderStatusRefunded {
+  background: #ede9fe;
+  color: #7c3aed;
+}
+
+.orderStatusPending {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.orderStatusDefault {
+  background: #e2e8f0;
+  color: #334155;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.pageBtn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: white;
+  color: #475569;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.pageBtn:hover:not(:disabled) {
+  border-color: #4f46e5;
+  color: #4f46e5;
+}
+
+.pageBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.activePage {
+  background: #4f46e5;
+  color: white;
+  border-color: #4f46e5;
+}
+
+.pageInfo {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin: 0 16px;
+}
+
+/* Interactive Table Row */
+.tableRow {
+  transition: background-color 0.15s;
+  cursor: pointer;
+}
+
+.tableRow:hover {
+  background-color: #f8fafc;
+}
+
+.orderLink {
+  color: #4f46e5;
+  font-weight: 700;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.orderLink:hover {
+  color: #3730a3;
+  text-decoration: underline;
+}

--- a/frontend/src/app/host/payments/page.tsx
+++ b/frontend/src/app/host/payments/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { api } from '@/lib/api';
+import Sidebar from '@/components/layout/Sidebar';
+import styles from './page.module.css';
+
+interface Order {
+  orderId: number;
+  userName: string; // 추가: 주문자 이름
+  eventTitle: string;
+  amount: number;
+  orderedAt: string;
+  status: string;
+}
+
+interface HostEvent {
+  id: number;
+  title: string;
+}
+
+interface PageData {
+  content: Order[];
+  totalPages: number;
+  totalElements: number;
+  number: number;
+  size: number;
+}
+
+function getOrderStatusLabel(status: string) {
+  switch (status) {
+    case 'PAID':
+      return '결제완료';
+    case 'REGISTERED':
+      return '신청완료';
+    case 'CANCELLED':
+      return '주문취소';
+    case 'REFUNDED':
+      return '환불완료';
+    case 'PENDING':
+      return '결제대기';
+    default:
+      return status;
+  }
+}
+
+function getOrderStatusClass(status: string) {
+  switch (status) {
+    case 'PAID':
+      return styles.orderStatusPaid;
+    case 'REGISTERED':
+      return styles.orderStatusRegistered;
+    case 'CANCELLED':
+      return styles.orderStatusCancelled;
+    case 'REFUNDED':
+      return styles.orderStatusRefunded;
+    case 'PENDING':
+      return styles.orderStatusPending;
+    default:
+      return styles.orderStatusDefault;
+  }
+}
+
+function formatOrderDate(isoDateTime: string) {
+  if (!isoDateTime) return '-';
+  return isoDateTime.replace('T', ' ').slice(0, 16);
+}
+
+export default function HostPaymentsPage() {
+  const router = useRouter();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [events, setEvents] = useState<HostEvent[]>([]); // 추가: 강의 목록
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [eventFilter, setEventFilter] = useState(''); // 추가: 강의 필터
+
+  const handleRowClick = (orderId: number) => {
+    router.push(`/host/payments/${orderId}`);
+  };
+
+  // 강의 목록 조회
+  useEffect(() => {
+    async function fetchEvents() {
+      try {
+        const response = await api.get<{ status: string; data: { content: HostEvent[] } }>('/host/events?size=100');
+        if (response.data && response.data.content) {
+          setEvents(response.data.content);
+        }
+      } catch (error) {
+        console.error('Failed to fetch events:', error);
+      }
+    }
+    fetchEvents();
+  }, []);
+
+  useEffect(() => {
+    async function fetchOrders() {
+      setLoading(true);
+      try {
+        const url = `/host/orders?page=${page}&size=10${statusFilter ? `&status=${statusFilter}` : ''}${eventFilter ? `&eventId=${eventFilter}` : ''}`;
+        const response = await api.get<{ status: string; data: PageData }>(url);
+        
+        if (response.data) {
+          setOrders(response.data.content);
+          setTotalPages(response.data.totalPages);
+        }
+      } catch (error) {
+        console.error('Failed to fetch orders:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchOrders();
+  }, [page, statusFilter, eventFilter]);
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStatusFilter(e.target.value);
+    setPage(0);
+  };
+
+  const handleEventChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setEventFilter(e.target.value);
+    setPage(0);
+  };
+
+  return (
+    <div className="container-sidebar">
+      <div className="sidebar">
+        <Sidebar role="host" />
+      </div>
+
+      <div className="main-content">
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <h1 className={styles.pageTitle}>전체 주문 내역</h1>
+            <p className={styles.pageSubtitle}>모든 강의의 결제 및 신청 현황을 관리할 수 있습니다.</p>
+          </header>
+
+          <div className={styles.contentBox}>
+            <div className={styles.filterBar}>
+              <select 
+                className={styles.selectBox} 
+                value={eventFilter} 
+                onChange={handleEventChange}
+                style={{ marginRight: '12px' }}
+              >
+                <option value="">모든 강의</option>
+                {events.map(event => (
+                  <option key={event.id} value={event.id}>{event.title}</option>
+                ))}
+              </select>
+              <select 
+                className={styles.selectBox} 
+                value={statusFilter} 
+                onChange={handleStatusChange}
+              >
+                <option value="">전체 상태</option>
+                <option value="PAID">결제완료</option>
+                <option value="REGISTERED">신청완료</option>
+                <option value="CANCELLED">주문취소</option>
+                <option value="REFUNDED">환불완료</option>
+                <option value="PENDING">결제대기</option>
+              </select>
+            </div>
+
+            <div className={styles.tableContainer}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>주문번호</th>
+                    <th>주문자</th>
+                    <th>강의명</th>
+                    <th>주문금액</th>
+                    <th>주문일시</th>
+                    <th>상태</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <td colSpan={6} style={{ textAlign: 'center', padding: '40px' }}>로딩 중...</td>
+                    </tr>
+                  ) : orders.length > 0 ? (
+                    orders.map(order => (
+                      <tr 
+                        key={order.orderId} 
+                        className={styles.tableRow}
+                        onClick={() => handleRowClick(order.orderId)}
+                      >
+                        <td>
+                          <span className={styles.orderLink}>
+                            #{order.orderId}
+                          </span>
+                        </td>
+                        <td style={{ fontWeight: '600' }}>{order.userName}</td>
+                        <td>{order.eventTitle}</td>
+                        <td>{order.amount.toLocaleString()}원</td>
+                        <td>{formatOrderDate(order.orderedAt)}</td>
+                        <td>
+                          <span className={`${styles.orderStatus} ${getOrderStatusClass(order.status)}`}>
+                            {getOrderStatusLabel(order.status)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={6} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                        주문 내역이 없습니다.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {!loading && totalPages > 0 && (
+              <div className={styles.pagination}>
+                <button 
+                  className={styles.pageBtn} 
+                  disabled={page === 0}
+                  onClick={() => setPage(page - 1)}
+                >
+                  이전
+                </button>
+                
+                <span className={styles.pageInfo}>
+                  {page + 1} / {totalPages} 페이지
+                </span>
+
+                <button 
+                  className={styles.pageBtn} 
+                  disabled={page === totalPages - 1}
+                  onClick={() => setPage(page + 1)}
+                >
+                  다음
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
VO-727
🚀 주요 변경 사항
호스트가 자신의 강의에 대한 주문 내역을 효율적으로 관리할 수 있도록 기존 대시보드를 확장하고, 상세 정보 확인 및 관리가 가능한 기능을 구현했습니다.

1. 주문 내역 필터링 및 정보 강화 (Backend/Frontend)

- 강의별 필터링: 호스트가 개설한 강의 목록을 불러와 특정 강의의 주문 내역만 선별 조회할 수 있는 기능을 추가했습니다.
- 주문자 정보 연동: 기존 목록에서 누락되었던 주문자(닉네임) 정보를 추가하기 위해 Order - User 조인 쿼리를 최적화했습니다.

2. 주문 상세 조회 페이지 구현 (Frontend)

- 주문 번호 클릭 시 이동하는 상세 페이지(/host/payments/[id])를 신규 제작했습니다.
- 카드형 레이아웃: 주문자 정보(이름, 이메일), 결제 정보(금액, 수단, 일시), 강의/세션 정보를 직관적인 카드 UI로 배치했습니다.
- 반응형 디자인: 모바일에서도 모든 주문 정보를 한눈에 확인할 수 있도록 최적화했습니다.

3. 호스트 UX 개선 (Frontend)

- 행 전체 클릭(Row Click): 테이블의 텍스트가 아닌 행의 어느 부분을 클릭해도 상세 페이지로 이동하도록 개선했습니다.
- 상태 관리 버튼 UI: 입금 확인 완료, 주문 취소, 환불 승인 등 주문 상태에 따른 관리 액션 버튼을 미리 구성했습니다. (UI 구현 완료)

