### PR TITLE
feat: 결제 내역 '한 번에 결제한 단위'로 조회, 환불 구현

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -15,87 +15,16 @@ import java.util.List;
 
 public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> {
 
-        Page<OrderJpaEntity> findByUserId(Long userId, Pageable pageable);
-
-        @Query("SELECT o FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
-                        "o.id IN (SELECT MIN(o2.id) FROM OrderJpaEntity o2 WHERE o2.user.id = :userId GROUP BY o2.tossOrderId) AND " +
-                        "(o.status != 'PENDING' OR (o.status = 'PENDING' AND o.paymentMethod = 'VIRTUAL_ACCOUNT')) AND " +
-                        "(:hasStatuses = false OR o.event.status IN :statuses)")
-        Page<OrderJpaEntity> findValidOrdersByUserIdAndEventStatuses(
-                        @Param("userId") Long userId,
-                        @Param("hasStatuses") boolean hasStatuses,
-                        @Param("statuses") List<com.venueon.event.domain.model.EventStatus> statuses,
-                        Pageable pageable);
-
-        List<OrderJpaEntity> findByEventId(Long eventId);
-
-        List<OrderJpaEntity> findByUserIdAndEventId(Long userId, Long eventId);
-
-        long countByEventIdAndStatusIn(Long eventId, List<OrderStatus> statuses);
-
-        long countBySessionIdAndStatusIn(Long sessionId, List<OrderStatus> statuses);
-
-        @Query("""
-                        select new com.venueon.host.dto.HostRecentOrderResponse(
-                            o.id,
-                            e.title,
-                            o.amount,
-                            coalesce(o.displayOrderedAt, o.orderedAt),
-                            cast(o.status as string)
-                        )
-                        from OrderJpaEntity o
-                        join o.event e
-                        where e.creator.id = :creatorId
-                        order by coalesce(o.displayOrderedAt, o.orderedAt) desc
-                        """)
-        Page<HostRecentOrderResponse> findRecentOrdersByHostId(Long creatorId, Pageable pageable);
-
-        @Query("""
-                        select coalesce(sum(o.amount), 0)
-                        from OrderJpaEntity o
-                        join o.event e
-                        where e.creator.id = :creatorId
-                          and o.status = :status
-                          and o.orderedAt >= :startDateTime
-                          and o.orderedAt < :endDateTime
-                        """)
-        int sumRevenueByHostIdAndPeriod(
-                        @Param("creatorId") Long creatorId,
-                        @Param("status") OrderStatus status,
-                        @Param("startDateTime") LocalDateTime startDateTime,
-                        @Param("endDateTime") LocalDateTime endDateTime);
-
-        java.util.Optional<OrderJpaEntity> findByTossOrderId(String tossOrderId);
-
-        List<OrderJpaEntity> findAllByTossOrderId(String tossOrderId);
-
-        List<OrderJpaEntity> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
-
-        List<OrderJpaEntity> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId,
-                        List<OrderStatus> statuses);
-
-        Page<OrderJpaEntity> findByEventIdIn(List<Long> eventIds, Pageable pageable);
-
-        @Query("SELECT COUNT(o) FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
-                        "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
-                        "o.event.status = 'ONGOING'")
-        long countOngoingByUserId(@Param("userId") Long userId);
-
-        @Query("SELECT COUNT(o) FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
-                        "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
-                        "o.event.status = 'ENDED'")
-        long countCompletedByUserId(@Param("userId") Long userId);
-               
-    // =================================
     Page<OrderJpaEntity> findByUserId(Long userId, Pageable pageable);
 
     @Query("SELECT o FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
+           "o.id IN (SELECT MIN(o2.id) FROM OrderJpaEntity o2 WHERE o2.user.id = :userId GROUP BY o2.tossOrderId) AND " +
            "(o.status != 'PENDING' OR (o.status = 'PENDING' AND o.paymentMethod = 'VIRTUAL_ACCOUNT')) AND " +
            "(:hasStatuses = false OR o.event.status IN :statuses)")
     Page<OrderJpaEntity> findValidOrdersByUserIdAndEventStatuses(
-            @Param("userId") Long userId, 
-            @Param("hasStatuses") boolean hasStatuses, 
-            @Param("statuses") List<com.venueon.event.domain.model.EventStatus> statuses, 
+            @Param("userId") Long userId,
+            @Param("hasStatuses") boolean hasStatuses,
+            @Param("statuses") List<com.venueon.event.domain.model.EventStatus> statuses,
             Pageable pageable);
 
     List<OrderJpaEntity> findByEventId(Long eventId);
@@ -103,7 +32,7 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     List<OrderJpaEntity> findByUserIdAndEventId(Long userId, Long eventId);
 
     long countByEventIdAndStatusIn(Long eventId, List<OrderStatus> statuses);
-    
+
     long countBySessionIdAndStatusIn(Long sessionId, List<OrderStatus> statuses);
 
     @Query("""
@@ -168,7 +97,7 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
     List<OrderJpaEntity> findAllByTossOrderId(String tossOrderId);
 
     List<OrderJpaEntity> findByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);
-    
+
     List<OrderJpaEntity> findByUserIdAndSessionIdAndStatusIn(Long userId, Long sessionId, List<OrderStatus> statuses);
 
     Page<OrderJpaEntity> findByEventIdIn(List<Long> eventIds, Pageable pageable);

--- a/backend/src/test/java/com/venueon/ApplicationContextLoadTest.java
+++ b/backend/src/test/java/com/venueon/ApplicationContextLoadTest.java
@@ -1,0 +1,11 @@
+package com.venueon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationContextLoadTest {
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## 🚀 과제 및 변경 사항 개요
장바구니 일괄 결제 도입에 따라, 마이페이지에서 주문 내역이 개별 항목 단위가 아닌 **'한 번의 결제 그룹(Batch)'** 단위로 표시되도록 고도화하였습니다. 또한, 일괄 결제 건에 대한 환불 시 그룹 내 모든 주문이 투명하게 일괄 취소되도록 통합 환불 로직을 구현했습니다.

## 🛠️ 주요 구현 사항

### 1. 백엔드 (Backend)
- **전용 DTO 도입 (`OrderSummaryResponse`)**: 결제 목록 조회를 위한 경량화된 DTO를 생성하여 그룹화된 정보를 효율적으로 전달합니다.
- **주문 내역 그룹화 쿼리**: `OrderJpaRepository`에서 `tossOrderId`를 기준으로 결제 그룹당 대표 데이터 1건만 조회하도록 SQL을 개선했습니다.
- **비즈니스 로직 고도화 (`OrderService`)**:
    - `getMyOrders`: 각 결체 건에 속한 모든 주문의 금액과 수량을 합산하고, 상품명을 "상품 A 외 N건" 형식으로 가공합니다.
    - `cancelOrder`: 특정 주문 취소 시 해당 결제 그룹(`tossOrderId`) 전체를 식별하여 토스 결제 취소와 함께 내부 주문 상태를 일괄 환불로 업데이트합니다.
- **REST API 안정화**: 컨트롤러 반환 타입을 신규 DTO로 변경하고, 필드 미칭 및 참조 오류를 수정했습니다.

### 2. 프론트엔드 (Frontend)
- **결제 내역 목록 UI 개선**: `OrdersPage`에서 새로운 DTO 구조를 반영하여 결제 건별로 묶어서 표시합니다.
- **그룹 정보 표시**: 일괄 결제 건의 경우 "총 N개 항목" 안내를 추가하여 사용자가 상세 내역을 인지할 수 있도록 했습니다.
- **CSS 스타일 업데이트**: 그룹화된 상품명과 수량 정보를 시각적으로 구분하기 위한 전용 스타일을 추가했습니다.

## 🧪 테스트 결과
- **목록 조회**: 장바구니에서 여러 항목을 동시 결제 시 마이페이지 목록에 1행으로 합산 표시됨을 확인.
- **일괄 환불**: 목록에서 상세 보기 이동 후 '환불 하기' 클릭 시, 해당 결제 덩어리의 모든 항목이 정상적으로 환불 처리되고 토스 API가 1회 호출됨을 확인.
- **빌드 검증**: `npm run build` 및 백엔드 컴파일 정상 완료.
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 12 22 08 PM" src="https://github.com/user-attachments/assets/a7d29db8-532d-4da0-9e87-2914bbbb5ea0" />
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 12 22 15 PM" src="https://github.com/user-attachments/assets/89154de0-926b-4498-b6a5-7cd4f257f4a2" />
<img width="1728" height="1117" alt="Screenshot 2026-04-10 at 12 23 08 PM" src="https://github.com/user-attachments/assets/49ae8974-dd1b-41e4-95f0-4c52f8993c64" />

## 📌 참고 사항
- 이번 변경으로 인해 개별 주문 상세 내역은 리스트의 '상세 보기'를 통해 기존과 동일하게 확인할 수 있습니다.