### PR TITLE
fix: DataInitializer 커뮤니티 생성 시 creator_id 누락 문제 수정

### DIFF
--- a/backend/src/main/java/com/venueon/common/config/DataInitializer.java
+++ b/backend/src/main/java/com/venueon/common/config/DataInitializer.java
@@ -103,7 +103,7 @@ public class DataInitializer implements ApplicationRunner {
         List<EventJpaEntity> events = createEvents(hosts, categories);
         createSessions(events);
         createTickets(events);
-        List<CommunityJpaEntity> communities = createCommunities();
+        List<CommunityJpaEntity> communities = createCommunities(admin);
         List<PostJpaEntity> posts = createPosts(users, communities);
         List<OrderJpaEntity> orders = createOrders(users, events);
         List<ReportJpaEntity> reports = createReports(users, events, posts);
@@ -612,10 +612,10 @@ public class DataInitializer implements ApplicationRunner {
     }
 
 
-    private List<CommunityJpaEntity> createCommunities() {
+    private List<CommunityJpaEntity> createCommunities(UserJpaEntity admin) {
         return communityRepository.saveAll(List.of(
-                CommunityJpaEntity.builder().name("자유게시판").description("누구나 자유롭게 이야기하는 공간").build(),
-                CommunityJpaEntity.builder().name("질문답변").description("서로 돕고 배우는 공간").build()
+                CommunityJpaEntity.builder().name("자유게시판").description("누구나 자유롭게 이야기하는 공간").creator(admin).build(),
+                CommunityJpaEntity.builder().name("질문답변").description("서로 돕고 배우는 공간").creator(admin).build()
         ));
     }
 


### PR DESCRIPTION
## 변경 사항
- CI 배포 중(create-drop 모드) `CommunityJpaEntity` 객체 생성 시 작성자(`creator`) 값 누락으로 발생하던 `not-null constraint violation` 에러를 해결했습니다.
- `DataInitializer`가 커뮤니티 샘플 데이터를 생성할 때 관리자 계정을 주입하도록 수정했습니다.