### PR TITLE
feat:게시물 검색기능 추가 / 글쓰기 버튼 위치 변경 / 글쓰기,수정페이지 css 수정

### DIFF
--- a/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
+++ b/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
@@ -44,7 +44,8 @@ public class PostController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String email = ((UserDetails) authentication.getPrincipal()).getUsername();
@@ -69,7 +70,8 @@ public class PostController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String email = ((UserDetails) authentication.getPrincipal()).getUsername();
@@ -110,10 +112,11 @@ public class PostController {
             @RequestParam(required = false) PostType type,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = null;
-        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal())) {
             email = ((UserDetails) authentication.getPrincipal()).getUsername();
         }
 
@@ -146,7 +149,8 @@ public class PostController {
     public ResponseEntity<Void> toggleBookmark(@PathVariable Long id) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = null;
-        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal())) {
             email = ((UserDetails) authentication.getPrincipal()).getUsername();
         }
 
@@ -161,9 +165,10 @@ public class PostController {
     @GetMapping("/bookmarks/me")
     public ResponseEntity<Page<PostListResponse>> getMyBookmarks(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
@@ -179,7 +184,8 @@ public class PostController {
     @PatchMapping("/{id}/pin")
     public ResponseEntity<Void> togglePin(@PathVariable Long id) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String email = ((UserDetails) authentication.getPrincipal()).getUsername();
@@ -194,7 +200,8 @@ public class PostController {
     @PatchMapping("/{id}/notice")
     public ResponseEntity<Void> toggleNotice(@PathVariable Long id) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String email = ((UserDetails) authentication.getPrincipal()).getUsername();

--- a/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
+++ b/backend/src/main/java/com/venueon/post/adapter/in/web/PostController.java
@@ -108,6 +108,7 @@ public class PostController {
     public ResponseEntity<Page<PostListResponse>> getPostList(
             @RequestParam Long communityId,
             @RequestParam(required = false) PostType type,
+            @RequestParam(required = false) String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -116,7 +117,7 @@ public class PostController {
             email = ((UserDetails) authentication.getPrincipal()).getUsername();
         }
 
-        Page<PostListResponse> posts = getPostQuery.getPostsByCommunityId(communityId, type, pageable, email);
+        Page<PostListResponse> posts = getPostQuery.getPostsByCommunityId(communityId, type, keyword, pageable, email);
         return ResponseEntity.ok(posts);
     }
 

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/PostPersistenceAdapter.java
@@ -92,6 +92,12 @@ public class PostPersistenceAdapter implements PostRepositoryPort {
     }
 
     @Override
+    public Page<Post> findByKeyword(Long communityId, PostType type, String keyword, Pageable pageable) {
+        return postJpaRepository.searchByKeyword(communityId, type, keyword, pageable)
+                .map(this::mapToDomain);
+    }
+
+    @Override
     public boolean existsLike(Long postId, Long userId) {
         return postLikeJpaRepository.existsByPostIdAndUserId(postId, userId);
     }

--- a/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
+++ b/backend/src/main/java/com/venueon/post/adapter/out/persistence/repository/PostJpaRepository.java
@@ -13,4 +13,17 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
     Page<PostJpaEntity> findByCommunityIdAndTypeOrderByIsNoticeDescIsPinnedDescCreatedAtDesc(Long communityId, PostType type, Pageable pageable);
 
     Page<PostJpaEntity> findByAuthorId(Long authorId, Pageable pageable);
+    
+    @org.springframework.data.jpa.repository.Query("SELECT p FROM PostJpaEntity p " +
+            "WHERE p.community.id = :communityId " +
+            "AND (:type IS NULL OR p.type = :type) " +
+            "AND (p.title LIKE CONCAT('%', :keyword, '%') " +
+            "OR p.content LIKE CONCAT('%', :keyword, '%') " +
+            "OR p.author.nickname LIKE CONCAT('%', :keyword, '%')) " +
+            "ORDER BY p.isNotice DESC, p.isPinned DESC, p.createdAt DESC")
+    Page<PostJpaEntity> searchByKeyword(
+            @org.springframework.data.repository.query.Param("communityId") Long communityId,
+            @org.springframework.data.repository.query.Param("type") com.venueon.post.domain.model.PostType type,
+            @org.springframework.data.repository.query.Param("keyword") String keyword,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/post/application/port/in/GetPostQuery.java
+++ b/backend/src/main/java/com/venueon/post/application/port/in/GetPostQuery.java
@@ -6,10 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface GetPostQuery {
-    Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, Pageable pageable);
+    Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, String keyword, Pageable pageable);
     
     // 북마크 상태 확인을 위해 이메일이 포함된 조회 추가
-    Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, Pageable pageable, String email);
+    Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, String keyword, Pageable pageable, String email);
 
     // 내 북마크 목록만 모아보기
     Page<PostListResponse> getBookmarkedPosts(String email, Pageable pageable);

--- a/backend/src/main/java/com/venueon/post/application/port/out/PostRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/post/application/port/out/PostRepositoryPort.java
@@ -15,6 +15,8 @@ public interface PostRepositoryPort {
     Page<Post> findByCommunityId(Long communityId, Pageable pageable);
 
     Page<Post> findByCommunityIdAndType(Long communityId, PostType type, Pageable pageable);
+    
+    Page<Post> findByKeyword(Long communityId, PostType type, String keyword, Pageable pageable);
 
     boolean existsLike(Long postId, Long userId);
 

--- a/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
+++ b/backend/src/main/java/com/venueon/post/application/service/PostQueryService.java
@@ -22,13 +22,13 @@ public class PostQueryService implements GetPostQuery {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, Pageable pageable) {
-        return getPostsByCommunityId(communityId, type, pageable, null);
+    public Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, String keyword, Pageable pageable) {
+        return getPostsByCommunityId(communityId, type, keyword, pageable, null);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, Pageable pageable,
+    public Page<PostListResponse> getPostsByCommunityId(Long communityId, PostType type, String keyword, Pageable pageable,
             String email) {
         Page<Post> postPage;
 
@@ -37,7 +37,9 @@ public class PostQueryService implements GetPostQuery {
                 ? userRepositoryPort.findByEmail(email).map(User::getId).orElse(null)
                 : null;
 
-        if (type != null) {
+        if (keyword != null && !keyword.isBlank()) {
+            postPage = postRepositoryPort.findByKeyword(communityId, type, keyword, pageable);
+        } else if (type != null) {
             postPage = postRepositoryPort.findByCommunityIdAndType(communityId, type, pageable);
         } else {
             postPage = postRepositoryPort.findByCommunityId(communityId, pageable);

--- a/frontend/src/app/community/[id]/posts/[postId]/edit/page.tsx
+++ b/frontend/src/app/community/[id]/posts/[postId]/edit/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { InputField, TextareaField, Dropdown, Button } from '@/components/ui';
 import { useUIStore } from '@/store/useUIStore';
+import styles from '../../../../components/CommunityForm.module.css';
 
 interface Props {
   params: Promise<{ id: string; postId: string }>;
@@ -86,29 +87,21 @@ export default function PostEditPage({ params }: Props) {
 
   if (isLoading) {
     return (
-      <div className="container-single">
+      <div className={styles.formContainer}>
         <div style={{ textAlign: 'center', padding: '100px' }}>게시글 로딩 중...</div>
       </div>
     );
   }
 
   return (
-    <div className="container-single">
+    <div className={styles.formContainer}>
       
       <section style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '32px' }}>
         <Button variant="secondary" onClick={() => router.back()}>← 뒤로가기</Button>
         <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#111827' }}>게시글 수정</h1>
       </section>
 
-      <section style={{ 
-        background: '#F9FAFB', 
-        padding: '32px', 
-        borderRadius: '16px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        gap: '24px',
-        border: '1px solid #E5E7EB'
-      }}>
+      <section className={styles.formSection}>
         <Dropdown
           label="말머리 (필수)"
           value={type}

--- a/frontend/src/app/community/[id]/write/page.tsx
+++ b/frontend/src/app/community/[id]/write/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { InputField, TextareaField, Dropdown, Button } from '@/components/ui';
 import { useUIStore } from '@/store/useUIStore';
+import styles from '../../components/CommunityForm.module.css';
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -61,23 +62,15 @@ export default function CommunityWritePage({ params }: Props) {
   };
 
   return (
-    /* 사이드바 없이 중앙 800px 레이아웃 적용 */
-    <div className="container-single">
+    /* 사이드바 없이 중앙 1000px 레이아웃 적용 */
+    <div className={styles.formContainer}>
       
       <section style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '32px' }}>
         <Button variant="secondary" onClick={() => router.back()}>← 뒤로가기</Button>
         <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#111827' }}>새 게시글 작성</h1>
       </section>
 
-      <section style={{ 
-        background: '#F9FAFB', 
-        padding: '32px', 
-        borderRadius: '16px', 
-        display: 'flex', 
-        flexDirection: 'column', 
-        gap: '24px',
-        border: '1px solid #E5E7EB'
-      }}>
+      <section className={styles.formSection}>
         <Dropdown
           label="말머리 (필수)"
           value={type}

--- a/frontend/src/app/community/components/CommunityForm.module.css
+++ b/frontend/src/app/community/components/CommunityForm.module.css
@@ -1,0 +1,22 @@
+.formContainer {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: var(--space-24);
+}
+
+.formSection {
+  background: #F9FAFB;
+  padding: 32px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  border: 1px solid #E5E7EB;
+}
+
+@media (max-width: 768px) {
+  .formContainer {
+    max-width: 100%;
+    padding: var(--space-16);
+  }
+}

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -27,6 +27,14 @@
   flex: 1;
 }
 
+.searchButton {
+  flex-shrink: 0;
+}
+
+.writeRow {
+  margin-bottom: 24px;
+}
+
 .postList {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -60,6 +60,8 @@ export default function CommunityPostContainer({ communityId, canManage }: Props
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
+  const [keyword, setKeyword] = useState('');
+  const [searchInput, setSearchInput] = useState('');
 
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
   const [comments, setComments] = useState<CommentResponse[]>([]);
@@ -83,7 +85,7 @@ export default function CommunityPostContainer({ communityId, canManage }: Props
     if (!silent) setIsLoading(true);
     try {
       const response = await fetch(
-        `/api/posts?communityId=${communityId}&page=${currentPage - 1}&size=10`
+        `/api/posts?communityId=${communityId}&page=${currentPage - 1}&size=10${keyword ? `&keyword=${encodeURIComponent(keyword)}` : ''}`
       );
 
       if (!response.ok) {
@@ -320,11 +322,22 @@ export default function CommunityPostContainer({ communityId, canManage }: Props
     }
   };
 
+  const handleSearch = () => {
+    setKeyword(searchInput);
+    setCurrentPage(1); // 검색 시 첫 페이지로 이동
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
   const [isPostMenuOpen, setIsPostMenuOpen] = useState(false);
 
   useEffect(() => {
     fetchPosts();
-  }, [communityId, currentPage]);
+  }, [communityId, currentPage, keyword]);
 
   useEffect(() => {
     if (selectedPostId) {
@@ -367,10 +380,27 @@ export default function CommunityPostContainer({ communityId, canManage }: Props
       <div className={styles.leftSidebar}>
         <div className={styles.searchRow}>
           <div className={styles.searchInputWrapper}>
-            <InputField variant="search" placeholder="검색어를 입력하세요" />
+            <InputField 
+              variant="search" 
+              placeholder="게시글 검색 (제목, 내용, 작성자)" 
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
           </div>
           <Button 
             variant="primary" 
+            onClick={handleSearch}
+            className={styles.searchButton}
+          >
+            검색
+          </Button>
+        </div>
+
+        <div className={styles.writeRow}>
+          <Button 
+            variant="primary" 
+            fullWidth
             onClick={() => {
               if (!isLoggedIn) {
                 showToast('로그인이 필요합니다.', 'error');

--- a/frontend/src/components/ui/Button.module.css
+++ b/frontend/src/components/ui/Button.module.css
@@ -59,3 +59,7 @@
 .outlined:hover:not(:disabled) {
   filter: brightness(0.95);
 }
+
+.fullWidth {
+  width: 100%;
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -4,11 +4,13 @@ import styles from './Button.module.css';
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger' | 'outlined';
   size?: 'medium' | 'large';
+  fullWidth?: boolean;
 }
 
 export default function Button({
   variant = 'primary',
   size = 'medium',
+  fullWidth = false,
   className = '',
   children,
   ...props
@@ -22,11 +24,12 @@ export default function Button({
         ? styles.outlined
         : styles.danger;
   const sizeClass = size === 'large' ? styles.large : styles.medium;
+  const fullWidthClass = fullWidth ? styles.fullWidth : '';
 
 
   return (
     <button
-      className={`${baseClass} ${variantClass} ${sizeClass} ${className}`.trim()}
+      className={`${baseClass} ${variantClass} ${sizeClass} ${fullWidthClass} ${className}`.trim()}
       {...props}
     >
       {children}

--- a/frontend/src/components/ui/TextareaField.module.css
+++ b/frontend/src/components/ui/TextareaField.module.css
@@ -41,7 +41,7 @@
   align-items: flex-start; /* 글씨가 위에서부터 써져야 함 */
   padding: var(--space-12) var(--space-16);
   width: 100%;
-  height: 108px; /* 피그마 지정 108px 고정 */
+  min-height: 108px; /* 최소 높이 지정, 필요 시 더 커질 수 있음 */
   background: var(--color-bg); /* #FFFFFF */
   border: 1px solid var(--color-text-gray-300); /* #D1D5DB */
   border-radius: var(--radius-md);
@@ -52,14 +52,12 @@
 .textareaElement {
   flex-grow: 1;
   width: 100%;
-  height: 100%; /* 부모 컨테이너(108px) 안에 꽉 차게 */
   border: none;
   outline: none;
   background: transparent;
   /* Body/Regular */
   font: var(--text-body-medium);
   color: var(--color-text-gray-700); /* 입력 상태 텍스트 색상 #374151 */
-  resize: none; /* 유저가 임의로 크기 조절 못하게 막음 (피그마 108px 스펙 강제) */
 }
 
 .textareaElement::placeholder {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -95,7 +95,7 @@ select {
 }
 
 .container-single {
-  max-width: 1000px;
+  max-width: 800px;
   margin: 0 auto;
   padding: var(--space-24);
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -95,7 +95,7 @@ select {
 }
 
 .container-single {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: var(--space-24);
 }


### PR DESCRIPTION
 *주요 작업 내용
커뮤니티 내 게시글 검색 기능을 구현하고, 게시글 작성 관련 UI/UX를 개선했습니다.

1. 백엔드 (Backend)
게시글 목록 조회 API에 키워드 검색 기능 추가 (제목, 내용, 작성자 닉네임 기준)
JPQL을 사용하여 통합 검색 쿼리 구현 및 계층별 로직 반영

2. 프론트엔드 (Frontend)
검색 UI 구현: 검색창에 인풋 상태 조절 및 API 연동 (Enter 및 검색 버튼 지원)
레이아웃 개선:
검색창 옆 '검색' 버튼 배치, '글쓰기' 버튼은 리스트 상단으로 이동
글쓰기/수정 컨테이너 너비 확장 (800px → 1000px)
본문 입력창 높이 자동 조절 및 유저 리사이징 허용
컴포넌트 추가: 

Button
 컴포넌트 fullWidth 옵션 추가

VO-657