### PR TITLE
fix(event/ticket): 안정적인 세션/티켓 수정 및 순서 관리 기능 추가

### DIFF
--- a/backend/src/main/java/com/venueon/community/adapter/out/persistence/entity/CommunityJpaEntity.java
+++ b/backend/src/main/java/com/venueon/community/adapter/out/persistence/entity/CommunityJpaEntity.java
@@ -22,6 +22,7 @@ public class CommunityJpaEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
     private EventJpaEntity event;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/SessionJpaEntity.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/entity/SessionJpaEntity.java
@@ -26,6 +26,7 @@ public class SessionJpaEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
     private EventJpaEntity event;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/entity/OrderJpaEntity.java
@@ -33,10 +33,12 @@ public class OrderJpaEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
     private EventJpaEntity event;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id")
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
     private TicketJpaEntity ticket;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/venueon/ticket/adapter/out/persistence/TicketPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/ticket/adapter/out/persistence/TicketPersistenceAdapter.java
@@ -42,25 +42,17 @@ public class TicketPersistenceAdapter implements TicketRepositoryPort {
             // 수정
             entity = ticketJpaRepository.findById(ticket.getId())
                     .orElseThrow(() -> new IllegalArgumentException("티켓을 찾을 수 없습니다. ID: " + ticket.getId()));
-            // 기존 매핑 삭제
+            
+            // 기존 매핑 삭제 (orphanRemoval = true 에 의해 동작)
             entity.getTicketSessions().clear();
+            
             // 엔티티 필드 업데이트
-            entity = TicketJpaEntity.builder()
-                    .id(entity.getId())
-                    .event(event)
-                    .name(ticket.getName())
-                    .description(ticket.getDescription())
-                    .price(ticket.getPrice())
-                    .originalPrice(ticket.getOriginalPrice())
-                    .maxQuantity(ticket.getMaxQuantity())
-                    .soldCount(ticket.getSoldCount())
-                    .isAllSessions(ticket.getIsAllSessions())
-                    .sortOrder(ticket.getSortOrder())
-                    .isActive(ticket.getIsActive())
-                    .salesStart(ticket.getSalesStart())
-                    .salesEnd(ticket.getSalesEnd())
-                    .createdAt(ticket.getCreatedAt())
-                    .build();
+            entity.update(
+                    ticket.getName(), ticket.getDescription(), ticket.getPrice(),
+                    ticket.getOriginalPrice(), ticket.getMaxQuantity(), ticket.getSoldCount(),
+                    ticket.getIsAllSessions(), ticket.getSortOrder(), ticket.getIsActive(),
+                    ticket.getSalesStart(), ticket.getSalesEnd()
+            );
         } else {
             // 신규 생성
             entity = TicketJpaEntity.builder()
@@ -79,25 +71,22 @@ public class TicketPersistenceAdapter implements TicketRepositoryPort {
                     .build();
         }
 
-        TicketJpaEntity saved = ticketJpaRepository.save(entity);
-
-        // 세션 매핑 저장 (isAllSessions=false인 경우에만)
+        // 세션 매핑 추가 (isAllSessions=false인 경우에만)
         if (!ticket.getIsAllSessions() && sessionIds != null && !sessionIds.isEmpty()) {
             for (Long sessionId : sessionIds) {
                 SessionJpaEntity session = sessionJpaRepository.findById(sessionId)
                         .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다. ID: " + sessionId));
-                ticketSessionJpaRepository.save(
-                        TicketSessionJpaEntity.builder()
-                                .ticket(saved)
-                                .session(session)
-                                .build()
-                );
+                TicketSessionJpaEntity ticketSession = TicketSessionJpaEntity.builder()
+                        .ticket(entity)
+                        .session(session)
+                        .build();
+                entity.getTicketSessions().add(ticketSession);
             }
         }
 
-        return ticketMapper.toDomain(
-                ticketJpaRepository.findById(saved.getId()).orElseThrow()
-        );
+        TicketJpaEntity saved = ticketJpaRepository.save(entity);
+
+        return ticketMapper.toDomain(saved);
     }
 
     @Override

--- a/backend/src/main/java/com/venueon/ticket/adapter/out/persistence/entity/TicketJpaEntity.java
+++ b/backend/src/main/java/com/venueon/ticket/adapter/out/persistence/entity/TicketJpaEntity.java
@@ -26,6 +26,7 @@ public class TicketJpaEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
     private EventJpaEntity event;
 
     @Column(nullable = false, length = 100)
@@ -76,5 +77,19 @@ public class TicketJpaEntity {
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(String name, String description, int price, int originalPrice, Integer maxQuantity, int soldCount, boolean isAllSessions, int sortOrder, boolean isActive, LocalDateTime salesStart, LocalDateTime salesEnd) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.originalPrice = originalPrice;
+        this.maxQuantity = maxQuantity;
+        this.soldCount = soldCount;
+        this.isAllSessions = isAllSessions;
+        this.sortOrder = sortOrder;
+        this.isActive = isActive;
+        this.salesStart = salesStart;
+        this.salesEnd = salesEnd;
     }
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,7 +9,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.config.import=optional:file:../.env[.properties]
 
 # JPA
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 

--- a/frontend/src/app/api/events/[id]/route.ts
+++ b/frontend/src/app/api/events/[id]/route.ts
@@ -43,13 +43,18 @@ export async function PUT(
 
     const body = await request.json();
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-User-Id": userId.toString(),
+      "X-User-Role": userRoleStr,
+    };
+    if (session.jwt) {
+      headers["Authorization"] = `Bearer ${session.jwt}`;
+    }
+
     const response = await fetch(`${BACKEND_URL}/host/events/${id}`, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        "X-User-Id": userId.toString(),
-        "X-User-Role": userRoleStr,
-      },
+      headers,
       body: JSON.stringify(body),
     });
 
@@ -82,12 +87,17 @@ export async function DELETE(
     if (session.role?.id === 1) userRoleStr = "ADMIN";
     else if (session.role?.id === 2) userRoleStr = "USER";
 
+    const headers: Record<string, string> = {
+      "X-User-Id": userId.toString(),
+      "X-User-Role": userRoleStr,
+    };
+    if (session.jwt) {
+      headers["Authorization"] = `Bearer ${session.jwt}`;
+    }
+
     const response = await fetch(`${BACKEND_URL}/host/events/${id}`, {
       method: "DELETE",
-      headers: {
-        "X-User-Id": userId.toString(),
-        "X-User-Role": userRoleStr,
-      },
+      headers,
     });
 
     if (!response.ok) {

--- a/frontend/src/app/api/events/route.ts
+++ b/frontend/src/app/api/events/route.ts
@@ -48,12 +48,17 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-User-Id": userId.toString()
+    };
+    if (session.jwt) {
+      headers["Authorization"] = `Bearer ${session.jwt}`;
+    }
+
     const response = await fetch(`${API_BASE_URL}/host/events`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-User-Id": userId.toString()
-      },
+      headers,
       body: JSON.stringify(body)
     });
 

--- a/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
+++ b/frontend/src/app/events/[id]/_components/EventActionMenu.tsx
@@ -41,9 +41,9 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
       const res = await fetch(`/api/events/${eventId}`, {
         method: 'DELETE',
       });
-      if (!res.ok) throw new Error('세션 삭제에 실패했습니다.');
+      if (!res.ok) throw new Error('이벤트 삭제에 실패했습니다.');
 
-      showToast('세션가 성공적으로 삭제되었습니다.', 'success');
+      showToast('이벤트가 성공적으로 삭제되었습니다.', 'success');
       router.push('/');
       router.refresh();
     } catch (err: any) {
@@ -89,7 +89,7 @@ export default function EventActionMenu({ eventId, creatorId }: Props) {
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
         onConfirm={handleDelete}
-        title="세션 삭제"
+        title="이벤트 삭제"
         subtitle="정말 삭제하시겠습니까? (이 작업은 되돌릴 수 없습니다)"
         confirmText="삭제"
         status="danger"

--- a/frontend/src/app/events/[id]/edit/page.tsx
+++ b/frontend/src/app/events/[id]/edit/page.tsx
@@ -55,18 +55,6 @@ export default async function EventEditPage({ params }: Props) {
     redirect(`/login?redirect=/events/${id}/edit`);
   }
 
-  if (session.role?.id !== 3 && session.role?.id !== 1) {
-    return (
-      <div style={{ textAlign: 'center', padding: '100px 20px' }}>
-        <h2 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>접근 권한이 없습니다</h2>
-        <p style={{ color: '#666' }}>이벤트 수정은 호스트(HOST) 또는 관리자(ADMIN) 계정만 가능합니다.</p>
-        <a href="/" style={{ display: 'inline-block', marginTop: '1.5rem', padding: '0.75rem 1.5rem', background: '#000', color: '#fff', borderRadius: '8px', textDecoration: 'none' }}>
-          홈으로 돌아가기
-        </a>
-      </div>
-    );
-  }
-
   const { id } = await params;
   const [event, tickets] = await Promise.all([
     getEventDetail(id),
@@ -79,6 +67,13 @@ export default async function EventEditPage({ params }: Props) {
         <h2>이벤트를 찾을 수 없습니다.</h2>
       </div>
     );
+  }
+
+  const isAdmin = session.role?.id === 1;
+  const isCreator = session.userId === event.creatorId;
+
+  if (!isAdmin && !isCreator) {
+    redirect(`/events/${id}`);
   }
 
   return (

--- a/frontend/src/app/events/new/_components/EventForm.tsx
+++ b/frontend/src/app/events/new/_components/EventForm.tsx
@@ -62,6 +62,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
   );
   const [categories, setCategories] = useState<{ id: number, name: string }[]>([]);
   const [deletedTicketIds, setDeletedTicketIds] = useState<number[]>([]);
+  const [deletedSessionIds, setDeletedSessionIds] = useState<number[]>([]);
 
   const [formData, setFormData] = useState({
     categoryId: initialData?.categoryId ? String(initialData.categoryId) : '1',
@@ -116,7 +117,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
   const handleFileUpload = async (file: File) => {
     // 이미지 파일 유형 검증
-    if (!file.type.startsWith('image/')) {
+    if (!file.type.startsWith('image/') && !file.name.toLowerCase().match(/\.(png|jpe?g|gif|webp)$/)) {
       showToast('이미지 파일만 업로드 가능합니다.', 'error');
       return;
     }
@@ -241,7 +242,8 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       // 세션 저장 로직
       const savedSessionIds: number[] = [];
       if (hasSession && sessions.length > 0) {
-        for (const session of sessions) {
+        for (let i = 0; i < sessions.length; i++) {
+          const session = sessions[i];
           // 세션 기간: 날짜+시간을 합쳐서 ISO 형식 생성
           let startTime = null;
           let endTime = null;
@@ -267,7 +269,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           const sessionPayload = {
             title: session.title || '새 세션',
             description: session.description || '세션 설명',
-            sortOrder: session.sortOrder || 0,
+            sortOrder: i,
             startTime,
             endTime,
             location: session.useCustomAddress ? session.location : formData.location || '',
@@ -309,19 +311,29 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         }
       }
 
+      // 실제 백엔드 연동을 위한 세션 삭제 처리 (DB에 존재하는 세션만)
+      for (const deletedId of deletedSessionIds) {
+        const dsRes = await fetch(`/api/host/events/${targetId}/sessions/${deletedId}`, { method: 'DELETE' });
+        if (!dsRes.ok) {
+          const dsErr = await dsRes.json().catch(() => ({}));
+          throw new Error(`세션 삭제 실패: ${dsErr.message || "오류가 발생했습니다"}`);
+        }
+      }
+
       // 티켓 저장 로직
       // 1) 삭제된 티켓 처리 (DB에 존재하는 티켓만)
       for (const deletedId of deletedTicketIds) {
-        try {
-          await fetch(`/api/host/tickets/${deletedId}`, { method: 'DELETE' });
-        } catch (e) {
-          console.error(`Failed to delete ticket ${deletedId}:`, e);
+        const dtRes = await fetch(`/api/host/tickets/${deletedId}`, { method: 'DELETE' });
+        if (!dtRes.ok) {
+          const dtErr = await dtRes.json().catch(() => ({}));
+          throw new Error(`티켓 삭제 실패: ${dtErr.message || "오류가 발생했습니다"}`);
         }
       }
 
       // 2) 생성/수정
       if (tickets.length > 0) {
-        for (const t of tickets) {
+        for (let j = 0; j < tickets.length; j++) {
+          const t = tickets[j];
           // 유효성 검증
           if (!t.isAllSessions && (!t.selectedSessionIndices || t.selectedSessionIndices.length === 0)) {
             throw new Error(`"${t.name || '새 티켓'}" 티켓에 포함할 세션을 1개 이상 선택해주세요.`);
@@ -342,7 +354,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             sessionIds: t.isAllSessions
               ? []
               : (t.selectedSessionIndices || []).map((idx: number) => savedSessionIds[idx]).filter((id: any) => id !== undefined),
-            sortOrder: 0,
+            sortOrder: j,
             salesStart: t.salesStart || null,
             salesEnd: t.salesEnd || null,
           };
@@ -371,10 +383,8 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       if (mode === 'create' && !isDraft) {
         // 바로 게시하기 (새로 만들 때만)
-        const publishRes = await fetch(`/api/events/${targetId}/status`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ status: 2 }) // 2 = PUBLISHED
+        const publishRes = await fetch(`/api/host/events/${targetId}/status?status=2`, {
+          method: 'PATCH'
         });
         if (!publishRes.ok) throw new Error('상태 변경 실패');
       }
@@ -387,6 +397,43 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleMoveSession = (index: number, direction: 'up' | 'down') => {
+    if (direction === 'up' && index === 0) return;
+    if (direction === 'down' && index === sessions.length - 1) return;
+
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+
+    // 티켓이 가리키는 인덱스도 같이 스왑해줍니다.
+    const newTickets = tickets.map(t => {
+      if (t.isAllSessions || !t.selectedSessionIndices) return t;
+      const newIndices = t.selectedSessionIndices.map((idx: number) => {
+        if (idx === index) return targetIndex;
+        if (idx === targetIndex) return index;
+        return idx;
+      });
+      return { ...t, selectedSessionIndices: newIndices };
+    });
+    setTickets(newTickets);
+
+    const newSessions = [...sessions];
+    const temp = newSessions[index];
+    newSessions[index] = newSessions[targetIndex];
+    newSessions[targetIndex] = temp;
+    setSessions(newSessions);
+  };
+
+  const handleMoveTicket = (index: number, direction: 'up' | 'down') => {
+    if (direction === 'up' && index === 0) return;
+    if (direction === 'down' && index === tickets.length - 1) return;
+
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    const newTickets = [...tickets];
+    const temp = newTickets[index];
+    newTickets[index] = newTickets[targetIndex];
+    newTickets[targetIndex] = temp;
+    setTickets(newTickets);
   };
 
   return (
@@ -462,7 +509,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/*"
+          accept="image/*, .png, .jpg, .jpeg"
           style={{ display: 'none' }}
           onChange={(e) => {
             if (e.target.files && e.target.files[0]) {
@@ -647,17 +694,59 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
                       </span>
                       세션 {index + 1}
                     </span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const newSessions = [...sessions];
-                        newSessions.splice(index, 1);
-                        setSessions(newSessions);
-                      }}
-                      style={{ background: 'none', border: 'none', color: '#ff4d4f', cursor: 'pointer', fontSize: '0.85rem' }}
-                    >
-                      🗑️ 삭제
-                    </button>
+                    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                      {index > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => handleMoveSession(index, 'up')}
+                          style={{ background: 'none', border: '1px solid #ddd', padding: '0.2rem 0.5rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.85rem' }}
+                        >
+                          ⬆️ 위로
+                        </button>
+                      )}
+                      {index < sessions.length - 1 && (
+                        <button
+                          type="button"
+                          onClick={() => handleMoveSession(index, 'down')}
+                          style={{ background: 'none', border: '1px solid #ddd', padding: '0.2rem 0.5rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.85rem' }}
+                        >
+                          ⬇️ 아래로
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const isSessionUsedInTicket = tickets.some(t => 
+                            !t.isAllSessions && t.selectedSessionIndices && t.selectedSessionIndices.includes(index)
+                          );
+
+                          if (isSessionUsedInTicket) {
+                            alert('티켓에 포함된 세션은 티켓 삭제 후 삭제가능합니다.');
+                            return;
+                          }
+
+                          const newTickets = tickets.map(t => {
+                            if (t.isAllSessions || !t.selectedSessionIndices) return t;
+                            return {
+                              ...t,
+                              selectedSessionIndices: t.selectedSessionIndices.map((idx: number) => idx > index ? idx - 1 : idx)
+                            };
+                          });
+                          setTickets(newTickets);
+
+                          if (sessions[index].id) {
+                            setDeletedSessionIds(prev => [...prev, sessions[index].id]);
+                          }
+
+                          const newSessions = [...sessions];
+                          newSessions.splice(index, 1);
+                          setSessions(newSessions);
+                        }}
+                        style={{ background: 'none', border: 'none', color: '#ff4d4f', cursor: 'pointer', fontSize: '0.85rem' }}
+                      >
+                        🗑️ 삭제
+                      </button>
+                    </div>
                   </div>
 
                   {/* 기본 정보: 제목, 정원, 장소 */}
@@ -929,22 +1018,47 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             {tickets.map((ticket, index) => (
-              <div key={index} style={{ border: '1px solid #ddd', borderRadius: '8px', padding: '1rem', position: 'relative' }}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const removed = tickets[index];
-                    if (removed.id) {
-                      setDeletedTicketIds(prev => [...prev, removed.id]);
-                    }
-                    const newTickets = [...tickets];
-                    newTickets.splice(index, 1);
-                    setTickets(newTickets);
-                  }}
-                  style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'none', border: 'none', color: '#ff4d4f', cursor: 'pointer' }}
-                >
-                  🗑️ 삭제
-                </button>
+              <div key={index} style={{ border: '1px solid #ddd', borderRadius: '8px', padding: '1.5rem', position: 'relative', background: '#fafbfc' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', paddingBottom: '0.75rem', borderBottom: '1px solid #eee' }}>
+                  <span style={{ fontSize: '0.95rem', fontWeight: '700', color: '#333' }}>
+                    티켓 {index + 1}
+                  </span>
+                  <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                    {index > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => handleMoveTicket(index, 'up')}
+                        style={{ background: 'none', border: '1px solid #ddd', padding: '0.2rem 0.5rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.85rem' }}
+                      >
+                        ⬆️ 위로
+                      </button>
+                    )}
+                    {index < tickets.length - 1 && (
+                      <button
+                        type="button"
+                        onClick={() => handleMoveTicket(index, 'down')}
+                        style={{ background: 'none', border: '1px solid #ddd', padding: '0.2rem 0.5rem', borderRadius: '4px', cursor: 'pointer', fontSize: '0.85rem' }}
+                      >
+                        ⬇️ 아래로
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const removed = tickets[index];
+                        if (removed.id) {
+                          setDeletedTicketIds(prev => [...prev, removed.id]);
+                        }
+                        const newTickets = [...tickets];
+                        newTickets.splice(index, 1);
+                        setTickets(newTickets);
+                      }}
+                      style={{ background: 'none', border: 'none', color: '#ff4d4f', cursor: 'pointer', fontSize: '0.85rem' }}
+                    >
+                      🗑️ 삭제
+                    </button>
+                  </div>
+                </div>
                 <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '1fr 1fr' }}>
                   <div style={{ gridColumn: '1 / -1' }}>
                     <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>티켓 이름</label>
@@ -964,10 +1078,10 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
                     <input
                       type="number"
                       min="0"
-                      value={ticket.price || 0}
+                      value={ticket.price === 0 ? '' : ticket.price}
                       onChange={(e) => {
                         const newTickets = [...tickets];
-                        newTickets[index].price = parseInt(e.target.value, 10) || 0;
+                        newTickets[index].price = e.target.value === '' ? 0 : parseInt(e.target.value, 10) || 0;
                         setTickets(newTickets);
                       }}
                       style={{ width: '100%', padding: '0.5rem', border: '1px solid #ddd', borderRadius: '4px' }}
@@ -1017,6 +1131,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
                     <label style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.3rem', fontWeight: 'bold' }}>수량 제한 <span style={{ fontWeight: 'normal', color: '#666' }}>(비우면 무제한)</span></label>
                     <input
                       type="number"
+                      min="0"
                       value={ticket.maxQuantity || ''}
                       onChange={(e) => {
                         const newTickets = [...tickets];


### PR DESCRIPTION
VO-840
VO-842
VO-844
VO-845
VO-846
VO-853
VO-860
VO-861

### 🚀 변경 사항 요약 (Bug Fixes & Refactoring)

**1. 이벤트 생성 & 접근 관련 치명적 버그 수정**
- **권한 외 이벤트 수정 페이지 접근 방지:** 호스트 본인 또는 어드민(Admin)이 아닌 계정으로 이벤트 수정 페이지(`/[id]/edit`)에 접근 시, 비정상적으로 렌더링되던 문제를 수정하고 상세 페이지로 강제 리다이렉트 되도록 안전장치 반영.
- **이미지 업로드 `.png` 확장자 불가 버그 해결:** 백엔드 또는 폼 체크에서 png 파일 포맷이 거부되는 현상 해결.
- **이벤트 생성 시 상태 변경(Status) 오류 (404/400) 수정:** 이벤트 생성(게시)과 동시에 올바른 상태 API를 콜하여 정상처리되도록 로직 안정화.

**2. 입력 폼 UX 및 데이터 정합성 이슈 해결**
- **가격 입력 시 "0" 노출 버그 방지:** 새로운 가격 입력 시, 기존 `0` 이 화면에 계속 노출되면서 입력값을 방해하던 문제 수정.
- **티켓/수량 부분 음수(마이너스) 입력 불가 처리:** 수량 폼에서 `-` 값이 입력되던 것을 완전히 차단하여 데이터 무결성을 보장하도록 개선.

**3. 이벤트 & 세션 삭제 정합성 파이프라인 구축**
- **이벤트 액션 모달 문구 오류 수정:** 이벤트 삭제 버튼을 눌렀음에도 "세션을 삭제하시겠습니까?"라고 표기되던 UI의 오탈자(Typo) 수정.
- **세션 미삭제 및 400 Bad Request 에러 해결:** 폼 내부 표면적으로만 지워지고 실제 백엔드에서는 지워지지 않던 현상을 수정.
- **티켓-세션 의존성 방어 로직 (안전 알림):** "티켓에 포함된 세션은 티켓 삭제 후 세션을 삭제할 수 있습니다."라는 경고(Alert) 시스템을 도입. 연관된 티켓이 없다면 정상적으로 세션 및 DB 정보를 날리도록 동기화.

**4. 세션 & 티켓 순서 관리 및 레이아웃 개선**
- **순서 변경 기능 (UI & DB Sync):** 
  - 세션과 티켓 목록 각각에 `[⬆️ 위로]`, `[⬇️ 아래로]` 이동 버튼 추가.
  - UI에서 위치를 바꿀 시, 해당하는 인덱스가 즉각적으로 백엔드의 `sortOrder` 에도 반영되도록 맵핑 페이로드 전송 로직 수정.
- **티켓 박스 UI 레이아웃 오버랩 버그 수정:** Absolute 속성으로 인하여 삭제/이동 버튼이 '티켓 이름' 입력칸과 겹쳐 UI가 깨지던 현상을 Flexbox 기반 카드 헤더 방식으로 리팩토링.
- **수정 페이지 이동 시 티켓->세션 매핑 해제 버그 해결:** 기존 JPA 엔티티를 덮어쓰며 `orphanRemoval=true` 연관관계 파괴로 인한 DB 무시 오류 발생 방지를 위해, `.update()` 와 `.add()` 방식으로 백엔드 저장 로직 완벽 수정.

**5. 데이터베이스 환경 설정**
- **로컬 DB DDL 정책 변경:** `application-dev.properties`의 `ddl-auto: create` 설정을 `update`로 변경하여 잦은 서버 재시작으로 인한 데이터 소실 방지.

### 📝 관련된 Jira 이슈
* [VO-840] 


[VO-840]: https://venueon.atlassian.net/browse/VO-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ