### PR TITLE
fix: 헬스체크 배포 오류(DI 실패) 수정 및 Event DTO 정리

### DIFF
--- a/backend/src/main/java/com/venueon/comment/application/service/CommentCommandService.java
+++ b/backend/src/main/java/com/venueon/comment/application/service/CommentCommandService.java
@@ -20,7 +20,7 @@ import com.venueon.common.annotation.UseCase;
 @RequiredArgsConstructor
 @Transactional
 public class CommentCommandService
-        implements CreateCommentUseCase, CommentLikeUseCase, UpdateCommentUseCase, DeleteCommentUseCase {
+        implements CreateCommentUseCase, CommentLikeUseCase, UpdateCommentUseCase, DeleteCommentUseCase, CommentAdminUseCase {
 
     private final CommentRepositoryPort commentRepositoryPort;
     private final UserRepositoryPort userRepositoryPort;
@@ -78,6 +78,7 @@ public class CommentCommandService
         comment.update(request.content());
     }
 
+    @Override
     public void hideComment(Long commentId) {
         Comment comment = commentRepositoryPort.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("Comment not found: " + commentId));


### PR DESCRIPTION
## 변경 사항
- `AdminReportService`에서 주입받고자 했던 `CommentAdminUseCase` 타입의 Bean이 누락되어 서버 배포(헬스체크) 중 기동 실패하던 문제를 해결했습니다. (`CommentCommandService` 선언부에 `implements CommentAdminUseCase` 추가)
- `HostEventResponse` DTO 등 V6 아키텍처에 맞춘 데이터 정리 커밋이 포함되어 있습니다.