### PR TITLE
fix: 비밀번호 변경 및 계정 탈퇴 버그 수정 fix #VO-852 fix #VO-855

### DIFF
--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -31,10 +31,10 @@ public class UserPersistenceAdapter implements UserRepositoryPort {
         if (user.getId() != null) {
             entity = userJpaRepository.findWithCategoriesById(user.getId()).orElse(userMapper.toEntity(user, roleEntity));
             entity.updateProfile(user.getNickname(), user.getProfileImg());
+            entity.updatePassword(user.getPassword());
             entity.updateBadgeVisibility(user.isBadgeVisible());
-            // Here we should also ideally allow updating role, but keeping existing logic as is unless role update is needed
             if (!user.isActive()) {
-                entity.softDelete();
+                entity.softDelete(user.getEmail());
             }
         } else {
             entity = userMapper.toEntity(user, roleEntity);

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/entity/UserJpaEntity.java
@@ -73,6 +73,10 @@ public class UserJpaEntity {
         this.profileImg = profileImg;
     }
 
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void updateBadgeVisibility(boolean isBadgeVisible) {
         this.isBadgeVisible = isBadgeVisible;
     }
@@ -84,9 +88,10 @@ public class UserJpaEntity {
         }
     }
 
-    public void softDelete() {
+    public void softDelete(String newEmail) {
         this.isActive = false;
-        // Optionally clear personal info or change email to prevent re-join blocks if required
-        // this.email = "deleted_" + this.id + "_" + this.email;
+        if (newEmail != null) {
+            this.email = newEmail;
+        }
     }
 }

--- a/backend/src/main/java/com/venueon/user/domain/model/User.java
+++ b/backend/src/main/java/com/venueon/user/domain/model/User.java
@@ -114,6 +114,7 @@ public class User {
      */
     public void deactivate() {
         this.active = false;
+        this.email = "deleted_" + System.currentTimeMillis() + "_" + this.email;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -15,6 +15,7 @@ import styles from './page.module.css';
 
 export default function ProfileSettingsPage() {
   const { showToast } = useUIStore();
+  const { logout } = useAuth();
   const router = useRouter();
 
   const [baseImage, setBaseImage] = useState<string | undefined>(undefined);
@@ -241,6 +242,7 @@ export default function ProfileSettingsPage() {
       const res = await fetch('/api/users/me', { method: 'DELETE' });
       if (res.ok) {
         showToast('계정이 안전하게 탈퇴 처리되었습니다.', 'success');
+        await logout(); // 로그아웃 처리하여 세션 파기
         router.push('/');
       } else {
         showToast('탈퇴 처리 중 오류가 발생했습니다.', 'error');


### PR DESCRIPTION

## 🔗 관련 이슈
close #VO-852
close  #VO-855 

## 📌 개요
- 비밀번호 변경 시 DB에 반영되지 않는 문제 해결
- 계정 탈퇴 시 로그인 세션이 유지되는 문제 및 동일 이메일 재가입 불가 문제 해결

## 🛠️ 작업 내용
- **비밀번호 변경 로직 (Backend)**
  - `UserJpaEntity`에 변경된 비밀번호를 업데이트할 수 있는 `updatePassword()` 메서드 추가
  - `UserPersistenceAdapter`의 `save()` 메서드에서 JPA 객체 저장 시 도메인 객체의 비밀번호 변경분을 올바르게 연동하도록 수정

- **계정 탈퇴 로직 (Frontend & Backend)**
  - (Frontend) 탈퇴 성공 즉시 백그라운드에서 `logout()` 함수를 호출하여 상태 관리를 초기화하고 자동 로그아웃되도록 안전장치 추가
  - (Backend) DB에서 `UserJpaEntity`를 Soft Delete 처리할 때, 기존 이메일 앞에 `deleted_{timestamp}_` 프리픽스(prefix)를 붙여 덮어씌움으로써 기존 사용자가 동일 이메일로 다시 가입할 수 있도록 조치

