### PR TITLE
feat: 호스트 회원가입 사업자등록번호 진위확인 및 상태조회 API 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       TOSS_CLIENT_KEY: ${{ vars.TOSS_CLIENT_KEY }}
       TOSS_SECRET_KEY: ${{ secrets.TOSS_SECRET_KEY }}
       GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+      DATA_GO_KR_API_KEY: ${{ secrets.DATA_GO_KR_API_KEY }}
 
     steps:
       # 1. ✅ 소스코드 체크아웃 (GitHub Actions 표준 방식)
@@ -65,6 +66,7 @@ jobs:
           TOSS_CLIENT_KEY=${{ vars.TOSS_CLIENT_KEY }}
           TOSS_SECRET_KEY=${{ secrets.TOSS_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
+          DATA_GO_KR_API_KEY=${{ secrets.DATA_GO_KR_API_KEY }}
           ENVEOF
           # 앞쪽 공백 제거
           sed -i 's/^[[:space:]]*//' .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
       - API_BASE_URL=${API_BASE_URL}
       - NEXT_PUBLIC_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - DATA_GO_KR_API_KEY=${DATA_GO_KR_API_KEY}
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/src/app/(auth)/host-signup/page.module.css
+++ b/frontend/src/app/(auth)/host-signup/page.module.css
@@ -21,3 +21,48 @@
   color: var(--color-text-muted);
   white-space: nowrap;
 }
+
+/* 사업자등록번호 인증 버튼 영역 */
+.businessInputWrapper {
+  display: flex;
+  gap: var(--space-8, 8px);
+  align-items: flex-start;
+}
+
+.businessInputContainer {
+  flex: 1;
+}
+
+.verifyBtn {
+  margin-top: 22px; /* 라벨 높이(18px) + 간격(4px) = 22px */
+  padding: 0 var(--space-16, 16px);
+  height: 48px; /* InputField 기본 높이 48px */
+  border-radius: var(--radius-md, 8px);
+  font-weight: 600;
+  flex-shrink: 0;
+  transition: all 0.2s ease-in-out;
+  outline: none;
+}
+
+.verifyBtnDefault {
+  border: 1px solid var(--color-text-gray-300, #e2e8f0);
+  background: var(--color-text-white, white);
+  color: var(--color-text-gray-700, #0f172a);
+  cursor: pointer;
+}
+
+.verifyBtnDefault:not(:disabled):hover {
+  background: var(--color-surface, #f8fafc);
+}
+
+.verifyBtnDefault:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.verifyBtnVerified {
+  border: 1px solid var(--color-primary, #10b981);
+  background: var(--color-primary-light, #ecfdf5);
+  color: var(--color-primary, #10b981);
+  cursor: default;
+}

--- a/frontend/src/app/(auth)/host-signup/page.tsx
+++ b/frontend/src/app/(auth)/host-signup/page.tsx
@@ -39,6 +39,48 @@ export default function HostSignupPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
+  // 사업자번호 인증 상태
+  const [isBusinessVerified, setIsBusinessVerified] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+
+  const verifyBusinessNumber = async () => {
+    if (!businessNumber || businessNumber.length < 10) {
+      showToast("유효한 사업자등록번호 10자리를 입력해 주세요.", "error");
+      return;
+    }
+    setVerifyLoading(true);
+    try {
+      const res = await fetch('/api/business/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ businessNumber })
+      });
+      const data = await res.json();
+      
+      if (!res.ok) throw new Error(data.error || "인증 요청에 실패했습니다.");
+
+      const statusData = data.data?.[0];
+      if (!statusData) throw new Error("인증 결과를 확인할 수 없습니다.");
+
+      if (statusData.tax_type === "국세청에 등록되지 않은 사업자등록번호입니다") {
+        setIsBusinessVerified(false);
+        showToast("국세청에 등록되지 않은 번호입니다.", "error");
+      } else if (statusData.b_stt_cd === "01" || statusData.b_stt === "계속사업자") {
+        setIsBusinessVerified(true);
+        showToast("정상 사업자로 확인되었습니다.", "success");
+      } else {
+        setIsBusinessVerified(false);
+        showToast(`휴/폐업 상태입니다: ${statusData.b_stt}`, "error");
+      }
+    } catch (err: any) {
+      setIsBusinessVerified(false);
+      showToast(err.message, "error");
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -47,6 +89,12 @@ export default function HostSignupPage() {
     if (!isHostRequiredAgreed(agreements)) {
       setError("필수 약관에 모두 동의해 주세요.");
       showToast("필수 약관에 모두 동의해 주세요.", "error");
+      return;
+    }
+
+    if (!isBusinessVerified) {
+      setError("사업자등록번호 인증을 완료해 주세요.");
+      showToast("사업자등록번호 인증을 완료해 주세요.", "error");
       return;
     }
 
@@ -150,15 +198,31 @@ export default function HostSignupPage() {
         onChange={(e) => setManagerName(e.target.value)}
         placeholder="담당자 이름을 입력하세요."
       />
-      <InputField
-        id="businessNumber"
-        label="사업자등록번호"
-        type="text"
-        required
-        value={businessNumber}
-        onChange={(e) => setBusinessNumber(e.target.value)}
-        placeholder="사업자등록번호를 입력하세요."
-      />
+      <div className={styles.businessInputWrapper}>
+        <div className={styles.businessInputContainer}>
+          <InputField
+            id="businessNumber"
+            label="사업자등록번호"
+            type="text"
+            required
+            value={businessNumber}
+            onChange={(e) => {
+              setBusinessNumber(e.target.value);
+              setIsBusinessVerified(false);
+            }}
+            placeholder="숫자만 10자리 입력하세요."
+            disabled={isBusinessVerified}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={verifyBusinessNumber}
+          disabled={verifyLoading || isBusinessVerified || businessNumber.length < 10}
+          className={`${styles.verifyBtn} ${isBusinessVerified ? styles.verifyBtnVerified : styles.verifyBtnDefault}`}
+        >
+          {verifyLoading ? "확인 중..." : isBusinessVerified ? "인증 완료" : "인증하기"}
+        </button>
+      </div>
       <UploadField
         label="사업자등록증 (선택)"
         accept="image/*,.pdf"

--- a/frontend/src/app/api/business/status/route.ts
+++ b/frontend/src/app/api/business/status/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const { businessNumber } = await req.json();
+
+    if (!businessNumber) {
+      return NextResponse.json({ error: "사업자등록번호가 필요합니다." }, { status: 400 });
+    }
+
+    // 숫자만 추출
+    const cleanNumber = businessNumber.replace(/[^0-9]/g, "");
+
+    const serviceKey = process.env.DATA_GO_KR_API_KEY;
+    if (!serviceKey) {
+      return NextResponse.json({ error: "서버에 API 키가 설정되지 않았습니다." }, { status: 500 });
+    }
+
+    // 국세청 상태조회 API URL
+    // 참고: 발급받은 API 키가 인코딩된 상태면 그대로 사용, 디코딩된 상태면 encodeURIComponent 필요할 수 있음
+    // 일단 그대로 querystring으로 넘김.
+    const url = `https://api.odcloud.kr/api/nts-businessman/v1/status?serviceKey=${serviceKey}&returnType=JSON`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      body: JSON.stringify({
+        b_no: [cleanNumber]
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: "공공데이터포털 API 호출에 실패했습니다.", details: errorData },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Business number verification error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
호스트 회원가입 시 입력한 사업자등록번호의 유효성을 국세청(공공데이터포털) API를 통해 검증하는 기능을 구현했습니다.

### 1. 프론트엔드 (Next.js)
- **API Proxy Route 추가**: `frontend/src/app/api/business/status/route.ts`
  - 클라이언트에서 직접 공공데이터포털 API를 호출할 경우 발생하는 인증키(API Key) 노출 문제를 해결하기 위해 Next.js 서버를 거치는 프록시 API를 구축했습니다.
- **호스트 가입 페이지 고도화**: `frontend/src/app/(auth)/host-signup/page.tsx`
  - 사업자등록번호 입력 필드 옆에 **[인증하기]** 버튼을 추가했습니다.
  - 국세청 상태조회 결과를 실시간으로 확인하여 '정상 사업자'일 경우에만 가입 신청이 가능하도록 폼 로직을 강화했습니다.
  - 인증 완료 시 입력 필드를 비활성화하여 정합성을 보장합니다.
- **UI/UX 개선 및 CSS 모듈화**: `frontend/src/app/(auth)/host-signup/page.module.css`
  - 기존의 인라인 스타일을 모두 CSS 모듈로 이관했습니다.
  - 미세하게 어긋나 있던 인증 버튼의 행렬(Vertical Alignment)을 픽셀 단위로 조정하여 좌측 인풋 박스와 수평을 맞췄습니다.

### 2. 배포 및 인프라 설정
- **CI/CD 워크플로우 업데이트**: `.github/workflows/deploy.yml`
  - GitHub Actions 실행 시 `DATA_GO_KR_API_KEY`를 주입하여 서버의 `.env` 생성 단계에서 포함되도록 수정했습니다.
- **Docker Compose 설정**: `docker-compose.yml`
  - 생성된 환경 변수를 프론트엔드 컨테이너 런타임에 전달하여 실제 운영 환경에서도 API 연동이 정상 작동하도록 설정했습니다.

## 🚀 테스트 방법
1. **환경 변수 설정**: `frontend/.env.local` 파일에 `DATA_GO_KR_API_KEY`를 추가합니다.
2. **번호 검증**: `/host-signup` 페이지에서 실제 사업자번호(10자리)를 입력하고 [인증하기]를 누릅니다.
3. **상태 확인**:
   - 정상 사업자: "정상 사업자로 확인되었습니다." 토스트 메시지 노출 및 버튼 녹색 변경.
   - 미등록/폐업: 해당 사유 토스트 메시지 노출 및 가입 버튼 비활성화 유지.
  
## ⚠️ 주의 사항 (작업 필수)
**GitHub Repository 설정**에 다음 Secret 값을 반드시 추가해야 정상 배포됩니다:
- `DATA_GO_KR_API_KEY`: 공공데이터포털에서 발급받은 실제 Service Key 
<img width="1728" height="1117" alt="Screenshot 2026-04-14 at 11 23 54 PM" src="https://github.com/user-attachments/assets/6b62fb91-aa4c-4bbb-b280-d26592a34740" />

---
**관련 이슈**: VO-604