### PR TITLE
fix: 프로필 이미지 영속성 및 사용자 정보 표시 수정 fix #VO-851

### DIFF
--- a/backend/src/main/java/com/venueon/admin/contact/adapter/in/web/dto/response/ContactDetailResponse.java
+++ b/backend/src/main/java/com/venueon/admin/contact/adapter/in/web/dto/response/ContactDetailResponse.java
@@ -16,6 +16,7 @@ public record ContactDetailResponse(
         Long requesterId,
         String requesterNickname,
         String requesterEmail,
+        String requesterProfileImg,
         ContactCategory category,
         ContactStatus status,
         String title,
@@ -32,6 +33,7 @@ public record ContactDetailResponse(
                 .requesterId(contact.getRequesterId())
                 .requesterNickname(contact.getRequesterNickname())
                 .requesterEmail(contact.getRequesterEmail())
+                .requesterProfileImg(contact.getRequesterProfileImg())
                 .category(contact.getCategory())
                 .status(contact.getStatus())
                 .title(contact.getTitle())

--- a/backend/src/main/java/com/venueon/admin/contact/adapter/in/web/dto/response/ContactListResponse.java
+++ b/backend/src/main/java/com/venueon/admin/contact/adapter/in/web/dto/response/ContactListResponse.java
@@ -16,6 +16,7 @@ public record ContactListResponse(
         Long requesterId,
         String requesterNickname,
         String requesterEmail,
+        String requesterProfileImg,
         ContactCategory category,
         ContactStatus status,
         String title,
@@ -29,6 +30,7 @@ public record ContactListResponse(
                 .requesterId(contact.getRequesterId())
                 .requesterNickname(contact.getRequesterNickname())
                 .requesterEmail(contact.getRequesterEmail())
+                .requesterProfileImg(contact.getRequesterProfileImg())
                 .category(contact.getCategory())
                 .status(contact.getStatus())
                 .title(contact.getTitle())

--- a/backend/src/main/java/com/venueon/admin/contact/adapter/out/persistence/ContactMapper.java
+++ b/backend/src/main/java/com/venueon/admin/contact/adapter/out/persistence/ContactMapper.java
@@ -11,9 +11,13 @@ import org.springframework.stereotype.Component;
 public class ContactMapper {
 
     public Contact toDomain(ContactJpaEntity entity) {
+        var requester = entity.getRequester();
         return Contact.builder()
                 .id(entity.getId())
                 .requesterId(entity.getRequesterId())
+                .requesterNickname(requester != null ? requester.getNickname() : null)
+                .requesterEmail(requester != null ? requester.getEmail() : null)
+                .requesterProfileImg(requester != null ? requester.getProfileImg() : null)
                 .category(entity.getCategory())
                 .status(entity.getStatus())
                 .title(entity.getTitle())

--- a/backend/src/main/java/com/venueon/admin/contact/adapter/out/persistence/entity/ContactJpaEntity.java
+++ b/backend/src/main/java/com/venueon/admin/contact/adapter/out/persistence/entity/ContactJpaEntity.java
@@ -26,6 +26,10 @@ public class ContactJpaEntity {
     @Column(name = "requester_id", nullable = false)
     private Long requesterId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id", insertable = false, updatable = false)
+    private com.venueon.user.adapter.out.persistence.entity.UserJpaEntity requester;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false, length = 30)
     private ContactCategory category;

--- a/backend/src/main/java/com/venueon/admin/contact/domain/model/Contact.java
+++ b/backend/src/main/java/com/venueon/admin/contact/domain/model/Contact.java
@@ -18,6 +18,7 @@ public class Contact {
     private Long requesterId;
     private String requesterNickname;
     private String requesterEmail;
+    private String requesterProfileImg;
     private ContactCategory category;
     private ContactStatus status;
     private String title;

--- a/backend/src/main/java/com/venueon/admin/contact/domain/model/ContactCategory.java
+++ b/backend/src/main/java/com/venueon/admin/contact/domain/model/ContactCategory.java
@@ -10,6 +10,18 @@ public enum ContactCategory {
     HOST_INQUIRY,
     /** 참석자 문의 */
     USER_INQUIRY,
+    /** 결제/환불 문의 (사용자) */
+    PAYMENT,
+    /** 계정 문제 (사용자) */
+    ACCOUNT,
+    /** 시스템 오류 (공통) */
+    SYSTEM_ERROR,
+    /** 이의 제기 (사용자) */
+    OBJECTION,
+    /** 정산 문의 (호스트) */
+    BILLING,
+    /** 이벤트 관리 (호스트) */
+    EVENT_MANAGEMENT,
     /** 기타 */
     OTHER
 }

--- a/backend/src/main/java/com/venueon/admin/report/adapter/in/web/dto/ReportResponse.java
+++ b/backend/src/main/java/com/venueon/admin/report/adapter/in/web/dto/ReportResponse.java
@@ -18,6 +18,7 @@ public class ReportResponse {
     private Long id;
     private Long reporterId;
     private String reporterNickname;
+    private String reporterProfileImg;
     private ReportTargetType targetType;
     private Long targetId;
     private String reason;
@@ -28,12 +29,14 @@ public class ReportResponse {
     private LocalDateTime resolvedAt;
 
     @Builder
-    private ReportResponse(Long id, Long reporterId, String reporterNickname, ReportTargetType targetType, 
+    private ReportResponse(Long id, Long reporterId, String reporterNickname, String reporterProfileImg,
+                           ReportTargetType targetType, 
                            Long targetId, String reason, String detail, ReportStatus status, 
                            AdminAction adminAction, LocalDateTime createdAt, LocalDateTime resolvedAt) {
         this.id = id;
         this.reporterId = reporterId;
         this.reporterNickname = reporterNickname;
+        this.reporterProfileImg = reporterProfileImg;
         this.targetType = targetType;
         this.targetId = targetId;
         this.reason = reason;
@@ -49,6 +52,7 @@ public class ReportResponse {
                 .id(entity.getId())
                 .reporterId(entity.getReporter().getId())
                 .reporterNickname(entity.getReporter().getNickname())
+                .reporterProfileImg(entity.getReporter().getProfileImg())
                 .targetType(entity.getTargetType())
                 .targetId(entity.getTargetId())
                 .reason(entity.getReason())

--- a/backend/src/main/java/com/venueon/host/order/adapter/in/web/dto/HostAttendeeResponse.java
+++ b/backend/src/main/java/com/venueon/host/order/adapter/in/web/dto/HostAttendeeResponse.java
@@ -12,6 +12,7 @@ public record HostAttendeeResponse(
         Long orderId,           // 주문 ID (고유 식별)
         String userName,        // 수강생 이름 (nickname)
         String userEmail,       // 수강생 이메일
+        String userProfileImg,  // 수강생 프로필 이미지
         String eventTitle,      // 수강 강의명
         int amount,             // 결제 금액
         LocalDateTime orderedAt,// 신청일시

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -128,6 +128,7 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
                 o.id,
                 u.nickname,
                 u.email,
+                u.profileImg,
                 e.title,
                 o.amount,
                 coalesce(o.displayOrderedAt, o.orderedAt),

--- a/frontend/src/app/admin/contact/_components/ContactFilter.tsx
+++ b/frontend/src/app/admin/contact/_components/ContactFilter.tsx
@@ -16,8 +16,14 @@ interface ContactFilterProps {
 
 const CATEGORY_TABS = [
   { value: '', label: '전체' },
-  { value: 'HOST_INQUIRY', label: '호스트 문의' },
-  { value: 'USER_INQUIRY', label: '참석자 문의' },
+  { value: 'PAYMENT', label: '결제/환불' },
+  { value: 'ACCOUNT', label: '계정 문제' },
+  { value: 'SYSTEM_ERROR', label: '시스템 오류' },
+  { value: 'OBJECTION', label: '이의 제기' },
+  { value: 'BUSINESS_LICENSE', label: '사업자 인증' },
+  { value: 'BILLING', label: '정산 문의' },
+  { value: 'EVENT_MANAGEMENT', label: '이벤트 관리' },
+  { value: 'OTHER', label: '기타' },
 ];
 
 const STATUS_TABS = [

--- a/frontend/src/app/admin/contact/_components/ContactTable.tsx
+++ b/frontend/src/app/admin/contact/_components/ContactTable.tsx
@@ -53,6 +53,11 @@ export default function ContactTable({ contacts, isLoading, onViewDetail }: Cont
             <TableCell>
               <UserProfile 
                 name={req.requesterNickname || req.requesterEmail?.split('@')[0] || '사용자'} 
+                imageUrl={req.requesterProfileImg 
+                  ? (req.requesterProfileImg.startsWith('/') || req.requesterProfileImg.startsWith('http') 
+                    ? req.requesterProfileImg 
+                    : `/upload/${req.requesterProfileImg}`)
+                  : undefined}
                 size="medium" 
               />
             </TableCell>

--- a/frontend/src/app/admin/reports/_components/ReportTable.tsx
+++ b/frontend/src/app/admin/reports/_components/ReportTable.tsx
@@ -267,7 +267,17 @@ export default function ReportTable() {
                   <>
                     <td className={styles.colStudent}>
                       <div className={styles.userProfile}>
-                        <div className={styles.avatar}></div>
+                        <div className={styles.avatar}>
+                          {item.reporterProfileImg && (
+                            <img 
+                              src={item.reporterProfileImg.startsWith('/') || item.reporterProfileImg.startsWith('http') 
+                                ? item.reporterProfileImg 
+                                : `/upload/${item.reporterProfileImg}`}
+                              alt={item.reporterNickname}
+                              style={{ width: '100%', height: '100%', borderRadius: '50%', objectFit: 'cover' }}
+                            />
+                          )}
+                        </div>
                         <span className={styles.userName}>{item.reporterNickname}</span>
                       </div>
                     </td>

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -22,3 +22,35 @@ export async function GET() {
     return NextResponse.json({ isLoggedIn: false });
   }
 }
+
+/**
+ * PUT /api/auth/session — 프로필 수정 후 세션 쿠키 동기화
+ * nickname, profileImg 를 iron-session에 갱신하여 새로고침 후에도 최신 값 유지
+ */
+export async function PUT(req: Request) {
+  try {
+    const cookieStore = await cookies();
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
+
+    if (!session.isLoggedIn) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+
+    // 전달된 필드만 업데이트
+    if (body.nickname !== undefined) {
+      session.nickname = body.nickname;
+    }
+    if (body.profileImg !== undefined) {
+      session.profileImg = body.profileImg || undefined;
+    }
+
+    await session.save();
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Session update error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/host/contact/page.tsx
+++ b/frontend/src/app/host/contact/page.tsx
@@ -24,12 +24,7 @@ function formatDate(dateStr: string | null): string {
   });
 }
 
-/** ContactModal 카테고리 → 백엔드 ContactCategory 매핑 */
-function mapCategoryToBackend(category: string): ContactCategory {
-  if (category === 'auth') return 'BUSINESS_LICENSE';
-  if (category === 'etc') return 'OTHER';
-  return 'HOST_INQUIRY';
-}
+/** ContactModal 카테고리 값은 백엔드 ContactCategory와 동일 */
 
 export default function HostContactPage() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -79,7 +74,7 @@ export default function HostContactPage() {
   }) => {
     try {
       await userContactAPI.createContact({
-        category: mapCategoryToBackend(data.category),
+        category: data.category as ContactCategory,
         title: data.title,
         content: data.content,
         attachmentUrl: undefined, // TODO: 파일 업로드 후 URL 연동

--- a/frontend/src/app/mypage/contact/page.tsx
+++ b/frontend/src/app/mypage/contact/page.tsx
@@ -24,16 +24,7 @@ function formatDate(dateStr: string | null): string {
   });
 }
 
-/** ContactModal 카테고리 → 백엔드 ContactCategory 매핑 */
-function mapCategoryToBackend(category: string, role: 'user' | 'host'): ContactCategory {
-  if (role === 'host') {
-    if (category === 'auth') return 'BUSINESS_LICENSE';
-    if (category === 'etc') return 'OTHER';
-    return 'HOST_INQUIRY';
-  }
-  if (category === 'etc') return 'OTHER';
-  return 'USER_INQUIRY';
-}
+/** ContactModal 카테고리 값은 백엔드 ContactCategory와 동일 */
 
 export default function UserContactPage() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -90,7 +81,7 @@ export default function UserContactPage() {
   }) => {
     try {
       await userContactAPI.createContact({
-        category: mapCategoryToBackend(data.category, 'user'),
+        category: data.category as ContactCategory,
         title: data.title,
         content: data.content,
         attachmentUrl: undefined, // TODO: 파일 업로드 후 URL 연동
@@ -125,7 +116,10 @@ export default function UserContactPage() {
                   variant="line"
                   options={[
                     { value: '', label: '전체' },
-                    { value: 'USER_INQUIRY', label: '일반 문의' },
+                    { value: 'PAYMENT', label: '결제/환불' },
+                    { value: 'ACCOUNT', label: '계정 문제' },
+                    { value: 'SYSTEM_ERROR', label: '시스템 오류' },
+                    { value: 'OBJECTION', label: '이의 제기' },
                     { value: 'OTHER', label: '기타' },
                   ]}
                   activeValue={categoryFilter}

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -68,7 +68,11 @@ export default function ProfileSettingsPage() {
           const fetchedEmail = data.email || '';
           const fetchedName = data.nickname || '';
           // DB에 null이면 기본 아바타 아이콘이 뜨도록 undefined 로 세팅
-          const fetchedImg = data.profileImg || undefined;
+          // 서버에 저장된 상대경로(profile/2026/04/uuid.jpg)에 /upload/ prefix 추가
+          const rawImg = data.profileImg;
+          const fetchedImg = rawImg
+            ? (rawImg.startsWith('/') || rawImg.startsWith('http') ? rawImg : `/upload/${rawImg}`)
+            : undefined;
 
           setBaseEmail(fetchedEmail);
           setBaseName(fetchedName);
@@ -150,7 +154,37 @@ export default function ProfileSettingsPage() {
   // 저장(확인) 클릭 - 실제 백엔드 연동 부분
   const handleSave = async () => {
     try {
-      // BFF 프록시 경로 (Route Handler가 /api 제거 후 백엔드로 전달, JWT 자동 포함)
+      // 1) 새로 선택한 파일이 있으면 먼저 서버에 업로드
+      let finalProfileImg: string | null = null;
+
+      if (selectedFile) {
+        // FormData로 파일 업로드 (category=profile)
+        const formData = new FormData();
+        formData.append('file', selectedFile);
+        formData.append('category', 'profile');
+
+        const uploadRes = await fetch('/api/files/upload', {
+          method: 'POST',
+          body: formData,
+        });
+
+        if (!uploadRes.ok) {
+          showToast('이미지 업로드에 실패했습니다.', 'error');
+          return;
+        }
+
+        const uploadData = await uploadRes.json();
+        // 백엔드 반환: { data: { filePath: "profile/2026/04/uuid.jpg" } }
+        finalProfileImg = uploadData.data?.filePath || uploadData.filePath || null;
+      } else if (profileImage && !profileImage.startsWith('blob:')) {
+        // 기존 이미지 유지 — /upload/ prefix 제거 후 상대경로만 저장
+        finalProfileImg = profileImage.replace(/^\/upload\//, '');
+      } else {
+        // 이미지 삭제 (profileImage === undefined)
+        finalProfileImg = null;
+      }
+
+      // 2) 프로필 정보 저장 (실제 서버 경로를 전송)
       const res = await fetch('/api/users/me/profile', {
         method: 'PUT',
         headers: {
@@ -158,23 +192,35 @@ export default function ProfileSettingsPage() {
         },
         body: JSON.stringify({
           nickname: userName,
-          profileImg: profileImage,
+          profileImg: finalProfileImg,
           categories: categories,
           showBadge: showBadge,
         }),
       });
 
       if (res.ok) {
-        setBaseImage(profileImage);
+        // 저장된 이미지 경로에 /upload/ prefix 붙여서 화면에 표시
+        const displayImg = finalProfileImg ? `/upload/${finalProfileImg}` : undefined;
+
+        setBaseImage(displayImg);
+        setProfileImage(displayImg);
+        setSelectedFile(null);
         setBaseEmail(userEmail);
         setBaseName(userName);
         setBaseCategories(categories);
         setBaseBadge(showBadge);
         showToast('내 정보 수정이 완료되었습니다.', 'success');
 
-        // 헤더 갱신 (저장 성공 시) - 강제로 로컬 스토어의 유저 정보 동기화
+        // 3) Zustand 스토어 갱신 (Header 즉시 반영)
         const { updateUser } = useAuth.getState();
-        updateUser({ nickname: userName, profileImg: profileImage });
+        updateUser({ nickname: userName, profileImg: displayImg });
+
+        // 4) iron-session 동기화 (새로고침 후에도 유지)
+        await fetch('/api/auth/session', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nickname: userName, profileImg: finalProfileImg }),
+        });
       } else {
         const errorText = await res.text();
         try {
@@ -221,7 +267,7 @@ export default function ProfileSettingsPage() {
               <div className={styles.imageRow}>
                 {/* 공용 UserProfile 을 사용하되, CSS로 사진 크기 72px 변경 및 텍스트 숨김 처리 */}
                 <UserProfile
-                  name="장회원"
+                  name={userName || '사용자'}
                   imageUrl={profileImage}
                   className={styles.customProfile}
                 />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -31,7 +31,13 @@ export default function Header({
 
   // 실제 세션의 정보가 있으면 우선적으로 보여주고, 없으면 기존 prop/기본값 사용
   const displayUserName = user?.nickname || userName;
-  const displayUserImage = user?.profileImg || userImageUrl;
+  const rawUserImage = user?.profileImg || userImageUrl;
+  // 서버 상대경로(profile/2026/04/uuid.jpg)에 /upload/ prefix 추가
+  const displayUserImage = rawUserImage
+    ? (rawUserImage.startsWith('/') || rawUserImage.startsWith('http') || rawUserImage.startsWith('blob:')
+      ? rawUserImage
+      : `/upload/${rawUserImage}`)
+    : undefined;
 
   // /mypage 경로일 때는 항상 'myPage' 해더(세션 목록 + 프로필)를 보여주도록 강제
   const isMyPage = pathname?.startsWith('/mypage');

--- a/frontend/src/components/modal/ContactDetailModal.tsx
+++ b/frontend/src/components/modal/ContactDetailModal.tsx
@@ -160,6 +160,11 @@ export default function ContactDetailModal({
                   <div className={styles.metaValue}>
                     <UserProfile
                       name={detail.requesterNickname || detail.requesterEmail || '알 수 없음'}
+                      imageUrl={detail.requesterProfileImg
+                        ? (detail.requesterProfileImg.startsWith('/') || detail.requesterProfileImg.startsWith('http')
+                          ? detail.requesterProfileImg
+                          : `/upload/${detail.requesterProfileImg}`)
+                        : undefined}
                       size="medium"
                     />
                   </div>

--- a/frontend/src/components/modal/ContactModal.tsx
+++ b/frontend/src/components/modal/ContactModal.tsx
@@ -8,19 +8,19 @@ import { CancelIcon } from '@/components/icons';
 import { Tabs, TextareaField, InputField, Button, UploadField } from '@/components/ui';
 
 const USER_CATEGORIES = [
-  { value: 'payment', label: '결제/환불' },
-  { value: 'account', label: '계정 문제' },
-  { value: 'error', label: '시스템 오류' },
-  { value: 'objection', label: '이의 제기' },
-  { value: 'etc', label: '기타' },
+  { value: 'PAYMENT', label: '결제/환불' },
+  { value: 'ACCOUNT', label: '계정 문제' },
+  { value: 'SYSTEM_ERROR', label: '시스템 오류' },
+  { value: 'OBJECTION', label: '이의 제기' },
+  { value: 'OTHER', label: '기타' },
 ];
 
 const HOST_CATEGORIES = [
-  { value: 'auth', label: '사업자 인증' },
-  { value: 'billing', label: '정산 문의' },
-  { value: 'event', label: '이벤트 관리' },
-  { value: 'error', label: '시스템 오류' },
-  { value: 'etc', label: '기타' },
+  { value: 'BUSINESS_LICENSE', label: '사업자 인증' },
+  { value: 'BILLING', label: '정산 문의' },
+  { value: 'EVENT_MANAGEMENT', label: '이벤트 관리' },
+  { value: 'SYSTEM_ERROR', label: '시스템 오류' },
+  { value: 'OTHER', label: '기타' },
 ];
 
 export interface ContactModalProps {

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -50,6 +50,7 @@ export interface AdminReportListItem {
   id: number;
   reporterId: number;
   reporterNickname: string;
+  reporterProfileImg: string | null;
   targetType: 'EVENT' | 'POST' | 'COMMENT' | 'USER';
   targetId: number;
   reason: string;

--- a/frontend/src/lib/contact-api.ts
+++ b/frontend/src/lib/contact-api.ts
@@ -5,7 +5,7 @@ import { apiFetch } from './api';
 
 // ── 타입 정의 ──
 
-export type ContactCategory = 'BUSINESS_LICENSE' | 'HOST_INQUIRY' | 'USER_INQUIRY' | 'OTHER';
+export type ContactCategory = 'BUSINESS_LICENSE' | 'HOST_INQUIRY' | 'USER_INQUIRY' | 'PAYMENT' | 'ACCOUNT' | 'SYSTEM_ERROR' | 'OBJECTION' | 'BILLING' | 'EVENT_MANAGEMENT' | 'OTHER';
 export type ContactStatus = 'PENDING' | 'REVIEWING' | 'COMPLETED' | 'REJECTED' | 'CANCELLED';
 
 export interface ContactListItem {
@@ -13,6 +13,7 @@ export interface ContactListItem {
   requesterId: number;
   requesterNickname: string | null;
   requesterEmail: string | null;
+  requesterProfileImg: string | null;
   category: ContactCategory;
   status: ContactStatus;
   title: string;
@@ -26,6 +27,7 @@ export interface ContactDetail {
   requesterId: number;
   requesterNickname: string | null;
   requesterEmail: string | null;
+  requesterProfileImg: string | null;
   category: ContactCategory;
   status: ContactStatus;
   title: string;
@@ -57,6 +59,12 @@ export const CATEGORY_LABELS: Record<ContactCategory, string> = {
   BUSINESS_LICENSE: '사업자등록증 확인',
   HOST_INQUIRY: '호스트 문의',
   USER_INQUIRY: '참석자 문의',
+  PAYMENT: '결제/환불',
+  ACCOUNT: '계정 문제',
+  SYSTEM_ERROR: '시스템 오류',
+  OBJECTION: '이의 제기',
+  BILLING: '정산 문의',
+  EVENT_MANAGEMENT: '이벤트 관리',
   OTHER: '기타',
 };
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #VO-851

## 📝 변경 사항

### 1. 프로필 이미지 영속성 해결
- 기존: blob: URL을 DB에 저장 → 새로고침 시 이미지 깨짐
- 수정: 서버에 실제 파일 업로드 후 반환된 상대 경로를 DB에 저장

### 2. 세션 동기화
- PUT /api/auth/session API 신규 생성하여 프로필 저장 시 iron-session 쿠키 최신화

### 3. 모든 활동에 사용자 프로필/이름 표시
- 문의(Contact): ContactJpaEntity에 @ManyToOne User 관계 추가 → 프로필 이미지/닉네임 JOIN 조회
- 신고(Report): reporterProfileImg 추가
- 수강생 목록(Attendee): userProfileImg 추가 + JPQL 반영
- 프론트엔드: UserProfile 컴포넌트에 실제 이미지 전달 + /upload/ prefix 처리

### 4. 문의 유형 불일치 수정
- 기존: 사용자가 선택한 세부 유형이 전부 USER_INQUIRY로 통합되어 어드민에게 '참석자 문의'로만 표시
- 수정: ContactCategory enum 확장(4→10개), ContactModal value를 백엔드 enum과 직접 일치시켜 매핑 함수 제거

### 5. UI 로직 개선
- 기본 아바타 이름 하드코딩("장회원") → 동적 할당
- Header에서 서버 상대 경로 /upload/ prefix 자동 추가

## 📁 변경 파일 (21개)

**Backend:** ContactJpaEntity, Contact, ContactMapper, ContactListResponse, ContactDetailResponse, ContactCategory, ReportResponse, HostAttendeeResponse, OrderJpaRepository

**Frontend:** profile/page.tsx, session/route.ts, Header.tsx, contact-api.ts, admin-api.ts, ContactModal.tsx, ContactTable.tsx, ContactDetailModal.tsx, ContactFilter.tsx, ReportTable.tsx, mypage/contact/page.tsx, host/contact/page.tsx




