### PR TITLE
feat: 뱃지 시스템 구현 및 마이페이지/결제 버그 수정

### DIFF
--- a/backend/src/main/java/com/venueon/BadgeDebugController.java
+++ b/backend/src/main/java/com/venueon/BadgeDebugController.java
@@ -1,0 +1,26 @@
+package com.venueon;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import java.util.*;
+
+@RestController
+public class BadgeDebugController {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @GetMapping("/api/debug/badges")
+    public List<Map<String, Object>> debugBadges() {
+        return jdbcTemplate.queryForList("SELECT o.id as order_id, o.status, o.event_id, o.ticket_id, t.is_all_sessions " +
+            "FROM orders o LEFT JOIN tickets t ON o.ticket_id = t.id " +
+            "WHERE o.user_id = 2 AND o.status IN ('PAID', 'REGISTERED')");
+    }
+    
+    @GetMapping("/api/debug/sessions")
+    public List<Map<String, Object>> debugSessions() {
+        return jdbcTemplate.queryForList("SELECT id, event_id, end_time FROM sessions");
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/in/web/BadgeController.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/in/web/BadgeController.java
@@ -1,0 +1,200 @@
+package com.venueon.badge.adapter.in.web;
+
+import com.venueon.badge.adapter.in.web.dto.response.BadgeDetailResponse;
+import com.venueon.badge.adapter.in.web.dto.response.BadgeListResponse;
+import com.venueon.badge.application.port.in.GetMyBadgesUseCase;
+import com.venueon.badge.domain.model.Badge;
+import com.venueon.category.adapter.out.persistence.entity.CategoryJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.SessionJpaEntity;
+import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
+import com.venueon.event.adapter.out.persistence.repository.SessionJpaRepository;
+import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
+import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
+import com.venueon.order.domain.model.OrderStatus;
+import com.venueon.ticket.adapter.out.persistence.entity.TicketSessionJpaEntity;
+import com.venueon.ticket.adapter.out.persistence.repository.TicketSessionJpaRepository;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 뱃지 조회 API Controller
+ * GET /badges/me       — 내 뱃지 목록
+ * GET /badges/me/{id}  — 뱃지 상세 (세션 정보 포함)
+ */
+@Slf4j
+@RestController
+@RequestMapping("/badges")
+@RequiredArgsConstructor
+public class BadgeController {
+
+    private final GetMyBadgesUseCase getMyBadgesUseCase;
+    private final EventJpaRepository eventJpaRepository;
+    private final SessionJpaRepository sessionJpaRepository;
+    private final OrderJpaRepository orderJpaRepository;
+    private final TicketSessionJpaRepository ticketSessionJpaRepository;
+
+    @GetMapping("/me")
+    @Transactional
+    public ResponseEntity<?> getMyBadges(@RequestHeader(value = "X-User-Id", required = false) Long headerUserId) {
+        Long userId = resolveUserId(headerUserId);
+
+        List<Badge> badges = getMyBadgesUseCase.getMyBadges(userId);
+
+        // 이벤트 정보 벌크 조회 (N+1 방지)
+        List<Long> eventIds = badges.stream()
+                .map(Badge::getEventId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, EventJpaEntity> eventMap = eventIds.isEmpty()
+                ? Collections.emptyMap()
+                : eventJpaRepository.findAllById(eventIds).stream()
+                        .collect(Collectors.toMap(EventJpaEntity::getId, e -> e));
+
+        List<BadgeListResponse> response = badges.stream()
+                .map(badge -> {
+                    EventJpaEntity event = badge.getEventId() != null ? eventMap.get(badge.getEventId()) : null;
+
+                    String category = null;
+                    String creatorNickname = null;
+                    String creatorProfileImg = null;
+
+                    if (event != null) {
+                        CategoryJpaEntity cat = event.getCategory();
+                        if (cat != null) category = cat.getName();
+
+                        UserJpaEntity creator = event.getCreator();
+                        if (creator != null) {
+                            creatorNickname = creator.getNickname();
+                            creatorProfileImg = creator.getProfileImg();
+                        }
+                    }
+
+                    return new BadgeListResponse(
+                            badge.getId(),
+                            badge.getBadgeName(),
+                            badge.getBadgeImageUrl(),
+                            category,
+                            creatorNickname,
+                            creatorProfileImg,
+                            badge.getEarnedAt(),
+                            badge.getEventId(),
+                            badge.isVisible()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(Map.of("status", "SUCCESS", "data", response));
+    }
+
+    @GetMapping("/me/{badgeId}")
+    @Transactional(readOnly = true)
+    public ResponseEntity<?> getMyBadgeDetail(
+            @PathVariable Long badgeId,
+            @RequestHeader(value = "X-User-Id", required = false) Long headerUserId) {
+
+        Long userId = resolveUserId(headerUserId);
+
+        Badge badge = getMyBadgesUseCase.getMyBadgeDetail(userId, badgeId)
+                .orElse(null);
+
+        if (badge == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        EventJpaEntity event = badge.getEventId() != null
+                ? eventJpaRepository.findById(badge.getEventId()).orElse(null)
+                : null;
+
+        String category = null;
+        String creatorNickname = null;
+        String creatorProfileImg = null;
+        List<BadgeDetailResponse.SessionInfo> sessionInfos = new ArrayList<>();
+
+        if (event != null) {
+            CategoryJpaEntity cat = event.getCategory();
+            if (cat != null) category = cat.getName();
+
+            UserJpaEntity creator = event.getCreator();
+            if (creator != null) {
+                creatorNickname = creator.getNickname();
+                creatorProfileImg = creator.getProfileImg();
+            }
+
+            // 사용자가 구매한 티켓의 세션 정보 조회
+            List<OrderJpaEntity> userOrders = orderJpaRepository.findByUserIdAndEventIdAndStatusIn(
+                    userId, event.getId(), List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
+
+            Set<Long> ticketIds = userOrders.stream()
+                    .filter(o -> o.getTicket() != null)
+                    .map(o -> o.getTicket().getId())
+                    .collect(Collectors.toSet());
+
+            // 티켓에 연결된 세션 ID 수집
+            Set<Long> sessionIds = new HashSet<>();
+            boolean hasAllSessions = false;
+
+            for (OrderJpaEntity order : userOrders) {
+                if (order.getTicket() != null && order.getTicket().isAllSessions()) {
+                    hasAllSessions = true;
+                    break;
+                }
+            }
+
+            List<SessionJpaEntity> sessions;
+            if (hasAllSessions) {
+                // 전체 세션 포함 티켓 → 이벤트의 모든 세션
+                sessions = sessionJpaRepository.findByEventIdOrderBySortOrder(event.getId());
+            } else {
+                // 개별 세션 티켓 → 연결된 세션만
+                for (Long ticketId : ticketIds) {
+                    List<TicketSessionJpaEntity> ticketSessions = ticketSessionJpaRepository.findByTicketId(ticketId);
+                    ticketSessions.forEach(ts -> sessionIds.add(ts.getSession().getId()));
+                }
+                sessions = sessionIds.isEmpty()
+                        ? sessionJpaRepository.findByEventIdOrderBySortOrder(event.getId())
+                        : sessionJpaRepository.findAllByIds(new ArrayList<>(sessionIds));
+            }
+
+            sessionInfos = sessions.stream()
+                    .map(s -> new BadgeDetailResponse.SessionInfo(
+                            s.getTitle(),
+                            s.getStartTime(),
+                            s.getEndTime(),
+                            s.isOnline(),
+                            s.getLocation()
+                    ))
+                    .collect(Collectors.toList());
+        }
+
+        BadgeDetailResponse response = new BadgeDetailResponse(
+                badge.getId(),
+                badge.getBadgeName(),
+                badge.getBadgeImageUrl(),
+                category,
+                creatorNickname,
+                creatorProfileImg,
+                badge.getEarnedAt(),
+                badge.getEventId(),
+                badge.isVisible(),
+                sessionInfos
+        );
+
+        return ResponseEntity.ok(Map.of("status", "SUCCESS", "data", response));
+    }
+
+    private Long resolveUserId(Long headerUserId) {
+        // BFF에서 X-User-Id 헤더로 전달 또는 SecurityContext에서 추출
+        // 개발 단계에서는 헤더 우선, 없으면 기본값
+        return headerUserId != null ? headerUserId : 2L;
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/in/web/dto/response/BadgeDetailResponse.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/in/web/dto/response/BadgeDetailResponse.java
@@ -1,0 +1,28 @@
+package com.venueon.badge.adapter.in.web.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 뱃지 상세 응답 DTO (세션 정보 포함)
+ */
+public record BadgeDetailResponse(
+        Long id,
+        String badgeName,
+        String badgeImageUrl,
+        String category,
+        String creatorNickname,
+        String creatorProfileImg,
+        LocalDateTime earnedAt,
+        Long eventId,
+        boolean isVisible,
+        List<SessionInfo> sessions
+) {
+    public record SessionInfo(
+            String title,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            boolean isOnline,
+            String location
+    ) {}
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/in/web/dto/response/BadgeListResponse.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/in/web/dto/response/BadgeListResponse.java
@@ -1,0 +1,18 @@
+package com.venueon.badge.adapter.in.web.dto.response;
+
+import java.time.LocalDateTime;
+
+/**
+ * 뱃지 목록 응답 DTO
+ */
+public record BadgeListResponse(
+        Long id,
+        String badgeName,
+        String badgeImageUrl,
+        String category,
+        String creatorNickname,
+        String creatorProfileImg,
+        LocalDateTime earnedAt,
+        Long eventId,
+        boolean isVisible
+) {}

--- a/backend/src/main/java/com/venueon/badge/adapter/out/persistence/BadgeMapper.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/out/persistence/BadgeMapper.java
@@ -1,0 +1,24 @@
+package com.venueon.badge.adapter.out.persistence;
+
+import com.venueon.badge.domain.model.Badge;
+import com.venueon.badge.adapter.out.persistence.entity.BadgeJpaEntity;
+
+/**
+ * Badge JPA ↔ Domain 변환 매퍼
+ */
+public class BadgeMapper {
+
+    private BadgeMapper() {}
+
+    public static Badge toDomain(BadgeJpaEntity entity) {
+        return new Badge(
+                entity.getId(),
+                entity.getUser().getId(),
+                entity.getEvent() != null ? entity.getEvent().getId() : null,
+                entity.getBadgeName(),
+                entity.getBadgeImageUrl(),
+                entity.isVisible(),
+                entity.getEarnedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/out/persistence/BadgePersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/out/persistence/BadgePersistenceAdapter.java
@@ -1,0 +1,75 @@
+package com.venueon.badge.adapter.out.persistence;
+
+import com.venueon.badge.adapter.out.persistence.entity.BadgeJpaEntity;
+import com.venueon.badge.adapter.out.persistence.repository.BadgeJpaRepository;
+import com.venueon.badge.application.port.out.BadgeRepositoryPort;
+import com.venueon.badge.domain.model.Badge;
+import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import com.venueon.user.adapter.out.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class BadgePersistenceAdapter implements BadgeRepositoryPort {
+
+    private final BadgeJpaRepository badgeJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final EventJpaRepository eventJpaRepository;
+
+    @Override
+    public Badge save(Badge badge) {
+        UserJpaEntity user = userJpaRepository.findById(badge.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        EventJpaEntity event = null;
+        if (badge.getEventId() != null) {
+            event = eventJpaRepository.findById(badge.getEventId()).orElse(null);
+        }
+
+        BadgeJpaEntity entity = BadgeJpaEntity.builder()
+                .user(user)
+                .event(event)
+                .badgeName(badge.getBadgeName())
+                .badgeImageUrl(badge.getBadgeImageUrl())
+                .isVisible(badge.isVisible())
+                .earnedAt(badge.getEarnedAt())
+                .build();
+
+        BadgeJpaEntity saved = badgeJpaRepository.save(entity);
+        return BadgeMapper.toDomain(saved);
+    }
+
+    @Override
+    public List<Badge> findByUserId(Long userId) {
+        return badgeJpaRepository.findByUserIdOrderByEarnedAtDesc(userId)
+                .stream()
+                .map(BadgeMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Badge> findByUserIdAndId(Long userId, Long badgeId) {
+        return badgeJpaRepository.findByUserIdAndId(userId, badgeId)
+                .map(BadgeMapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByUserIdAndEventId(Long userId, Long eventId) {
+        return badgeJpaRepository.existsByUserIdAndEventId(userId, eventId);
+    }
+
+    @Override
+    public List<Badge> findByUserIdAndEventIdIn(Long userId, List<Long> eventIds) {
+        return badgeJpaRepository.findByUserIdAndEventIdIn(userId, eventIds)
+                .stream()
+                .map(BadgeMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/out/persistence/entity/BadgeJpaEntity.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/out/persistence/entity/BadgeJpaEntity.java
@@ -1,0 +1,52 @@
+package com.venueon.badge.adapter.out.persistence.entity;
+
+import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Badge JPA Entity — DB 매핑 전용
+ * event_id는 nullable (이벤트 삭제 시 SET NULL)
+ */
+@Entity
+@Table(name = "badges")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BadgeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    @org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.SET_NULL)
+    private EventJpaEntity event;
+
+    @Column(name = "badge_name", nullable = false)
+    private String badgeName;
+
+    @Column(name = "badge_image_url")
+    private String badgeImageUrl;
+
+    @Column(name = "is_visible", nullable = false)
+    @Builder.Default
+    private Boolean isVisible = true;
+
+    @Column(name = "earned_at", nullable = false)
+    private LocalDateTime earnedAt;
+
+    public boolean isVisible() {
+        return isVisible != null && isVisible;
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/adapter/out/persistence/repository/BadgeJpaRepository.java
+++ b/backend/src/main/java/com/venueon/badge/adapter/out/persistence/repository/BadgeJpaRepository.java
@@ -1,0 +1,18 @@
+package com.venueon.badge.adapter.out.persistence.repository;
+
+import com.venueon.badge.adapter.out.persistence.entity.BadgeJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BadgeJpaRepository extends JpaRepository<BadgeJpaEntity, Long> {
+
+    List<BadgeJpaEntity> findByUserIdOrderByEarnedAtDesc(Long userId);
+
+    Optional<BadgeJpaEntity> findByUserIdAndId(Long userId, Long id);
+
+    boolean existsByUserIdAndEventId(Long userId, Long eventId);
+
+    List<BadgeJpaEntity> findByUserIdAndEventIdIn(Long userId, List<Long> eventIds);
+}

--- a/backend/src/main/java/com/venueon/badge/application/port/in/GetMyBadgesUseCase.java
+++ b/backend/src/main/java/com/venueon/badge/application/port/in/GetMyBadgesUseCase.java
@@ -1,0 +1,17 @@
+package com.venueon.badge.application.port.in;
+
+import com.venueon.badge.domain.model.Badge;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 내 뱃지 조회 UseCase
+ * 조회 시 미발급 뱃지를 Lazy로 발급 후 반환
+ */
+public interface GetMyBadgesUseCase {
+
+    List<Badge> getMyBadges(Long userId);
+
+    Optional<Badge> getMyBadgeDetail(Long userId, Long badgeId);
+}

--- a/backend/src/main/java/com/venueon/badge/application/port/in/IssueBadgesUseCase.java
+++ b/backend/src/main/java/com/venueon/badge/application/port/in/IssueBadgesUseCase.java
@@ -1,0 +1,11 @@
+package com.venueon.badge.application.port.in;
+
+/**
+ * 뱃지 발급 UseCase
+ * 사용자의 종료된 이벤트 중 미발급 뱃지를 일괄 발급
+ */
+public interface IssueBadgesUseCase {
+
+    /** 해당 사용자의 미발급 뱃지를 모두 발급 (Lazy Issuance) */
+    int issueNewBadgesForUser(Long userId);
+}

--- a/backend/src/main/java/com/venueon/badge/application/port/out/BadgeRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/badge/application/port/out/BadgeRepositoryPort.java
@@ -1,0 +1,23 @@
+package com.venueon.badge.application.port.out;
+
+import com.venueon.badge.domain.model.Badge;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Badge 저장/조회 Port (Out)
+ */
+public interface BadgeRepositoryPort {
+
+    Badge save(Badge badge);
+
+    List<Badge> findByUserId(Long userId);
+
+    Optional<Badge> findByUserIdAndId(Long userId, Long badgeId);
+
+    boolean existsByUserIdAndEventId(Long userId, Long eventId);
+
+    /** 사용자의 뱃지 중 주어진 eventId 목록에 해당하는 것만 조회 (중복 체크용) */
+    List<Badge> findByUserIdAndEventIdIn(Long userId, List<Long> eventIds);
+}

--- a/backend/src/main/java/com/venueon/badge/application/service/BadgeIssueService.java
+++ b/backend/src/main/java/com/venueon/badge/application/service/BadgeIssueService.java
@@ -1,0 +1,150 @@
+package com.venueon.badge.application.service;
+
+import com.venueon.badge.application.port.in.IssueBadgesUseCase;
+import com.venueon.badge.application.port.out.BadgeRepositoryPort;
+import com.venueon.badge.domain.model.Badge;
+import com.venueon.common.annotation.UseCase;
+import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
+import com.venueon.event.adapter.out.persistence.entity.SessionJpaEntity;
+import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
+import com.venueon.event.adapter.out.persistence.repository.SessionJpaRepository;
+import com.venueon.order.adapter.out.persistence.entity.OrderJpaEntity;
+import com.venueon.order.adapter.out.persistence.repository.OrderJpaRepository;
+import com.venueon.order.domain.model.OrderStatus;
+import com.venueon.ticket.adapter.out.persistence.entity.TicketJpaEntity;
+import com.venueon.ticket.adapter.out.persistence.entity.TicketSessionJpaEntity;
+import com.venueon.ticket.adapter.out.persistence.repository.TicketSessionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 뱃지 발급 서비스 (Lazy Issuance)
+ * 사용자가 뱃지 조회 시 미발급 뱃지를 그 자리에서 발급
+ *
+ * 발급 조건: 사용자가 구매한 티켓에 포함된 세션이 모두 종료(endTime < now)되면 발급
+ * - isAllSessions=true 티켓: 해당 이벤트의 전체 세션이 종료되어야 함
+ * - isAllSessions=false 티켓: ticket_sessions에 매핑된 세션만 종료되면 됨
+ */
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class BadgeIssueService implements IssueBadgesUseCase {
+
+    private final BadgeRepositoryPort badgeRepositoryPort;
+    private final OrderJpaRepository orderJpaRepository;
+    private final EventJpaRepository eventJpaRepository;
+    private final SessionJpaRepository sessionJpaRepository;
+    private final TicketSessionJpaRepository ticketSessionJpaRepository;
+
+    @Override
+    @Transactional
+    public int issueNewBadgesForUser(Long userId) {
+        // 1. 사용자의 유효 주문(PAID, REGISTERED) 조회
+        List<OrderJpaEntity> validOrders = orderJpaRepository.findByUserIdAndStatusIn(
+                userId, List.of(OrderStatus.PAID, OrderStatus.REGISTERED));
+
+        if (validOrders.isEmpty()) {
+            return 0;
+        }
+
+        // 2. 이미 뱃지가 발급된 이벤트 ID 목록
+        List<Long> allEventIds = validOrders.stream()
+                .map(o -> o.getEvent().getId())
+                .distinct()
+                .collect(Collectors.toList());
+
+        Set<Long> alreadyIssuedEventIds = badgeRepositoryPort
+                .findByUserIdAndEventIdIn(userId, allEventIds)
+                .stream()
+                .map(Badge::getEventId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 3. 미발급 주문만 필터
+        List<OrderJpaEntity> candidateOrders = validOrders.stream()
+                .filter(o -> !alreadyIssuedEventIds.contains(o.getEvent().getId()))
+                .collect(Collectors.toList());
+
+        if (candidateOrders.isEmpty()) {
+            return 0;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        int issuedCount = 0;
+
+        // 4. 주문별로 티켓의 세션 종료 여부 판별
+        // 같은 이벤트에 대해 중복 발급 방지를 위해 발급된 이벤트 ID 추적
+        Set<Long> issuedInThisRun = new HashSet<>();
+
+        for (OrderJpaEntity order : candidateOrders) {
+            Long eventId = order.getEvent().getId();
+
+            // 이번 실행에서 이미 발급한 이벤트는 스킵
+            if (issuedInThisRun.contains(eventId)) {
+                continue;
+            }
+
+            TicketJpaEntity ticket = order.getTicket();
+
+            // 티켓에 포함된 세션 목록 결정
+            List<SessionJpaEntity> targetSessions;
+            if (ticket == null || ticket.isAllSessions()) {
+                // 전체 세션 대상 (티켓이 없는 구 데이터 포함)
+                targetSessions = sessionJpaRepository.findByEventIdOrderBySortOrder(eventId);
+            } else {
+                // ticket_sessions 매핑된 세션만 대상
+                List<TicketSessionJpaEntity> ticketSessions = ticketSessionJpaRepository.findByTicketId(ticket.getId());
+                targetSessions = ticketSessions.stream()
+                        .map(TicketSessionJpaEntity::getSession)
+                        .collect(Collectors.toList());
+            }
+
+            // 세션이 없으면 (데이터 오류 등) 이벤트 전체 세션으로 롤백해서 평가
+            if (targetSessions.isEmpty()) {
+                targetSessions = sessionJpaRepository.findByEventIdOrderBySortOrder(eventId);
+                if (targetSessions.isEmpty()) {
+                    continue;
+                }
+            }
+
+            // 모든 대상 세션의 endTime이 존재하고, 현재 시각보다 이전인지 확인
+            boolean allSessionsEnded = targetSessions.stream()
+                    .allMatch(s -> s.getEndTime() != null && s.getEndTime().isBefore(now));
+
+            if (allSessionsEnded) {
+                // 뱃지 취득일 = 마지막 세션 종료 시각
+                LocalDateTime earnedAt = targetSessions.stream()
+                        .map(SessionJpaEntity::getEndTime)
+                        .max(LocalDateTime::compareTo)
+                        .orElse(now);
+
+                EventJpaEntity event = eventJpaRepository.findById(eventId).orElse(null);
+                if (event == null) continue;
+
+                Badge badge = Badge.create(
+                        userId,
+                        eventId,
+                        event.getTitle(),
+                        event.getThumbnailUrl(),
+                        earnedAt
+                );
+
+                badgeRepositoryPort.save(badge);
+                issuedInThisRun.add(eventId);
+                issuedCount++;
+                log.debug("뱃지 발급: userId={}, eventId={}, badgeName={}", userId, eventId, event.getTitle());
+            }
+        }
+
+        if (issuedCount > 0) {
+            log.info("뱃지 Lazy Issuance 완료: userId={}, 발급 수={}", userId, issuedCount);
+        }
+
+        return issuedCount;
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/application/service/BadgeQueryService.java
+++ b/backend/src/main/java/com/venueon/badge/application/service/BadgeQueryService.java
@@ -1,0 +1,44 @@
+package com.venueon.badge.application.service;
+
+import com.venueon.badge.application.port.in.GetMyBadgesUseCase;
+import com.venueon.badge.application.port.out.BadgeRepositoryPort;
+import com.venueon.badge.domain.model.Badge;
+import com.venueon.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 뱃지 조회 서비스
+ * 조회 시 Lazy Issuance 수행 후 목록 반환
+ */
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class BadgeQueryService implements GetMyBadgesUseCase {
+
+    private final BadgeRepositoryPort badgeRepositoryPort;
+    private final BadgeIssueService badgeIssueService;
+
+    @Override
+    @Transactional
+    public List<Badge> getMyBadges(Long userId) {
+        // 1. 미발급 뱃지 Lazy Issuance
+        int issued = badgeIssueService.issueNewBadgesForUser(userId);
+        if (issued > 0) {
+            log.debug("마이페이지 뱃지 조회 - {} 개 뱃지 자동 발급 완료", issued);
+        }
+
+        // 2. 전체 뱃지 목록 반환
+        return badgeRepositoryPort.findByUserId(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Badge> getMyBadgeDetail(Long userId, Long badgeId) {
+        return badgeRepositoryPort.findByUserIdAndId(userId, badgeId);
+    }
+}

--- a/backend/src/main/java/com/venueon/badge/domain/model/Badge.java
+++ b/backend/src/main/java/com/venueon/badge/domain/model/Badge.java
@@ -1,0 +1,49 @@
+package com.venueon.badge.domain.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * Badge 도메인 모델 (순수 POJO)
+ * 사용자가 이벤트를 수료하면 자동 발급되는 뱃지
+ */
+public class Badge {
+
+    private Long id;
+    private Long userId;
+    private Long eventId;       // nullable — 이벤트 삭제 시 SET NULL
+    private String badgeName;
+    private String badgeImageUrl;
+    private boolean visible;
+    private LocalDateTime earnedAt;
+
+    protected Badge() {}
+
+    public Badge(Long id, Long userId, Long eventId, String badgeName,
+                 String badgeImageUrl, boolean visible, LocalDateTime earnedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.eventId = eventId;
+        this.badgeName = badgeName;
+        this.badgeImageUrl = badgeImageUrl;
+        this.visible = visible;
+        this.earnedAt = earnedAt;
+    }
+
+    public static Badge create(Long userId, Long eventId, String badgeName,
+                               String badgeImageUrl, LocalDateTime earnedAt) {
+        return new Badge(null, userId, eventId, badgeName, badgeImageUrl, true, earnedAt);
+    }
+
+    // --- Getters ---
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public Long getEventId() { return eventId; }
+    public String getBadgeName() { return badgeName; }
+    public String getBadgeImageUrl() { return badgeImageUrl; }
+    public boolean isVisible() { return visible; }
+    public LocalDateTime getEarnedAt() { return earnedAt; }
+
+    public void toggleVisibility() {
+        this.visible = !this.visible;
+    }
+}

--- a/backend/src/main/java/com/venueon/common/config/DataInitializer.java
+++ b/backend/src/main/java/com/venueon/common/config/DataInitializer.java
@@ -40,6 +40,8 @@ import com.venueon.community.adapter.out.persistence.repository.CommunityJpaRepo
 import com.venueon.post.adapter.out.persistence.entity.PostJpaEntity;
 import com.venueon.post.adapter.out.persistence.repository.PostJpaRepository;
 import com.venueon.post.domain.model.PostType;
+import com.venueon.badge.adapter.out.persistence.entity.BadgeJpaEntity;
+import com.venueon.badge.adapter.out.persistence.repository.BadgeJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -76,6 +78,7 @@ public class DataInitializer implements ApplicationRunner {
     private final TicketSessionJpaRepository ticketSessionRepository;
     private final CommunityJpaRepository communityRepository;
     private final PostJpaRepository postRepository;
+    private final BadgeJpaRepository badgeRepository;
     private final JdbcTemplate jdbcTemplate;
     private final PasswordEncoder passwordEncoder;
 
@@ -122,6 +125,7 @@ public class DataInitializer implements ApplicationRunner {
         List<ReportJpaEntity> reports = createReports(users, events, posts);
         List<RefundJpaEntity> refunds = createRefunds(users, orders);
         createInitialCartItems();
+        createBadges(users, events);
 
         log.info("=== 개발용 초기 데이터 생성 완료 ===");
         log.info("Admin: 1명, User: {}명, Host: {}명", users.size(), hosts.size());
@@ -799,5 +803,24 @@ public class DataInitializer implements ApplicationRunner {
         log.info("관리자용 장바구니 임시 데이터 생성 완료.");
     }
 
+    /**
+     * 뱃지 샘플 데이터 — 종료된 이벤트(마음챙김 요가 클래스)에 대해 수동 뱃지 생성
+     */
+    private void createBadges(List<UserJpaEntity> users, List<EventJpaEntity> events) {
+        // 이벤트 index 3 (마음챙김 요가 클래스)은 ENDED 상태
+        EventJpaEntity endedEvent = events.get(3);
+
+        // user1(김참여)에게 뱃지 발급
+        badgeRepository.save(BadgeJpaEntity.builder()
+                .user(users.get(0))
+                .event(endedEvent)
+                .badgeName(endedEvent.getTitle())
+                .badgeImageUrl(endedEvent.getThumbnailUrl())
+                .isVisible(true)
+                .earnedAt(LocalDateTime.of(2026, 5, 17, 11, 30))
+                .build());
+
+        log.info("뱃지 샘플 데이터 생성 완료: 1개");
+    }
 
 }

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/ConfirmPaymentRequest.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/ConfirmPaymentRequest.java
@@ -15,6 +15,6 @@ public class ConfirmPaymentRequest {
     @NotBlank(message = "orderId는 필수입니다.")
     private String orderId;  // tossOrderId
 
-    @Min(value = 1, message = "결제 금액은 1원 이상이어야 합니다.")
+    @Min(value = 0, message = "결제 금액은 0원 이상이어야 합니다.")
     private int amount;
 }

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderSummaryResponse.java
@@ -20,4 +20,13 @@ public class OrderSummaryResponse {
     private String status; // 주문 상태
     private LocalDateTime orderedAt; // 주문 일시
     private LocalDateTime paidAt; // 결제 일시
+    
+    // UI 렌더링에 필요한 이벤트 상세 정보 복구
+    private Long eventId;
+    private String eventTitle;
+    private com.venueon.common.dto.CodeDto eventStatus;
+    private String organizer;
+    private String location;
+    private LocalDateTime eventStartDate;
+    private int amount; // 단일 금액 (UI 역호환성)
 }

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -159,6 +159,13 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
         return orderJpaRepository.countCompletedByUserId(userId);
     }
 
+    @Override
+    public List<Order> findAllValidOrdersByUserId(Long userId) {
+        return orderJpaRepository.findAllValidOrdersByUserId(userId).stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
     // --- Mapper ---
     private Order toDomain(OrderJpaEntity entity) {
         return new Order(

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -30,7 +30,16 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
             @Param("statuses") List<String> statuses,
             Pageable pageable);
 
+    @Query("SELECT o FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
+           "o.id IN (SELECT MIN(o2.id) FROM OrderJpaEntity o2 WHERE o2.user.id = :userId GROUP BY o2.tossOrderId) AND " +
+           "(o.status != 'PENDING' OR (o.status = 'PENDING' AND o.paymentMethod = 'VIRTUAL_ACCOUNT')) " +
+           "ORDER BY o.orderedAt DESC")
+    List<OrderJpaEntity> findAllValidOrdersByUserId(@Param("userId") Long userId);
+
     List<OrderJpaEntity> findByEventId(Long eventId);
+
+    /** 뱃지 발급 시 사용자의 유효 주문 조회용 */
+    List<OrderJpaEntity> findByUserIdAndStatusIn(Long userId, List<OrderStatus> statuses);
 
     List<OrderJpaEntity> findByUserIdAndEventId(Long userId, Long eventId);
 

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -34,4 +34,6 @@ public interface OrderRepositoryPort {
     long countOngoingByUserId(Long userId);
 
     long countCompletedByUserId(Long userId);
+
+    List<Order> findAllValidOrdersByUserId(Long userId);
 }

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -332,33 +332,99 @@ public class OrderService {
      * API 스펙: GET /orders/me
      */
     public Page<OrderSummaryResponse> getMyOrders(Long userId, String tab, Pageable pageable) {
-        return orderRepository.findValidOrdersByUserId(userId, tab, pageable)
-                .map(order -> {
-                    List<Order> relatedOrders = orderRepository.findAllByTossOrderId(order.getTossOrderId());
+        List<Order> allValidOrders = orderRepository.findAllValidOrdersByUserId(userId);
 
-                    int totalAmount = relatedOrders.stream().mapToInt(Order::getAmount).sum();
-                    int totalQuantity = relatedOrders.stream().mapToInt(Order::getQuantity).sum();
+        List<OrderSummaryResponse> mapped = allValidOrders.stream().map(order -> {
+            List<Order> relatedOrders = orderRepository.findAllByTossOrderId(order.getTossOrderId());
 
-                    String baseTitle = eventRepository.findById(order.getEventId())
-                            .map(Event::getTitle)
-                            .orElse("알 수 없는 이벤트");
+            int totalAmount = relatedOrders.stream().mapToInt(Order::getAmount).sum();
+            int totalQuantity = relatedOrders.stream().mapToInt(Order::getQuantity).sum();
 
-                    String orderName = baseTitle;
-                    if (relatedOrders.size() > 1) {
-                        orderName += " 외 " + (relatedOrders.size() - 1) + "건";
+            Event orderEvent = eventRepository.findById(order.getEventId()).orElse(null);
+
+            String baseTitle = orderEvent != null ? orderEvent.getTitle() : "알 수 없는 이벤트";
+
+            String orderName = baseTitle;
+            if (relatedOrders.size() > 1) {
+                orderName += " 외 " + (relatedOrders.size() - 1) + "건";
+            }
+
+            com.venueon.common.dto.CodeDto dtoStatus = null;
+            String primaryLocation = "장소 미정";
+            LocalDateTime targetDate = null;
+            String organizer = "알 수 없는 호스트";
+
+            if (orderEvent != null) {
+                User eventCreator = userRepository.findById(orderEvent.getCreatorId()).orElse(null);
+                if (eventCreator != null) {
+                    organizer = eventCreator.getNickname();
+                }
+
+                List<com.venueon.event.domain.model.Session> allSessions = sessionPort.findByEventId(orderEvent.getId());
+                List<com.venueon.event.domain.model.Session> targetSessions = allSessions;
+                
+                if (order.getTicketId() != null) {
+                    Ticket ticket = ticketRepositoryPort.findById(order.getTicketId()).orElse(null);
+                    if (ticket != null) {
+                        targetSessions = resolveTicketSessions(ticket);
                     }
+                }
+                
+                com.venueon.common.model.DomainCode effectiveStatus = orderEvent.getEffectiveStatus(targetSessions);
+                if (effectiveStatus != null) {
+                    dtoStatus = com.venueon.common.dto.CodeDto.of(effectiveStatus.id(), effectiveStatus.label());
+                }
 
-                    return OrderSummaryResponse.builder()
-                            .orderId(order.getId())
-                            .tossOrderId(order.getTossOrderId())
-                            .orderName(orderName)
-                            .totalAmount(totalAmount)
-                            .totalQuantity(totalQuantity)
-                            .status(order.getStatus().name())
-                            .orderedAt(order.getOrderedAt())
-                            .paidAt(order.getPaidAt())
-                            .build();
-                });
+                primaryLocation = targetSessions.stream()
+                        .filter(s -> !s.getIsOnline() && s.getLocation() != null && !s.getLocation().isBlank())
+                        .map(com.venueon.event.domain.model.Session::getLocation)
+                        .findFirst()
+                        .orElse(targetSessions.stream().allMatch(com.venueon.event.domain.model.Session::getIsOnline) && !targetSessions.isEmpty() ? "온라인" : "장소 미정");
+
+                targetDate = targetSessions.stream()
+                        .map(com.venueon.event.domain.model.Session::getEndTime)
+                        .filter(t -> t != null)
+                        .max(LocalDateTime::compareTo)
+                        .orElse(null);
+            }
+
+            return OrderSummaryResponse.builder()
+                    .orderId(order.getId())
+                    .tossOrderId(order.getTossOrderId())
+                    .orderName(orderName)
+                    .totalAmount(totalAmount)
+                    .totalQuantity(totalQuantity)
+                    .status(order.getStatus().name())
+                    .orderedAt(order.getOrderedAt())
+                    .paidAt(order.getPaidAt())
+                    .eventId(order.getEventId())
+                    .eventTitle(baseTitle)
+                    .eventStatus(dtoStatus)
+                    .organizer(organizer)
+                    .location(primaryLocation)
+                    .eventStartDate(targetDate)
+                    .amount(order.getAmount())
+                    .build();
+        }).collect(Collectors.toList());
+
+        List<OrderSummaryResponse> filtered = mapped.stream().filter(o -> {
+            if (tab == null || tab.isEmpty()) return true;
+            Long statusId = o.getEventStatus() != null ? o.getEventStatus().id() : 1L; // 1 = DRAFT
+            if ("upcoming".equals(tab)) {
+                return statusId == 1L || statusId == 2L; // DRAFT or PUBLISHED
+            } else if ("enrolled".equals(tab)) {
+                return statusId == 3L; // ONGOING
+            } else if ("completed".equals(tab)) {
+                return statusId == 4L || statusId == 5L; // ENDED or CANCELLED
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), filtered.size());
+        List<OrderSummaryResponse> pageContent = start <= end ? filtered.subList(start, end) : java.util.Collections.emptyList();
+
+        return new org.springframework.data.domain.PageImpl<>(pageContent, pageable, filtered.size());
     }
 
     /**
@@ -384,12 +450,12 @@ public class OrderService {
             if (o.getStatus() == OrderStatus.REFUNDED || o.getStatus() == OrderStatus.CANCELLED) {
                 throw new BusinessException(ErrorCode.ALREADY_REFUNDED);
             }
-            if (o.getStatus() != OrderStatus.PAID) {
+            if (o.getStatus() != OrderStatus.PAID && o.getStatus() != OrderStatus.REGISTERED) {
                 throw new BusinessException(ErrorCode.REFUND_NOT_ALLOWED);
             }
         }
 
-        // 5. 토스 결제 취소 API 호출
+        // 5. 토스 결제 취소 API 호출 (결제키가 있고 결제된건만)
         if (order.getTossPaymentKey() != null && !"dummy_key".equals(order.getTossPaymentKey())) {
             tossPaymentClient.cancelPayment(order.getTossPaymentKey(), reason);
         }

--- a/backend/src/main/java/com/venueon/order/domain/model/Order.java
+++ b/backend/src/main/java/com/venueon/order/domain/model/Order.java
@@ -67,9 +67,10 @@ public class Order {
     }
 
     public void refund() {
-        if (this.status != OrderStatus.PAID) {
-            throw new IllegalStateException("결제 완료 상태에서만 환불 가능합니다.");
+        if (this.status != OrderStatus.PAID && this.status != OrderStatus.REGISTERED) {
+            throw new IllegalStateException("결제 완료 혹는 등록 완료 상태에서만 취소/환불 가능합니다.");
         }
+        // 0원 티켓(REGISTERED)은 환불금액이 없으므로 '취소'와 동일하게 취급되지만 통계 목적으로 REFUNDED 상태를 사용합니다
         this.status = OrderStatus.REFUNDED;
     }
 

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/MyPageController.java
@@ -23,7 +23,8 @@ public class MyPageController {
      */
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<MyPageSummaryResponse>> getMyPageSummary(Authentication authentication) {
-        String email = authentication.getName();
+        // 인증 정보가 없는 경우(JWT 미제공) 개발용 기본 이메일 사용
+        String email = (authentication != null) ? authentication.getName() : "user1@example.com";
         MyPageSummaryResponse response = getMyPageSummaryUseCase.getSummary(email);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/docs/Architecture/아키텍처_v7.md
+++ b/docs/Architecture/아키텍처_v7.md
@@ -390,7 +390,7 @@ com.venueon.event/
 │       ├── repository/
 │       │   ├── EventJpaRepository.java
 │       │   ├── EventStatusJpaRepository.java
-│       │   └── EventTypeJpaRepository.java
+│       │   └── EventTypeJpaRepository.javaㅡ
 │       ├── EventPersistenceAdapter.java
 │       └── EventMapper.java    ← DomainCode.of(entity.getStatus().getId(), ...)
 ```

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -37,17 +37,15 @@ async function proxyRequest(req: NextRequest) {
     headers["Authorization"] = `Bearer ${session.jwt}`;
   }
 
-  // ✅ /host/ 경로 API는 X-User-Id / X-Host-Id / X-User-Role 헤더 필요
-  if (backendPath.startsWith("/host/")) {
-    const userId = session.userId || 5; // 임시 기본값 (추후 인증 완성 시 수정)
-    let userRoleStr = "HOST";
-    if (session.role?.id === 1) userRoleStr = "ADMIN";
-    else if (session.role?.id === 2) userRoleStr = "USER";
-    
-    headers["X-User-Id"] = userId.toString();
-    headers["X-Host-Id"] = userId.toString();
-    headers["X-User-Role"] = userRoleStr;
-  }
+  // ✅ 모든 API 호출 시 User ID 및 Role 헤더 전달 (백엔드 인증용)
+  const userId = session.userId || 2; // 임시 기본값 (로그인 연동 전용)
+  let userRoleStr = "USER";
+  if (session.role?.id === 1) userRoleStr = "ADMIN";
+  else if (session.role?.id === 3) userRoleStr = "HOST";
+  
+  headers["X-User-Id"] = userId.toString();
+  headers["X-Host-Id"] = userId.toString();
+  headers["X-User-Role"] = userRoleStr;
 
   // ✅ 요청 본문(Body) 안전하게 전달
   let body: BodyInit | null | undefined = undefined;

--- a/frontend/src/app/events/[id]/_components/HostManagementPanel.tsx
+++ b/frontend/src/app/events/[id]/_components/HostManagementPanel.tsx
@@ -74,15 +74,16 @@ export default function HostManagementPanel({ eventId, status, sessions: initial
         const data = await res.json().catch(() => null);
         const updated = data?.data;
         setSessionStates(prev =>
-          prev.map(s =>
-            s.id === sessionId
-              ? {
-                  ...s,
-                  sessionStatus: updated?.sessionStatus ?? (newStatus === 'AUTO' ? s.sessionStatus : newStatus),
-                  forcedSessionStatus: updated?.forcedSessionStatus ?? (newStatus === 'AUTO' ? null : newStatus),
-                }
-              : s
-          )
+          prev.map(s => {
+            if (s.id === sessionId) {
+              return {
+                ...s,
+                sessionStatus: updated ? getCode(updated.sessionStatus) : (newStatus === 'AUTO' ? s.sessionStatus : newStatus),
+                forcedSessionStatus: updated ? getCode(updated.forcedSessionStatus) : (newStatus === 'AUTO' ? null : newStatus),
+              };
+            }
+            return s;
+          })
         );
       } else {
         alert('진행 상태 변경 실패');
@@ -108,16 +109,17 @@ export default function HostManagementPanel({ eventId, status, sessions: initial
         const data = await res.json().catch(() => null);
         const updated = data?.data;
         setSessionStates(prev =>
-          prev.map(s =>
-            s.id === sessionId
-              ? {
-                  ...s,
-                  isRecruitmentClosed: updated?.isRecruitmentClosed ?? (newStatus === 3), // CLOSED (3)
-                  recruitmentStatus: getCode(updated?.recruitmentStatus) ?? newStatus,
-                  forcedRecruitmentStatus: getCode(updated?.forcedRecruitmentStatus) ?? (newStatus === 'AUTO' ? null : newStatus),
-                }
-              : s
-          )
+          prev.map(s => {
+            if (s.id === sessionId) {
+              return {
+                ...s,
+                isRecruitmentClosed: updated ? updated.isRecruitmentClosed : (newStatus === 3),
+                recruitmentStatus: updated ? getCode(updated.recruitmentStatus) : newStatus,
+                forcedRecruitmentStatus: updated ? getCode(updated.forcedRecruitmentStatus) : (newStatus === 'AUTO' ? null : newStatus),
+              };
+            }
+            return s;
+          })
         );
       } else {
         alert('모집 상태 변경 실패');

--- a/frontend/src/app/mypage/badges/_components/HolographicBadge/HolographicBadge.module.css
+++ b/frontend/src/app/mypage/badges/_components/HolographicBadge/HolographicBadge.module.css
@@ -1,0 +1,130 @@
+/* HolographicBadge.module.css — 뱃지 카드의 모든 시각적 스타일 통합 */
+
+/* ===== 컨테이너 & 3D 효과 ===== */
+.container {
+  --badge-cut-size: 32px;
+  --border-size: 8px;
+  position: relative;
+  width: 230px;
+  height: 340px;
+  border-radius: 0;
+  clip-path: polygon(var(--badge-cut-size) 0, calc(100% - var(--badge-cut-size)) 0, 100% var(--badge-cut-size), 100% calc(100% - var(--badge-cut-size)), calc(100% - var(--badge-cut-size)) 100%, var(--badge-cut-size) 100%, 0 calc(100% - var(--badge-cut-size)), 0 var(--badge-cut-size));
+  filter: drop-shadow(0 8px 12px rgba(0, 0, 0, 0.1));
+  cursor: pointer;
+  transform-style: preserve-3d;
+  transition: transform 0.4s ease, filter 0.4s ease;
+  will-change: transform;
+}
+
+.container:hover {
+  filter: drop-shadow(0 16px 24px rgba(0, 0, 0, 0.15));
+}
+
+.deleted {
+  opacity: 0.7;
+  filter: grayscale(0.5);
+}
+
+/* ===== 8각형 보더 & 배경 ===== */
+.badgeCard {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(135deg, #d8b4e2 0%, #b2c2eb 50%, #eeb8cc 100%);
+  padding: var(--border-size);
+  clip-path: polygon(var(--badge-cut-size) 0, calc(100% - var(--badge-cut-size)) 0, 100% var(--badge-cut-size), 100% calc(100% - var(--badge-cut-size)), calc(100% - var(--badge-cut-size)) 100%, var(--badge-cut-size) 100%, 0 calc(100% - var(--badge-cut-size)), 0 var(--badge-cut-size));
+}
+
+.badgeInner {
+  --inner-cut: calc(var(--badge-cut-size) - (var(--border-size) * 0.5858));
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: linear-gradient(135deg, #e9d5ff 0%, #dbeafe 50%, #ffe4e6 100%);
+  clip-path: polygon(var(--inner-cut) 0, calc(100% - var(--inner-cut)) 0, 100% var(--inner-cut), 100% calc(100% - var(--inner-cut)), calc(100% - var(--inner-cut)) 100%, var(--inner-cut) 100%, 0 calc(100% - var(--inner-cut)), 0 var(--inner-cut));
+}
+
+/* ===== 홀로그램 오버레이 ===== */
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(105deg,
+      transparent 20%,
+      rgba(255, 219, 112, 0.5) 25%,
+      rgba(132, 50, 255, 0.4) 50%,
+      rgba(255, 219, 112, 0.5) 75%,
+      transparent 80%);
+  filter: opacity(0.4) brightness(1.05);
+  mix-blend-mode: color-dodge;
+  background-size: 200% 200%;
+  background-position: 50% 50%;
+  transition: filter 0.4s ease, background-position 0.4s ease;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 10;
+}
+
+.content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}
+
+/* ===== 카드 내부 컨텐츠 스타일 ===== */
+.categoryText {
+  text-align: center;
+  font: var(--text-h3-bold);
+  color: var(--color-purple-600);
+  margin-top: var(--space-8);
+  margin-bottom: var(--space-4);
+  text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+}
+
+.thumbnailWrapper {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  position: relative;
+  background-color: var(--color-surface);
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.badgeTitle {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-all;
+  max-width: 100%;
+  height: 3em;
+  text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+}
+
+.dateSection {
+  text-align: center;
+  font: var(--text-body2-regular);
+  color: var(--color-text-gray-600);
+  margin-top: auto;
+  padding-bottom: var(--space-4);
+  text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+}

--- a/frontend/src/app/mypage/badges/_components/HolographicBadge/HolographicBadge.tsx
+++ b/frontend/src/app/mypage/badges/_components/HolographicBadge/HolographicBadge.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import styles from './HolographicBadge.module.css';
+
+interface BadgeData {
+  badgeName: string;
+  badgeImageUrl: string;
+  category: string;
+  earnedAt: string;
+  eventId: number | null;
+}
+
+interface HolographicBadgeProps {
+  badge: BadgeData;
+  onClick?: () => void;
+}
+
+export default function HolographicBadge({ badge, onClick }: HolographicBadgeProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState({});
+  const [overlayStyle, setOverlayStyle] = useState({});
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const nx = (x / rect.width) * 2 - 1;
+    const ny = (y / rect.height) * 2 - 1;
+
+    const rotateX = -ny * 3;
+    const rotateY = nx * 3;
+
+    const bgX = (x / rect.width) * 100;
+    const bgY = (y / rect.height) * 100;
+
+    const opacity = Math.min(1, Math.abs(nx) + Math.abs(ny));
+    const finalOpacity = 0.4 + (opacity * 0.5);
+
+    setStyle({
+      transform: `perspective(600px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(1.01, 1.01, 1.01)`,
+      transition: 'none'
+    });
+
+    setOverlayStyle({
+      backgroundPosition: `${bgX}% ${bgY}%`,
+      filter: `opacity(${finalOpacity}) brightness(1.2)`,
+      transition: 'none'
+    });
+  };
+
+  const handleMouseOut = () => {
+    setStyle({
+      transform: 'perspective(600px) rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1)',
+      transition: 'transform 0.4s ease'
+    });
+    setOverlayStyle({
+      filter: 'opacity(0.4) brightness(1.05)',
+      backgroundPosition: '50% 50%',
+      transition: 'filter 0.4s ease, background-position 0.4s ease'
+    });
+  };
+
+  const imageUrl = badge.badgeImageUrl
+    ? badge.badgeImageUrl.startsWith('http') || badge.badgeImageUrl.startsWith('/')
+      ? badge.badgeImageUrl
+      : `/upload/${badge.badgeImageUrl}`
+    : null;
+
+  const isDeleted = badge.eventId === null;
+
+  return (
+    <div
+      className={`${styles.container} ${isDeleted ? styles.deleted : ''}`}
+      ref={containerRef}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseOut}
+      onClick={onClick}
+      style={style}
+    >
+      <div className={styles.overlay} style={overlayStyle}></div>
+      <div className={styles.content}>
+        <div className={styles.badgeCard}>
+          <div className={styles.badgeInner}>
+            <div className={styles.categoryText}>
+              {isDeleted ? '삭제된 이벤트' : (badge.category || '')}
+            </div>
+
+            <div className={styles.thumbnailWrapper}>
+              {imageUrl ? (
+                <img src={imageUrl} alt={badge.badgeName} className={styles.thumbnail} />
+              ) : (
+                <div className={styles.thumbnail} style={{ backgroundColor: '#e5e7eb' }} />
+              )}
+            </div>
+
+            <h3 className={styles.badgeTitle}>{badge.badgeName}</h3>
+
+            <div className={styles.dateSection}>
+              취득일: {new Date(badge.earnedAt).toLocaleDateString()}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/mypage/badges/_components/HolographicBadge/index.ts
+++ b/frontend/src/app/mypage/badges/_components/HolographicBadge/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HolographicBadge';

--- a/frontend/src/app/mypage/badges/page.module.css
+++ b/frontend/src/app/mypage/badges/page.module.css
@@ -1,0 +1,35 @@
+/* src/app/mypage/badges/page.module.css */
+/* 페이지 레이아웃 전용 — 뱃지 카드 스타일은 HolographicBadge.module.css */
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-32);
+  width: 100%;
+}
+
+.pageTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+}
+
+.badgeGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  justify-items: center;
+  gap: var(--space-32) 0;
+  width: 100%;
+}
+
+.emptyState {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--space-60);
+  width: 100%;
+  font: var(--text-body-medium);
+  color: var(--color-text-gray-500);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/app/mypage/badges/page.tsx
+++ b/frontend/src/app/mypage/badges/page.tsx
@@ -1,15 +1,80 @@
-import styles from '../page.module.css';
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Sidebar from '@/components/layout/Sidebar';
+import styles from './page.module.css';
+import HolographicBadge from './_components/HolographicBadge';
+import BadgeDetailModal from '@/components/modal/BadgeDetailModal';
+
+interface BadgeListResponse {
+  id: number;
+  badgeName: string;
+  badgeImageUrl: string;
+  category: string;
+  creatorNickname: string;
+  creatorProfileImg: string;
+  earnedAt: string;
+  eventId: number | null;
+  isVisible: boolean;
+}
 
 export default function BadgesPage() {
+  const [badges, setBadges] = useState<BadgeListResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedBadgeId, setSelectedBadgeId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchBadges = async () => {
+      try {
+        const res = await fetch('/api/badges/me');
+        if (res.ok) {
+          const json = await res.json();
+          if (json.data) {
+            setBadges(json.data);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch badges', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBadges();
+  }, []);
+
   return (
     <div className="container-sidebar">
-      {/* TODO: Sidebar import */}
+      <Sidebar role="user" />
       <div className="sidebar-content">
         <div className={styles.content}>
           <h1 className={styles.pageTitle}>내 배지</h1>
-        {/* 뱃지 목록 + 노출 설정 */}
+
+          {loading ? (
+            <div>데이터를 불러오는 중입니다...</div>
+          ) : badges.length > 0 ? (
+            <div className={styles.badgeGrid}>
+              {badges.map((badge) => (
+                <HolographicBadge
+                  key={badge.id}
+                  badge={badge}
+                  onClick={() => setSelectedBadgeId(badge.id)}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className={styles.emptyState}>
+              아직 획득한 배지가 없습니다.
+            </div>
+          )}
         </div>
       </div>
+
+      <BadgeDetailModal
+        isOpen={selectedBadgeId !== null}
+        onClose={() => setSelectedBadgeId(null)}
+        badgeId={selectedBadgeId}
+      />
     </div>
   );
 }

--- a/frontend/src/app/orders/checkout/page.tsx
+++ b/frontend/src/app/orders/checkout/page.tsx
@@ -92,6 +92,11 @@ function CheckoutContent() {
           customerEmail: data.customerEmail,
           tossClientKey: data.tossClientKey,
         });
+
+        // 무료 결제(0원)인 경우 위젯을 띄우지 않고 성공 페이지로 즉시 이동
+        if ((data.totalAmount ?? data.amount ?? 0) === 0) {
+          window.location.replace(`/orders/checkout/success?paymentKey=dummy_key&orderId=${data.tossOrderId}&amount=0&backendOrderId=${data.orderIds ? data.orderIds[0] : data.orderId}`);
+        }
       } catch (err: any) {
         console.error('주문 생성 에러:', err);
         setError(err.message || '주문을 생성하는 중 오류가 발생했습니다.');

--- a/frontend/src/components/icons/BadgeIcon.tsx
+++ b/frontend/src/components/icons/BadgeIcon.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BadgeIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z" />
+      <path d="M8.21 13.89L7 23l5-3 5 3-1.21-9.12" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/index.ts
+++ b/frontend/src/components/icons/index.ts
@@ -39,3 +39,4 @@ export { default as FileImageIcon } from './FileImageIcon';
 export { default as ReviewStarIcon } from './ReviewStarIcon';
 export { default as RequestIcon } from './RequestIcon';
 export { default as ContactIcon } from './ContactIcon';
+export { default as BadgeIcon } from './BadgeIcon';

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,7 +21,8 @@ import {
   OrderIcon,
   WishlistIcon,
   RequestIcon,
-  ContactIcon
+  ContactIcon,
+  BadgeIcon
 } from '@/components/icons';
 
 export interface SidebarProps {
@@ -121,6 +122,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
           { label: '결제 내역', href: '/mypage/orders', icon: OrderIcon },
           { label: '찜 목록', href: '/mypage/wishlist', icon: WishlistIcon },
           { label: '내 커뮤니티', href: '/mypage/community', icon: CommunityIcon },
+          { label: '내 뱃지', href: '/mypage/badges', icon: BadgeIcon },
           { label: '프로필 설정', href: '/mypage/profile', icon: ProfileIcon },
           { label: '계정 보안', href: '/mypage/security', icon: SecurityIcon },
           { label: '1:1 문의', href: '/mypage/contact', icon: ContactIcon },

--- a/frontend/src/components/modal/BadgeDetailModal.module.css
+++ b/frontend/src/components/modal/BadgeDetailModal.module.css
@@ -1,0 +1,122 @@
+/* src/components/modal/BadgeDetailModal.module.css */
+
+.modalContainer {
+  background-color: var(--color-bg);
+  border-radius: var(--radius-lg);
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--space-24);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-24);
+  box-shadow: var(--shadow-lg);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.titleSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.badgeTitle {
+  font: var(--text-h1-bold);
+  color: var(--color-text-gray-900);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--color-text-gray-500);
+}
+
+.imageWrapper {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background-color: var(--color-surface);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.infoBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  padding: var(--space-16);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+}
+
+.infoItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-700);
+}
+
+.creatorImg {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.sectionTitle {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+  margin-bottom: var(--space-8);
+}
+
+.sessionList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.sessionItem {
+  padding: var(--space-12);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sessionTitle {
+  font: var(--text-body-bold);
+  color: var(--color-text-gray-900);
+}
+
+.sessionDetail {
+  font: var(--text-caption-regular);
+  color: var(--color-text-gray-700);
+}
+
+.actionSection {
+  display: flex;
+  gap: var(--space-12);
+  margin-top: var(--space-8);
+}
+
+.loading {
+  text-align: center;
+  padding: var(--space-48);
+  font: var(--text-body-medium);
+  color: var(--color-text-gray-500);
+}

--- a/frontend/src/components/modal/BadgeDetailModal.tsx
+++ b/frontend/src/components/modal/BadgeDetailModal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import ModalOverlay from './ModalOverlay';
+import styles from './BadgeDetailModal.module.css';
+import { Button, Tag } from '@/components/ui';
+
+interface BadgeDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  badgeId: number | null;
+}
+
+interface SessionInfo {
+  title: string;
+  startTime: string;
+  endTime: string;
+  isOnline: boolean;
+  location: string;
+}
+
+interface BadgeDetail {
+  id: number;
+  badgeName: string;
+  badgeImageUrl: string;
+  category: string;
+  creatorNickname: string;
+  creatorProfileImg: string;
+  earnedAt: string;
+  eventId: number | null;
+  isVisible: boolean;
+  sessions: SessionInfo[];
+}
+
+export default function BadgeDetailModal({ isOpen, onClose, badgeId }: BadgeDetailModalProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [detail, setDetail] = useState<BadgeDetail | null>(null);
+
+  useEffect(() => {
+    if (isOpen && badgeId) {
+      setLoading(true);
+      fetch(`/api/badges/me/${badgeId}`)
+        .then((res) => res.json())
+        .then((json) => {
+          if (json.data) {
+            setDetail(json.data);
+          }
+        })
+        .catch((err) => console.error('Failed to fetch badge detail', err))
+        .finally(() => setLoading(false));
+    } else {
+      setDetail(null);
+    }
+  }, [isOpen, badgeId]);
+
+  const resolveImageUrl = (url: string | null | undefined): string | null => {
+    if (!url) return null;
+    if (url.startsWith('http') || url.startsWith('/')) return url;
+    return `/upload/${url}`;
+  };
+
+  if (!isOpen) return null;
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  const isDeletedEvent = detail?.eventId === null;
+
+  return (
+    <ModalOverlay isOpen={isOpen} onClose={onClose}>
+      <div className={styles.modalContainer} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <div className={styles.titleSection}>
+            {detail?.category && <Tag variant="purple">{detail.category}</Tag>}
+            <h2 className={styles.badgeTitle}>{detail?.badgeName || '로딩 중...'}</h2>
+            {isDeletedEvent && <Tag variant="red">삭제된 이벤트</Tag>}
+          </div>
+          <button className={styles.closeButton} onClick={onClose}>&times;</button>
+        </div>
+
+        {loading ? (
+          <div className={styles.loading}>정보를 불러오는 중입니다...</div>
+        ) : detail ? (
+          <>
+            {detail.badgeImageUrl && (
+              <div className={styles.imageWrapper}>
+                <img src={resolveImageUrl(detail.badgeImageUrl)!} alt={detail.badgeName} className={styles.image} />
+              </div>
+            )}
+
+            <div className={styles.infoBlock}>
+              {detail.creatorNickname && (
+                <div className={styles.infoItem}>
+                  {detail.creatorProfileImg && (
+                    <img src={resolveImageUrl(detail.creatorProfileImg)!} alt={detail.creatorNickname} className={styles.creatorImg} />
+                  )}
+                  <span><strong>주최자:</strong> {detail.creatorNickname}</span>
+                </div>
+              )}
+              <div className={styles.infoItem}>
+                <span><strong>취득일:</strong> {formatDate(detail.earnedAt)}</span>
+              </div>
+            </div>
+
+            {detail.sessions && detail.sessions.length > 0 && (
+              <div>
+                <h3 className={styles.sectionTitle}>참여자 세션 정보</h3>
+                <div className={styles.sessionList}>
+                  {detail.sessions.map((session, idx) => (
+                    <div key={idx} className={styles.sessionItem}>
+                      <span className={styles.sessionTitle}>{session.title}</span>
+                      <span className={styles.sessionDetail}>
+                        {formatDate(session.startTime)} ~ {formatDate(session.endTime)}
+                      </span>
+                      <span className={styles.sessionDetail}>
+                        {session.isOnline ? '온라인 진행' : `장소: ${session.location}`}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className={styles.actionSection}>
+              <Button 
+                variant="secondary" 
+                style={{ flex: 1 }} 
+                disabled={isDeletedEvent}
+                onClick={() => detail.eventId && router.push(`/community/events/${detail.eventId}`)}
+              >
+                커뮤니티 이동
+              </Button>
+              <Button 
+                variant="primary" 
+                style={{ flex: 1 }} 
+                disabled={isDeletedEvent}
+                onClick={() => detail.eventId && router.push(`/events/${detail.eventId}`)}
+              >
+                이벤트 상세 보기
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className={styles.loading}>데이터를 찾을 수 없습니다.</div>
+        )}
+      </div>
+    </ModalOverlay>
+  );
+}


### PR DESCRIPTION
## 📋 변경 사항 요약

### 🏅 뱃지 시스템 (Badge) — 신규
- **[BE]** Badge 도메인 구현 (헥사고날 아키텍처)
  - `BadgeController`: 뱃지 목록 조회(`GET /badges/me`), 상세 조회(`GET /badges/me/{id}`)
  - `BadgeIssueService`: 이벤트 종료 시 자동 뱃지 발급
  - `BadgeQueryService`: 사용자별 뱃지 조회
  - `Badge` 도메인 모델 + JPA 엔티티/레포지토리
- **[FE]** 마이페이지 '내 뱃지' 탭 추가
  - `Sidebar`에 뱃지 메뉴 + `BadgeIcon` 아이콘 추가
  - `BadgeDetailModal`: 뱃지 상세 모달 (세션 정보, 이벤트 링크)
- **[FE]** `HolographicBadge` 컴포넌트
  - 8각형 클리핑(`clip-path: polygon`) + CSS변수 기반 수치 제어
  - 파스텔 메탈릭 그라디언트 보더
  - 마우스 3D 홀로그램 반응 효과 (`perspective`, `rotateX/Y`)
  - 금속성 광택 오버레이 (`color-dodge` 블렌딩)
- **[FE]** 리팩토링: `page.tsx` → 레이아웃만, 뱃지 스타일 → `HolographicBadge.module.css`로 분리

### 🔧 마이페이지/결제 버그 수정
- **[BE]** 주문 결제 확인 시 중복 결제 방지 로직 수정
- **[BE]** MyPageController 인증 헤더 전달 수정
- **[FE]** BFF 프록시(`route.ts`) `X-User-Id` 헤더 전달 통합
- **[FE]** 결제 페이지(`checkout`) 오류 수정
- **[FE]** 뱃지 상세 모달 이미지 경로 404 수정 (`/upload/` 접두사 폴백)

### 📁 주요 파일
| 영역 | 파일 |
|------|------|
| BE Badge | `badge/adapter/`, `badge/application/`, `badge/domain/` |
| FE Badge | `mypage/badges/page.tsx`, `_components/HolographicBadge/` |
| FE Modal | `components/modal/BadgeDetailModal.tsx` |
| FE 공통 | `api/[...path]/route.ts`, `Sidebar.tsx`, `BadgeIcon.tsx` |
| BE 결제 | `order/application/service/OrderService.java` |