### PR TITLE
feat: 메인페이지 이벤트 필터/UI 고도화 및 호스트 닉네임 표출

### DIFF
--- a/backend/src/main/java/com/venueon/event/adapter/in/web/EventController.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/EventController.java
@@ -46,12 +46,14 @@ public class EventController {
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String type,
             @RequestParam(required = false) Boolean isOnline,
+            @RequestParam(required = false) Long recruitmentStatusId,
+            @RequestParam(required = false) Long eventStatusId,
             @RequestParam(required = false, defaultValue = "latest") String sort,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "12") int size
     ) {
         EventSearchCondition condition = new EventSearchCondition(
-                keyword, categoryId, type, isOnline, sort
+                keyword, categoryId, type, isOnline, recruitmentStatusId, eventStatusId, sort
         );
 
         Pageable pageable = createPageable(page, size, sort);
@@ -73,11 +75,21 @@ public class EventController {
         Map<Long, List<Ticket>> ticketsByEventId = allTickets.stream()
                 .collect(Collectors.groupingBy(Ticket::getEventId));
 
+        // 호스트 정보 벌크 조회
+        List<Long> creatorIds = eventPage.getContent().stream()
+                .map(Event::getCreatorId)
+                .distinct()
+                .toList();
+        List<HostInfo> hostInfos = eventQueryService.getHostInfosByCreatorIds(creatorIds);
+        Map<Long, String> hostNameMap = hostInfos.stream()
+                .collect(Collectors.toMap(HostInfo::userId, HostInfo::orgName));
+
         Page<EventListResponse> result = eventPage.map(event ->
                 EventListResponse.from(
                         event,
                         sessionsByEventId.getOrDefault(event.getId(), List.of()),
-                        ticketsByEventId.getOrDefault(event.getId(), List.of())
+                        ticketsByEventId.getOrDefault(event.getId(), List.of()),
+                        hostNameMap.getOrDefault(event.getCreatorId(), "호스트 " + event.getCreatorId())
                 )
         );
 

--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
@@ -20,6 +20,7 @@ public record EventListResponse(
         com.venueon.common.dto.CodeDto recruitmentStatus,   // 모집상태 (세션 종합)
         Long categoryId,
         Long creatorId,
+        String creatorName,
         LocalDateTime createdAt,
         boolean hasSession,
         LocalDateTime startDate,               // 세션 최소 시작일
@@ -34,21 +35,21 @@ public record EventListResponse(
     /**
      * 세션 정보 없이 생성 (fallback)
      */
-    public static EventListResponse from(Event event) {
-        return from(event, List.of(), List.of());
+    public static EventListResponse from(Event event, String creatorName) {
+        return from(event, List.of(), List.of(), creatorName);
     }
 
     /**
      * 세션만 있는 경우 (하위 호환)
      */
-    public static EventListResponse from(Event event, List<Session> sessions) {
-        return from(event, sessions, List.of());
+    public static EventListResponse from(Event event, List<Session> sessions, String creatorName) {
+        return from(event, sessions, List.of(), creatorName);
     }
 
     /**
      * 세션 + 티켓 정보를 받아 전체 Computed 필드 계산
      */
-    public static EventListResponse from(Event event, List<Session> sessions, List<Ticket> tickets) {
+    public static EventListResponse from(Event event, List<Session> sessions, List<Ticket> tickets, String creatorName) {
         LocalDateTime startDate = null;
         LocalDateTime endDate = null;
         com.venueon.common.model.DomainCode effectiveStatus = event.getStatus();
@@ -122,6 +123,7 @@ public record EventListResponse(
                 recruitmentStatus != null ? com.venueon.common.dto.CodeDto.of(recruitmentStatus.id(), recruitmentStatus.label()) : null,
                 event.getCategoryId(),
                 event.getCreatorId(),
+                creatorName,
                 event.getCreatedAt(),
                 event.getHasSession(),
                 startDate,

--- a/backend/src/main/java/com/venueon/event/adapter/out/internal/HostInfoAdapter.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/internal/HostInfoAdapter.java
@@ -39,4 +39,25 @@ public class HostInfoAdapter implements LoadHostInfoPort {
                 hostProfileOpt.map(HostProfileJpaEntity::getOrgDescription).orElse(null)
         ));
     }
+    @Override
+    public java.util.List<HostInfo> findByUserIds(java.util.List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return java.util.List.of();
+        
+        java.util.List<UserJpaEntity> users = userJpaRepository.findAllById(userIds);
+        java.util.List<HostProfileJpaEntity> hostProfiles = hostProfileJpaRepository.findByUserIdIn(userIds);
+        
+        java.util.Map<Long, HostProfileJpaEntity> profileMap = hostProfiles.stream()
+                .collect(java.util.stream.Collectors.toMap(p -> p.getUser().getId(), p -> p));
+                
+        return users.stream().map(user -> {
+            HostProfileJpaEntity profile = profileMap.get(user.getId());
+            return new HostInfo(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImg(),
+                    (profile != null && profile.getOrgName() != null) ? profile.getOrgName() : user.getNickname(),
+                    profile != null ? profile.getOrgDescription() : null
+            );
+        }).toList();
+    }
 }

--- a/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/event/adapter/out/persistence/EventPersistenceAdapter.java
@@ -16,6 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import com.venueon.event.adapter.out.persistence.entity.SessionJpaEntity;
+
+
 /**
  * EventRepositoryPort 구현체 — JPA 연동
  */
@@ -95,7 +100,104 @@ public class EventPersistenceAdapter implements EventRepositoryPort {
                 }
             }
 
-            // TODO: isOnline 필터 — 세션 JOIN 기반으로 재구현 예정 (EventJpaEntity에 sessions 관계 매핑 추가 후)
+            // isOnline 필터 — 세션 JOIN 기반
+            if (condition.isOnline() != null) {
+                Subquery<Integer> sq = query.subquery(Integer.class);
+                Root<SessionJpaEntity> session = sq.from(SessionJpaEntity.class);
+                sq.select(cb.literal(1));
+                sq.where(
+                        cb.equal(session.get("event").get("id"), root.get("id")),
+                        cb.equal(session.get("isOnline"), condition.isOnline())
+                );
+                predicates.add(cb.exists(sq));
+            }
+
+            // 모집상태 필터 (recruitmentStatusId)
+            if (condition.recruitmentStatusId() != null) {
+                Subquery<Integer> sq = query.subquery(Integer.class);
+                Root<SessionJpaEntity> session = sq.from(SessionJpaEntity.class);
+                sq.select(cb.literal(1));
+
+                java.time.LocalDateTime now = java.time.LocalDateTime.now();
+                Predicate statusPredicate = null;
+
+                if (condition.recruitmentStatusId() == 1L) { // 모집예정 (PENDING)
+                    statusPredicate = cb.and(
+                            cb.isNotNull(session.get("recruitStartDate")),
+                            cb.greaterThan(session.get("recruitStartDate"), now)
+                    );
+                } else if (condition.recruitmentStatusId() == 2L) { // 모집중 (OPEN)
+                    statusPredicate = cb.and(
+                            cb.or(cb.isNull(session.get("isRecruitmentClosed")), cb.isFalse(session.get("isRecruitmentClosed"))),
+                            cb.or(
+                                    cb.equal(session.get("maxAttendees"), 0),
+                                    cb.lessThan(session.get("currentAttendees"), session.get("maxAttendees"))
+                            ),
+                            cb.or(cb.isNull(session.get("recruitStartDate")), cb.lessThanOrEqualTo(session.get("recruitStartDate"), now)),
+                            cb.or(cb.isNull(session.get("recruitEndDate")), cb.greaterThanOrEqualTo(session.get("recruitEndDate"), now))
+                    );
+                } else if (condition.recruitmentStatusId() == 3L) { // 모집마감 (CLOSED)
+                    statusPredicate = cb.or(
+                            cb.isTrue(session.get("isRecruitmentClosed")),
+                            cb.and(cb.greaterThan(session.get("maxAttendees"), 0), cb.greaterThanOrEqualTo(session.get("currentAttendees"), session.get("maxAttendees"))),
+                            cb.and(cb.isNotNull(session.get("recruitEndDate")), cb.lessThan(session.get("recruitEndDate"), now))
+                    );
+                }
+
+                if (statusPredicate != null) {
+                    jakarta.persistence.criteria.Join<Object, Object> forcedRecruitJoin = session.join("forcedRecruitmentStatus", jakarta.persistence.criteria.JoinType.LEFT);
+                    sq.where(
+                            cb.equal(session.get("event").get("id"), root.get("id")),
+                            cb.or(
+                                    cb.equal(forcedRecruitJoin.get("id"), condition.recruitmentStatusId()),
+                                    cb.and(cb.isNull(session.get("forcedRecruitmentStatus")), statusPredicate)
+                            )
+                    );
+                    predicates.add(cb.exists(sq));
+                }
+            }
+
+            // 메인 페이지 이벤트 상태 필터 (eventStatusId)
+            if (condition.eventStatusId() != null) {
+                Subquery<Integer> sq = query.subquery(Integer.class);
+                Root<SessionJpaEntity> session = sq.from(SessionJpaEntity.class);
+                sq.select(cb.literal(1));
+
+                java.time.LocalDateTime now = java.time.LocalDateTime.now();
+                Predicate statusPredicate = null;
+
+                if (condition.eventStatusId() == 2L) { // 진행예정 / 발행됨 (PUBLISHED)
+                    statusPredicate = cb.or(
+                            cb.isNull(session.get("startTime")),
+                            cb.greaterThan(session.get("startTime"), now)
+                    );
+                } else if (condition.eventStatusId() == 3L) { // 진행중 (ONGOING)
+                    statusPredicate = cb.and(
+                            cb.isNotNull(session.get("startTime")),
+                            cb.isNotNull(session.get("endTime")),
+                            cb.lessThanOrEqualTo(session.get("startTime"), now),
+                            cb.greaterThanOrEqualTo(session.get("endTime"), now)
+                    );
+                } else if (condition.eventStatusId() == 4L) { // 종료됨 (ENDED)
+                    statusPredicate = cb.and(
+                            cb.isNotNull(session.get("endTime")),
+                            cb.lessThan(session.get("endTime"), now)
+                    );
+                }
+
+                if (statusPredicate != null) {
+                    jakarta.persistence.criteria.Join<Object, Object> forcedSessionJoin = session.join("forcedSessionStatus", jakarta.persistence.criteria.JoinType.LEFT);
+                    sq.where(
+                            cb.equal(session.get("event").get("id"), root.get("id")),
+                            cb.or(
+                                    cb.equal(forcedSessionJoin.get("id"), condition.eventStatusId()),
+                                    cb.and(cb.isNull(session.get("forcedSessionStatus")), statusPredicate)
+                            )
+                    );
+                    predicates.add(cb.exists(sq));
+                }
+            }
+
             // TODO: 지역(regionSido/regionSigungu) 필터 — 세션 JOIN 기반으로 추가 예정
 
             return cb.and(predicates.toArray(new Predicate[0]));

--- a/backend/src/main/java/com/venueon/event/application/port/in/GetEventListUseCase.java
+++ b/backend/src/main/java/com/venueon/event/application/port/in/GetEventListUseCase.java
@@ -21,10 +21,12 @@ public interface GetEventListUseCase {
             Long categoryId,
             String type,
             Boolean isOnline,       // 세션 기반 필터 (향후 JOIN)
+            Long recruitmentStatusId, // 모집 상태 필터
+            Long eventStatusId,       // 이벤트 진행 상태 필터
             String sort
     ) {
         public static EventSearchCondition empty() {
-            return new EventSearchCondition(null, null, null, null, null);
+            return new EventSearchCondition(null, null, null, null, null, null, null);
         }
     }
 }

--- a/backend/src/main/java/com/venueon/event/application/port/out/LoadHostInfoPort.java
+++ b/backend/src/main/java/com/venueon/event/application/port/out/LoadHostInfoPort.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface LoadHostInfoPort {
 
     Optional<HostInfo> findByUserId(Long userId);
+    java.util.List<HostInfo> findByUserIds(java.util.List<Long> userIds);
 
     /**
      * 호스트 정보 Value Object

--- a/backend/src/main/java/com/venueon/event/application/service/EventQueryService.java
+++ b/backend/src/main/java/com/venueon/event/application/service/EventQueryService.java
@@ -38,4 +38,8 @@ public class EventQueryService implements GetEventListUseCase, GetEventDetailUse
     public HostInfo getHostInfoByCreatorId(Long creatorId) {
         return loadHostInfoPort.findByUserId(creatorId).orElse(null);
     }
+    
+    public java.util.List<HostInfo> getHostInfosByCreatorIds(java.util.List<Long> creatorIds) {
+        return loadHostInfoPort.findByUserIds(creatorIds);
+    }
 }

--- a/backend/src/main/java/com/venueon/user/adapter/out/persistence/repository/HostProfileJpaRepository.java
+++ b/backend/src/main/java/com/venueon/user/adapter/out/persistence/repository/HostProfileJpaRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface HostProfileJpaRepository extends JpaRepository<HostProfileJpaEntity, Long> {
 
     Optional<HostProfileJpaEntity> findByUserId(Long userId);
+    java.util.List<HostProfileJpaEntity> findByUserIdIn(java.util.List<Long> userIds);
 }

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -61,19 +61,38 @@
 
 .filterSection {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+  width: 100%;
+}
+
+.filterBar {
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  gap: var(--space-16);
 }
 
 .searchBox {
   width: 400px;
+  flex-shrink: 0;
 }
 
-.tagGroup {
+.dropdownGroup {
   display: flex;
+  flex-direction: row;
   gap: var(--space-8);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.activeFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  min-height: 38px;
 }
 
 .content {
@@ -109,10 +128,16 @@
     height: 250px;
   }
 
-  .filterSection {
+  .filterBar {
     flex-direction: column;
-    gap: var(--space-16);
     align-items: flex-start;
+  }
+
+  .dropdownGroup {
+    width: 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
   }
 
   .searchBox {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
-import { Card, CardGrid, InputField, Tabs, Pagination } from '@/components/ui';
+import { Card, CardGrid, InputField, Tabs, Pagination, FilterDropdown, FilterChip } from '@/components/ui';
 import { format } from 'date-fns';
 
 
@@ -16,6 +16,7 @@ interface EventData {
   recruitmentStatus: { id: number; label: string };
   categoryId: number;
   creatorId: number;
+  creatorName: string;
   createdAt: string;
   hasSession: boolean;
   minPrice: number | null;
@@ -36,10 +37,33 @@ export default function Home() {
   const [totalPages, setTotalPages] = useState(1);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('all');
+  const [activeIsOnline, setActiveIsOnline] = useState('all');
+  const [activeRecruitmentStatus, setActiveRecruitmentStatus] = useState('all');
+  const [activeEventStatus, setActiveEventStatus] = useState('all');
 
   const [categoryOptions, setCategoryOptions] = useState<{value: string, label: string}[]>([
-    { value: 'all', label: '전체보기' }
+    { value: 'all', label: '카테고리: 전체' }
   ]);
+
+  const isOnlineOptions = [
+    { value: 'all', label: '온/오프라인: 전체' },
+    { value: 'true', label: '온라인' },
+    { value: 'false', label: '오프라인' }
+  ];
+
+  const recruitmentOptions = [
+    { value: 'all', label: '모집상태: 전체' },
+    { value: '1', label: '모집예정' },
+    { value: '2', label: '모집중' },
+    { value: '3', label: '모집마감' }
+  ];
+
+  const eventStatusOptions = [
+    { value: 'all', label: '진행상태: 전체' },
+    { value: '2', label: '진행예정' },
+    { value: '3', label: '진행중' },
+    { value: '4', label: '종료됨' }
+  ];
 
   useEffect(() => {
     const fetchCategories = async () => {
@@ -51,7 +75,7 @@ export default function Home() {
             value: String(c.id),
             label: c.name
           }));
-          setCategoryOptions([{ value: 'all', label: '전체보기' }, ...opts]);
+          setCategoryOptions([{ value: 'all', label: '카테고리: 전체' }, ...opts]);
         }
       } catch (error) {
         console.error('Failed to fetch categories:', error);
@@ -60,7 +84,14 @@ export default function Home() {
     fetchCategories();
   }, []);
 
-  const fetchEvents = async (page: number, keyword: string = '', categoryId: string = 'all') => {
+  const fetchEvents = async (
+      page: number, 
+      keyword: string = '', 
+      categoryId: string = 'all',
+      isOnline: string = 'all',
+      recruitmentStatusId: string = 'all',
+      eventStatusId: string = 'all'
+    ) => {
     setLoading(true);
     try {
       // Backend pagination is 0-indexed, UI is 1-indexed
@@ -70,6 +101,15 @@ export default function Home() {
       }
       if (categoryId !== 'all') {
         url += `&categoryId=${categoryId}`;
+      }
+      if (isOnline !== 'all') {
+        url += `&isOnline=${isOnline}`;
+      }
+      if (recruitmentStatusId !== 'all') {
+        url += `&recruitmentStatusId=${recruitmentStatusId}`;
+      }
+      if (eventStatusId !== 'all') {
+        url += `&eventStatusId=${eventStatusId}`;
       }
 
       const res = await fetch(url);
@@ -103,14 +143,14 @@ export default function Home() {
   };
 
   useEffect(() => {
-    fetchEvents(currentPage, searchQuery, activeCategory);
-  }, [currentPage, activeCategory]);
+    fetchEvents(currentPage, searchQuery, activeCategory, activeIsOnline, activeRecruitmentStatus, activeEventStatus);
+  }, [currentPage, activeCategory, activeIsOnline, activeRecruitmentStatus, activeEventStatus]);
 
   // Handle Search Submit
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       setCurrentPage(1);
-      fetchEvents(1, searchQuery, activeCategory);
+      fetchEvents(1, searchQuery, activeCategory, activeIsOnline, activeRecruitmentStatus, activeEventStatus);
     }
   };
 
@@ -139,22 +179,65 @@ export default function Home() {
 
         {/* 필터 및 검색 섹션 */}
         <section className={styles.filterSection}>
-          <div className={styles.searchBox}>
-            <InputField
-              variant="search"
-              placeholder="검색어를 입력하세요"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={handleSearch}
-            />
+          <div className={styles.filterBar}>
+            <div className={styles.searchBox}>
+              <InputField
+                variant="search"
+                placeholder="검색어를 입력하세요"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleSearch}
+              />
+            </div>
+            <div className={styles.dropdownGroup}>
+              <FilterDropdown
+                options={categoryOptions}
+                value={activeCategory}
+                onChange={(val) => { setActiveCategory(val); setCurrentPage(1); }}
+              />
+              <FilterDropdown
+                options={isOnlineOptions}
+                value={activeIsOnline}
+                onChange={(val) => { setActiveIsOnline(val); setCurrentPage(1); }}
+              />
+              <FilterDropdown
+                options={recruitmentOptions}
+                value={activeRecruitmentStatus}
+                onChange={(val) => { setActiveRecruitmentStatus(val); setCurrentPage(1); }}
+              />
+              <FilterDropdown
+                options={eventStatusOptions}
+                value={activeEventStatus}
+                onChange={(val) => { setActiveEventStatus(val); setCurrentPage(1); }}
+              />
+            </div>
           </div>
-          <div className={styles.tagGroup}>
-            <Tabs
-              variant="pill"
-              options={categoryOptions}
-              activeValue={activeCategory}
-              onChange={(val) => setActiveCategory(val)}
-            />
+
+          <div className={styles.activeFilters}>
+            {activeCategory !== 'all' && (
+              <FilterChip 
+                label={categoryOptions.find(o => o.value === activeCategory)?.label || ''} 
+                onClose={() => setActiveCategory('all')} 
+              />
+            )}
+            {activeIsOnline !== 'all' && (
+              <FilterChip 
+                label={isOnlineOptions.find(o => o.value === activeIsOnline)?.label || ''} 
+                onClose={() => setActiveIsOnline('all')} 
+              />
+            )}
+            {activeRecruitmentStatus !== 'all' && (
+              <FilterChip 
+                label={recruitmentOptions.find(o => o.value === activeRecruitmentStatus)?.label || ''} 
+                onClose={() => setActiveRecruitmentStatus('all')} 
+              />
+            )}
+            {activeEventStatus !== 'all' && (
+              <FilterChip 
+                label={eventStatusOptions.find(o => o.value === activeEventStatus)?.label || ''} 
+                onClose={() => setActiveEventStatus('all')} 
+              />
+            )}
           </div>
         </section>
 
@@ -196,10 +279,10 @@ export default function Home() {
                       eventId={event.id}
                       isWishlistedProp={wishlistSet.has(event.id)}
                       imageUrl={event.thumbnailUrl ? `/upload/${event.thumbnailUrl}` : ''}
-                      organizer={`호스트 ${event.creatorId}`} // 백엔드 조인 시 실제 이름으로 변경
+                      organizer={event.creatorName || `호스트 ${event.creatorId}`}
                       dateTime={dateTimeStr}
                       location={event.isOnline ? '온라인 (Zoom 등)' : (event.primaryLocation || '장소 미정')}
-                      price={event.minPrice !== null ? (event.hasDiscount ? `${event.minPrice.toLocaleString()}원` : event.minPrice) : 0}
+                      price={event.minPrice !== null ? event.minPrice : 0}
                       originalPrice={event.hasDiscount && event.originalPrice ? event.originalPrice : undefined}
                       status={event.status?.label || 'DRAFT'}
                       recruitmentStatus={event.recruitmentStatus?.label || 'PENDING'}

--- a/frontend/src/components/ui/Card.module.css
+++ b/frontend/src/components/ui/Card.module.css
@@ -169,6 +169,12 @@
   gap: var(--space-8);
 }
 
+.discountRate {
+  font: var(--text-h2-bold);
+  color: var(--color-error);
+  margin: 0;
+}
+
 .originalPrice {
   font: var(--text-body-regular);
   color: var(--color-text-gray-500);

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -65,6 +65,10 @@ export default function Card({
       ? `₩${price.toLocaleString()}`
       : price;
 
+  const discountRate = originalPrice && typeof originalPrice === 'number' && typeof price === 'number' && originalPrice > 0 
+    ? Math.round(((originalPrice - price) / originalPrice) * 100) 
+    : null;
+
   return (
     <div className={styles.card}>
       <div className={styles.header}>
@@ -154,6 +158,9 @@ export default function Card({
       </div>
 
       <div className={styles.priceSection}>
+        {discountRate !== null && discountRate > 0 && (
+          <span className={styles.discountRate}>{discountRate}%</span>
+        )}
         {originalPrice && (
           <span className={styles.originalPrice}>
             {typeof originalPrice === 'number' ? `₩${originalPrice.toLocaleString()}` : originalPrice}

--- a/frontend/src/components/ui/FilterChip.module.css
+++ b/frontend/src/components/ui/FilterChip.module.css
@@ -1,0 +1,43 @@
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background-color: transparent;
+  border: 1px solid var(--color-text-gray-300);
+  border-radius: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-gray-900);
+  transition: all 0.2s ease;
+}
+
+.chip:hover {
+  background-color: var(--color-surface);
+  border-color: var(--color-text-gray-500);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--color-text-gray-500);
+  cursor: pointer;
+  transition: all 0.2s;
+  padding: 0;
+  border: none;
+}
+
+.closeButton:hover {
+  background-color: rgba(0, 0, 0, 0.15);
+  color: var(--color-text-gray-900);
+}
+
+.icon {
+  width: 8px;
+  height: 8px;
+}

--- a/frontend/src/components/ui/FilterChip.tsx
+++ b/frontend/src/components/ui/FilterChip.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import styles from './FilterChip.module.css';
+
+interface FilterChipProps {
+  label: string;
+  onClose: () => void;
+}
+
+export default function FilterChip({ label, onClose }: FilterChipProps) {
+  return (
+    <div className={styles.chip}>
+      <span>{label}</span>
+      <button className={styles.closeButton} onClick={onClose} aria-label="필터 해제">
+        <svg className={styles.icon} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10.5 3.5L3.5 10.5M3.5 3.5L10.5 10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/FilterDropdown.module.css
+++ b/frontend/src/components/ui/FilterDropdown.module.css
@@ -1,0 +1,44 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: max-content;
+}
+
+.triggerButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-8);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color var(--transition);
+  border-radius: var(--radius-md);
+}
+
+.triggerButton:hover {
+  background-color: var(--color-surface); /* #F3F4F6 */
+}
+
+.textSelected {
+  font: var(--text-body-medium);
+  font-weight: 500;
+  color: var(--color-text-gray-700);
+}
+
+.iconWrapper {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--color-text-gray-500);
+  transition: transform var(--transition);
+}
+
+.iconExpanded {
+  transform: rotate(180deg);
+}

--- a/frontend/src/components/ui/FilterDropdown.tsx
+++ b/frontend/src/components/ui/FilterDropdown.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import styles from './FilterDropdown.module.css';
+import { ArrowDownIcon } from '@/components/icons';
+import PopoverMenu from './PopoverMenu';
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+}
+
+export interface FilterDropdownProps {
+  options: DropdownOption[];
+  value?: string;
+  onChange?: (val: string) => void;
+  className?: string;
+}
+
+export default function FilterDropdown({
+  options,
+  value,
+  onChange,
+  className = ''
+}: FilterDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // 현재 선택된 객체 찾기
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  // 바깥 클릭 감지
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleSelect = (val: string) => {
+    if (onChange) {
+      onChange(val);
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={`${styles.wrapper} ${className}`.trim()} ref={wrapperRef}>
+      <button 
+        className={styles.triggerButton} 
+        onClick={() => setIsOpen(!isOpen)}
+        type="button"
+      >
+        <span className={styles.textSelected}>
+          {selectedOption ? selectedOption.label : '옵션 선택'}
+        </span>
+        <div className={`${styles.iconWrapper} ${isOpen ? styles.iconExpanded : ''}`}>
+          <ArrowDownIcon />
+        </div>
+      </button>
+
+      {isOpen && (
+        <PopoverMenu
+          items={options}
+          onSelect={handleSelect}
+          onClose={() => setIsOpen(false)}
+          selectedValue={value}
+          width="max-content"
+          style={{ top: '100%', left: 0, marginTop: '4px' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -20,4 +20,6 @@ export { default as CommentInput } from './CommentInput';
 export { default as ReviewItem } from './ReviewItem';
 export { default as PopoverMenu } from './PopoverMenu';
 export { default as FilePreviewList } from './FilePreviewList';
+export { default as FilterChip } from './FilterChip';
+export { default as FilterDropdown } from './FilterDropdown';
 export * from './Table';


### PR DESCRIPTION
VO-847
VO-848
VO-849
VO-850
VO-864

## 변경 사항

1. **메인페이지 검색 필터 고도화**
- 카테고리, 온/오프라인, 모집상태, 진행상태 필터를 가로로 배치 (모집/진행 상태 스펙 수정)
- 필터를 독립적인 `FilterDropdown` 컴포넌트로 분리하고 텍스트 형태의 세련된 UI 적용
- 선택된 필터들만 하단에 테두리형 `FilterChip` 형태로 노출되게 개선

2. **이벤트 리스트 아이템 컴포넌트(Card) 수정**
- 백엔드에서 `creatorName`(호스트 닉네임 또는 기관명)을 N+1 문제 없이 Batch Fetching으로 응답에 추가하여 `Card` 컴포넌트에 넘겨주도록 처리 (호스트 ID 대신 노출)
- 할인된 이벤트인 경우, 기존 가격 옆에 빨간색으로 포인트되는 **할인률(%)**이 렌더링되게 표출 추가

## 해결 방안 및 문제점
- Next.js의 `revalidate: 60` 캐시 문제로 `creatorName` 데이터가 갱신되지 못하던 이슈를 해결하였습니다.