### PR TITLE
fix: 전역 헤더 버튼 수정

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -63,6 +63,7 @@ export default function Header({
     if (roleId === 1 || roleLabel === 'admin') {
       return (
         <div className={styles.actionGroup}>
+          <Link href="/host"><Button variant="outlined" size="medium">호스트 센터</Button></Link>
           <Link href="/admin"><Button variant="outlined" size="medium">어드민 센터</Button></Link>
           <Link href="/community"><Button variant="outlined" size="medium">커뮤니티</Button></Link>
           <Link href="/mypage/profile">
@@ -77,7 +78,7 @@ export default function Header({
     if (roleId === 3 || roleLabel === 'host') {
       return (
         <div className={styles.actionGroup}>
-          <Link href="/host/dashboard"><Button variant="outlined" size="medium">호스트 센터</Button></Link>
+          <Link href="/host"><Button variant="outlined" size="medium">호스트 센터</Button></Link>
           <Link href="/community"><Button variant="outlined" size="medium">커뮤니티</Button></Link>
           <Link href="/mypage/profile">
             <UserProfile name={displayUserName} imageUrl={displayUserImage} size="large" />


### PR DESCRIPTION
호스트 센터 버튼이 /host/dashboard를 가리키고 있던 것을 /host으로 바로잡았습니다.
어드민 역할자도 헤더에서 호스트센터 버튼을 볼 수 있도록 했습니다.