### PR TITLE
feat: 프론트에서 복수 티켓 구매 장바구니 검증 로직

### DIFF
--- a/frontend/src/app/events/[id]/_components/TicketList.tsx
+++ b/frontend/src/app/events/[id]/_components/TicketList.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { Button, Tag } from '@/components/ui';
+import ConfirmModal from '@/components/modal/ConfirmModal';
 import styles from './TicketList.module.css';
 import { format, differenceInDays } from 'date-fns';
 
@@ -44,7 +45,59 @@ interface TicketListProps {
 export default function TicketList({ tickets, sessions, eventStatus }: TicketListProps) {
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
   const [addingToCart, setAddingToCart] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
   const router = useRouter();
+  const params = useParams();
+  const eventId = Number(params?.id);
+
+  const proceedAddToCart = async () => {
+    setAddingToCart(true);
+    try {
+      const res = await fetch('/api/cart', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticketId: selectedTicketId, quantity: 1 }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error || '장바구니 추가 실패');
+      }
+      setShowSuccessModal(true);
+    } catch (err: any) {
+      alert(err.message || '장바구니 추가 중 오류가 발생했습니다.');
+    } finally {
+      setAddingToCart(false);
+    }
+  };
+
+  const handleAddToCartClick = async () => {
+    setAddingToCart(true);
+    try {
+      const cartRes = await fetch('/api/cart');
+      if (!cartRes.ok) throw new Error('장바구니 목록을 불러오지 못했습니다.');
+      
+      const cartItems = await cartRes.json();
+      
+      const hasSameTicket = cartItems.some((item: any) => item.ticketId === selectedTicketId);
+      if (hasSameTicket) {
+        setShowErrorModal(true);
+        return;
+      }
+      
+      const hasSameEventTicket = cartItems.some((item: any) => item.eventId === eventId);
+      if (hasSameEventTicket) {
+        setShowConfirmModal(true);
+        return; // wait for modal
+      }
+      
+      await proceedAddToCart();
+    } catch (err: any) {
+      alert(err.message || '장바구니 확인 중 오류가 발생했습니다.');
+      setAddingToCart(false);
+    }
+  };
 
   if (!tickets || tickets.length === 0) {
     return (
@@ -174,25 +227,7 @@ export default function TicketList({ tickets, sessions, eventStatus }: TicketLis
               size="large"
               style={{ flex: 1 }}
               disabled={addingToCart}
-              onClick={async () => {
-                setAddingToCart(true);
-                try {
-                  const res = await fetch('/api/cart', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ticketId: selectedTicketId, quantity: 1 }),
-                  });
-                  if (!res.ok) {
-                    const body = await res.json().catch(() => null);
-                    throw new Error(body?.error || '장바구니 추가 실패');
-                  }
-                  alert('장바구니에 추가되었습니다!');
-                } catch (err: any) {
-                  alert(err.message || '장바구니 추가 중 오류가 발생했습니다.');
-                } finally {
-                  setAddingToCart(false);
-                }
-              }}
+              onClick={handleAddToCartClick}
             >
               {addingToCart ? '추가 중...' : '장바구니 담기'}
             </Button>
@@ -212,6 +247,51 @@ export default function TicketList({ tickets, sessions, eventStatus }: TicketLis
           </div>
         </div>
       )}
+
+      {/* 동일 이벤트 티켓 확인 모달 */}
+      <ConfirmModal
+        isOpen={showConfirmModal}
+        onClose={() => {
+          setShowConfirmModal(false);
+          setAddingToCart(false);
+        }}
+        onConfirm={() => {
+          setShowConfirmModal(false);
+          proceedAddToCart();
+        }}
+        title="같은 세미나의 티켓을 이미 장바구니에 담으셨습니다."
+        subtitle="그래도 새로운 티켓을 구매하시겠습니까?"
+        confirmText="예"
+        cancelText="아니오"
+      />
+
+      {/* 이미 담겨있는 티켓 에러 모달 */}
+      <ConfirmModal
+        isOpen={showErrorModal}
+        onClose={() => {
+          setShowErrorModal(false);
+          setAddingToCart(false);
+        }}
+        onConfirm={() => {
+          setShowErrorModal(false);
+          setAddingToCart(false);
+        }}
+        title="티켓 추가 불가"
+        subtitle="이미 장바구니에 담겨 있는 티켓입니다."
+        confirmText="확인"
+        hideCancel={true}
+      />
+
+      {/* 장바구니 추가 성공 모달 */}
+      <ConfirmModal
+        isOpen={showSuccessModal}
+        onClose={() => setShowSuccessModal(false)}
+        onConfirm={() => router.push('/cart')}
+        title="장바구니 추가 완료"
+        subtitle="티켓이 장바구니에 추가되었습니다."
+        confirmText="장바구니로 이동"
+        cancelText="계속 쇼핑하기"
+      />
     </div>
   );
 }

--- a/frontend/src/components/modal/ConfirmModal.tsx
+++ b/frontend/src/components/modal/ConfirmModal.tsx
@@ -18,6 +18,7 @@ export interface ConfirmModalProps {
   checkboxLabel?: string;
   cancelText?: string;
   confirmText?: string;
+  hideCancel?: boolean;
 }
 
 export default function ConfirmModal({
@@ -31,6 +32,7 @@ export default function ConfirmModal({
   checkboxLabel,
   cancelText = '취소',
   confirmText = '확인',
+  hideCancel = false,
 }: ConfirmModalProps) {
   const [isChecked, setIsChecked] = useState(false);
 
@@ -70,9 +72,11 @@ export default function ConfirmModal({
 
         {/* 버튼 그룹 */}
         <div className={styles.buttonGroup}>
-          <Button variant="secondary" style={{ flex: 1, padding: 0 }} onClick={onClose}>
-            {cancelText}
-          </Button>
+          {!hideCancel && (
+            <Button variant="secondary" style={{ flex: 1, padding: 0 }} onClick={onClose}>
+              {cancelText}
+            </Button>
+          )}
           <Button 
             variant={status === 'danger' ? 'danger' : 'primary'}
             style={{ flex: 1, padding: 0 }}


### PR DESCRIPTION
## 📌 작업 내용

장바구니 담기 과정에서 발생하는 여러 제약 조건 및 알림을 기존의 브라우저 기본 `alert`/`confirm` 창 대신 서비스 자체 커스텀 모달(`ConfirmModal`)을 사용하도록 UX를 개선하고, 동일 이벤트의 중복 티켓 추가에 대한 구매 정책을 적용했습니다.

### 1. 장바구니 담기 UI/UX 개선 (`TicketList.tsx`)
- **[성공 모달 추가]**: 티켓이 장바구니에 정상적으로 추가되었을 때 기존 브라우저 `alert`를 제거하고, "계속 쇼핑하기"와 "장바구니로 이동" 중 하나를 선택할 수 있는 `ConfirmModal`을 도입했습니다.
- **[동일 티켓 에러 모달 추가]**: 이미 장바구니에 포함된 티켓을 다시 담으려 할 때 표출되는 `alert`를 제거하고, 확인 버튼만 제공되는 커스텀 에러 모달로 교체했습니다.

### 2. 동일 이벤트 중복 티켓 정책 도입 (`TicketList.tsx`)
- 장바구니 담기 클릭 시, 현재 장바구니 데이터를 사전에 조회하여 검증합니다.
- **같은 이벤트(세미나)의 다른 종류의 티켓이 이미 담겨있는 경우**: "같은 세미나의 티켓을 이미 장바구니에 담으셨습니다. 그래도 새로운 티켓을 구매하시겠습니까?"를 묻는 사용자 확인 모달을 표출하고 동의 시에만 추가를 진행하도록 구성했습니다.

### 3. 공통 모달 기능 확장 (`ConfirmModal.tsx`)
- 단일 버튼(확인) 용도로 모달을 사용할 수 있도록, 보조 버튼(취소) 영역을 가릴 수 있는 `hideCancel: boolean` 선택형 Prop을 새롭게 추가하여 재사용성을 향상시켰습니다.

---

## 📸 스크린샷
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 1 06 24 PM" src="https://github.com/user-attachments/assets/c7eadd65-d81f-4726-a19b-7c11896cb3b7" />
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 1 06 31 PM" src="https://github.com/user-attachments/assets/f113839a-b3ab-41fd-80e1-6a1fa93d1c17" />
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 1 06 49 PM" src="https://github.com/user-attachments/assets/ce511b03-8144-4066-b26d-2e5961f9f75c" />


## 🔗 관련 이슈
- JIRA/TICKET ID: [VO-832]


[VO-832]: https://venueon.atlassian.net/browse/VO-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ