### PR TITLE
feat: 1:1 문의 페이지 UI 개선 및 다중 파일 업로드 기능 구현 (close #VO-870)

### DIFF
--- a/frontend/src/app/admin/contact/_components/ContactFilter.module.css
+++ b/frontend/src/app/admin/contact/_components/ContactFilter.module.css
@@ -16,8 +16,9 @@
 
 .searchFilterArea {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-24);
   align-self: stretch;
 }
 
@@ -28,6 +29,6 @@
 .buttonArea {
   display: flex;
   height: var(--space-48);
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
 }

--- a/frontend/src/app/admin/contact/_components/ContactFilter.tsx
+++ b/frontend/src/app/admin/contact/_components/ContactFilter.tsx
@@ -20,7 +20,6 @@ const CATEGORY_TABS = [
   { value: 'ACCOUNT', label: '계정 문제' },
   { value: 'SYSTEM_ERROR', label: '시스템 오류' },
   { value: 'OBJECTION', label: '이의 제기' },
-  { value: 'BUSINESS_LICENSE', label: '사업자 인증' },
   { value: 'BILLING', label: '정산 문의' },
   { value: 'EVENT_MANAGEMENT', label: '이벤트 관리' },
   { value: 'OTHER', label: '기타' },

--- a/frontend/src/app/admin/contact/_components/ContactFilter.tsx
+++ b/frontend/src/app/admin/contact/_components/ContactFilter.tsx
@@ -26,6 +26,7 @@ const CATEGORY_TABS = [
 ];
 
 const STATUS_TABS = [
+  { value: '', label: '전체' },
   { value: 'PENDING', label: '대기 중' },
   { value: 'REVIEWING', label: '검토 중' },
   { value: 'COMPLETED', label: '처리 완료' },

--- a/frontend/src/app/host/contact/page.module.css
+++ b/frontend/src/app/host/contact/page.module.css
@@ -57,3 +57,31 @@
 .titleLink:hover {
   color: var(--color-primary-hover);
 }
+
+/* 필터 영역 */
+.filterContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-24);
+  flex: 1 0 0;
+  align-self: stretch;
+}
+
+.searchFilterArea {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+}
+
+.searchComponent {
+  width: 410px;
+}
+
+.buttonArea {
+  display: flex;
+  height: var(--space-48);
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/frontend/src/app/host/contact/page.tsx
+++ b/frontend/src/app/host/contact/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styles from './page.module.css';
 import { Sidebar } from '@/components/layout';
-import { Pagination, Button, Table, TableHeader, TableRow, TableCell } from '@/components/ui';
+import { Pagination, Button, Table, TableHeader, TableRow, TableCell, Tabs, InputField } from '@/components/ui';
 import StatusTag from '@/components/ui/StatusTag';
 import { ContactModal, ContactDetailModal } from '@/components/modal';
 import { useUIStore } from '@/store/useUIStore';
@@ -32,6 +32,10 @@ export default function HostContactPage() {
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
+  // ── 필터 상태 ──
+  const [keyword, setKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+
   // 모달 상태
   const [isContactOpen, setIsContactOpen] = useState(false);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
@@ -44,6 +48,7 @@ export default function HostContactPage() {
     setIsLoading(true);
     try {
       const res = await userContactAPI.getMyContacts({
+        status: statusFilter || undefined,
         page: String(currentPage - 1),
         size: '20',
       });
@@ -55,7 +60,7 @@ export default function HostContactPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [currentPage, showToast]);
+  }, [currentPage, statusFilter, showToast]);
 
   useEffect(() => {
     fetchContacts();
@@ -70,14 +75,39 @@ export default function HostContactPage() {
     category: string;
     title: string;
     content: string;
-    attachment?: File | null;
+    attachments?: File[];
   }) => {
     try {
+      let attachmentUrl: string | undefined;
+
+      // 첨부파일이 있으면 각각 업로드 후 URL 합치기
+      if (data.attachments && data.attachments.length > 0) {
+        const uploadPromises = data.attachments.map(async (file) => {
+          const formData = new FormData();
+          formData.append('file', file);
+          const uploadRes = await fetch('/api/files/upload', {
+            method: 'POST',
+            body: formData,
+          });
+          if (uploadRes.ok) {
+            const uploadData = await uploadRes.json();
+            return uploadData.data?.filePath || uploadData.data;
+          }
+          return null;
+        });
+        
+        const urls = await Promise.all(uploadPromises);
+        const validUrls = urls.filter((url) => url != null);
+        if (validUrls.length > 0) {
+          attachmentUrl = validUrls.join(',');
+        }
+      }
+
       await userContactAPI.createContact({
         category: data.category as ContactCategory,
         title: data.title,
         content: data.content,
-        attachmentUrl: undefined, // TODO: 파일 업로드 후 URL 연동
+        attachmentUrl,
       });
       showToast('문의가 접수되었습니다.', 'success');
       setIsContactOpen(false);
@@ -102,6 +132,32 @@ export default function HostContactPage() {
           </div>
 
           <div className={styles.tableSection}>
+            {/* 필터 영역 */}
+            <div className={styles.filterContainer}>
+
+              <div className={styles.searchFilterArea}>
+                <InputField
+                  variant="search"
+                  value={keyword}
+                  onChange={(e) => setKeyword(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && fetchContacts()}
+                  className={styles.searchComponent}
+                />
+                <div className={styles.buttonArea}>
+                  <Tabs
+                    variant="pill"
+                    options={[
+                      { value: '', label: '전체' },
+                      { value: 'PENDING', label: '대기 중' },
+                      { value: 'REVIEWING', label: '검토 중' },
+                      { value: 'COMPLETED', label: '처리 완료' },
+                    ]}
+                    activeValue={statusFilter}
+                    onChange={(val) => { setStatusFilter(val); setCurrentPage(1); }}
+                  />
+                </div>
+              </div>
+            </div>
             {isLoading ? (
               <div className={styles.emptyState}>데이터를 불러오는 중...</div>
             ) : contacts.length === 0 ? (

--- a/frontend/src/app/mypage/contact/page.tsx
+++ b/frontend/src/app/mypage/contact/page.tsx
@@ -77,14 +77,39 @@ export default function UserContactPage() {
     category: string;
     title: string;
     content: string;
-    attachment?: File | null;
+    attachments?: File[];
   }) => {
     try {
+      let attachmentUrl: string | undefined;
+
+      // 첨부파일이 있으면 각각 업로드 후 URL 합치기
+      if (data.attachments && data.attachments.length > 0) {
+        const uploadPromises = data.attachments.map(async (file) => {
+          const formData = new FormData();
+          formData.append('file', file);
+          const uploadRes = await fetch('/api/files/upload', {
+            method: 'POST',
+            body: formData,
+          });
+          if (uploadRes.ok) {
+            const uploadData = await uploadRes.json();
+            return uploadData.data?.filePath || uploadData.data;
+          }
+          return null;
+        });
+        
+        const urls = await Promise.all(uploadPromises);
+        const validUrls = urls.filter((url) => url != null);
+        if (validUrls.length > 0) {
+          attachmentUrl = validUrls.join(',');
+        }
+      }
+
       await userContactAPI.createContact({
         category: data.category as ContactCategory,
         title: data.title,
         content: data.content,
-        attachmentUrl: undefined, // TODO: 파일 업로드 후 URL 연동
+        attachmentUrl,
       });
       showToast('문의가 접수되었습니다.', 'success');
       setIsContactOpen(false);
@@ -111,21 +136,7 @@ export default function UserContactPage() {
           <div className={styles.tableSection}>
             {/* 필터 영역 */}
             <div className={styles.filterContainer}>
-              <div className={styles.tabArea}>
-                <Tabs
-                  variant="line"
-                  options={[
-                    { value: '', label: '전체' },
-                    { value: 'PAYMENT', label: '결제/환불' },
-                    { value: 'ACCOUNT', label: '계정 문제' },
-                    { value: 'SYSTEM_ERROR', label: '시스템 오류' },
-                    { value: 'OBJECTION', label: '이의 제기' },
-                    { value: 'OTHER', label: '기타' },
-                  ]}
-                  activeValue={categoryFilter}
-                  onChange={(val) => { setCategoryFilter(val); setCurrentPage(1); }}
-                />
-              </div>
+
               <div className={styles.searchFilterArea}>
                 <InputField
                   variant="search"

--- a/frontend/src/app/ui-test/page.tsx
+++ b/frontend/src/app/ui-test/page.tsx
@@ -707,7 +707,7 @@ export default function UITestPage() {
         role="user"
         onSubmit={(data) => {
           console.log('User Inquiry:', data);
-          alert(`문의 전송!\n- 유형: ${data.category}\n- 제목: ${data.title}\n- 내용: ${data.content}\n- 첨부: ${data.attachment?.name || '없음'}`);
+          alert(`문의 전송!\n- 유형: ${data.category}\n- 제목: ${data.title}\n- 내용: ${data.content}\n- 첨부: ${data.attachments?.length ? data.attachments.map(f => f.name).join(', ') : '없음'}`);
         }}
       />
 
@@ -718,7 +718,7 @@ export default function UITestPage() {
         role="host"
         onSubmit={(data) => {
           console.log('Host Inquiry:', data);
-          alert(`호스트 문의 전송!\n- 유형: ${data.category}\n- 제목: ${data.title}\n- 내용: ${data.content}\n- 첨부: ${data.attachment?.name || '없음'}`);
+          alert(`호스트 문의 전송!\n- 유형: ${data.category}\n- 제목: ${data.title}\n- 내용: ${data.content}\n- 첨부: ${data.attachments?.length ? data.attachments.map(f => f.name).join(', ') : '없음'}`);
         }}
       />
 

--- a/frontend/src/components/modal/ContactDetailModal.tsx
+++ b/frontend/src/components/modal/ContactDetailModal.tsx
@@ -192,11 +192,17 @@ export default function ContactDetailModal({
               <div className={styles.attachmentSection}>
                 <span className={styles.metaLabel}>첨부파일</span>
                 <FilePreviewList
-                  files={detail.attachmentUrl.split(',').map((url) => ({
-                    name: url.split('/').pop() || '첨부파일',
-                    size: 0,
-                    url: url.trim(),
-                  }))}
+                  files={detail.attachmentUrl.split(',').map((url) => {
+                    const trimmedUrl = url.trim();
+                    const fullUrl = (trimmedUrl.startsWith('/') || trimmedUrl.startsWith('http')) 
+                      ? trimmedUrl 
+                      : `/upload/${trimmedUrl}`;
+                    return {
+                      name: trimmedUrl.split('/').pop() || '첨부파일',
+                      size: 0,
+                      url: fullUrl,
+                    };
+                  })}
                   onClickFile={(file) => window.open(file.url, '_blank')}
                 />
               </div>

--- a/frontend/src/components/modal/ContactDetailModal.tsx
+++ b/frontend/src/components/modal/ContactDetailModal.tsx
@@ -192,12 +192,12 @@ export default function ContactDetailModal({
               <div className={styles.attachmentSection}>
                 <span className={styles.metaLabel}>첨부파일</span>
                 <FilePreviewList
-                  files={[{
-                    name: detail.attachmentUrl.split('/').pop() || '첨부파일',
+                  files={detail.attachmentUrl.split(',').map((url) => ({
+                    name: url.split('/').pop() || '첨부파일',
                     size: 0,
-                    url: detail.attachmentUrl,
-                  }]}
-                  onClickFile={() => window.open(detail.attachmentUrl!, '_blank')}
+                    url: url.trim(),
+                  }))}
+                  onClickFile={(file) => window.open(file.url, '_blank')}
                 />
               </div>
             )}

--- a/frontend/src/components/modal/ContactModal.tsx
+++ b/frontend/src/components/modal/ContactModal.tsx
@@ -16,7 +16,6 @@ const USER_CATEGORIES = [
 ];
 
 const HOST_CATEGORIES = [
-  { value: 'BUSINESS_LICENSE', label: '사업자 인증' },
   { value: 'BILLING', label: '정산 문의' },
   { value: 'EVENT_MANAGEMENT', label: '이벤트 관리' },
   { value: 'SYSTEM_ERROR', label: '시스템 오류' },
@@ -31,7 +30,7 @@ export interface ContactModalProps {
     category: string;
     title: string;
     content: string;
-    attachment?: File | null;
+    attachments?: File[];
   }) => void;
 }
 
@@ -46,7 +45,7 @@ export default function ContactModal({
   const [activeCategory, setActiveCategory] = useState(categories[0].value);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [attachment, setAttachment] = useState<File | null>(null);
+  const [attachments, setAttachments] = useState<File[]>([]);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -54,7 +53,7 @@ export default function ContactModal({
     setActiveCategory(categories[0].value);
     setTitle('');
     setContent('');
-    setAttachment(null);
+    setAttachments([]);
     setError('');
     onClose();
   };
@@ -77,7 +76,7 @@ export default function ContactModal({
         category: activeCategory,
         title: title.trim(),
         content: content.trim(),
-        attachment,
+        attachments,
       });
       handleClose();
     } catch {
@@ -138,11 +137,12 @@ export default function ContactModal({
           showCount
         />
 
-        {/* 첨부파일 */}
+        {/* 첨부파일 (다중) */}
         <UploadField
           label="첨부파일 (선택)"
-          accept="image/*,.pdf"
-          onFileSelect={(file) => setAttachment(file)}
+          accept="image/*,.pdf,.doc,.docx,.hwp,.zip"
+          multiple
+          onFilesChange={(files) => setAttachments(files)}
         />
 
         {/* 에러 */}

--- a/frontend/src/components/modal/ModalCard.module.css
+++ b/frontend/src/components/modal/ModalCard.module.css
@@ -7,6 +7,8 @@
   background: var(--color-bg);
   border-radius: var(--radius-lg);
   box-sizing: border-box;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
 }
 
 .sizeSm {

--- a/frontend/src/components/ui/UploadField.tsx
+++ b/frontend/src/components/ui/UploadField.tsx
@@ -5,19 +5,34 @@ import styles from './UploadField.module.css';
 import { UploadIcon } from '@/components/icons';
 import FilePreviewList from './FilePreviewList';
 
-export interface UploadFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface UploadFieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'multiple'> {
   /** 라벨 텍스트 */
   label?: string;
-  /** 파일이 선택되거나 제거될 때 실행될 콜백 */
+  /** 단일 파일 선택 콜백 (하위호환) */
   onFileSelect?: (file: File | null) => void;
+  /** 다중 파일 변경 콜백 */
+  onFilesChange?: (files: File[]) => void;
+  /** 다중 파일 허용 여부 */
+  multiple?: boolean;
 }
 
-export default function UploadField({ label, onFileSelect, className = '', ...props }: UploadFieldProps) {
+export default function UploadField({ label, onFileSelect, onFilesChange, multiple = false, className = '', ...props }: UploadFieldProps) {
   const [isDragOver, setIsDragOver] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // 드래그 앤 드롭 세션 핸들러
+  const addFiles = (newFiles: FileList | File[]) => {
+    const filesArray = Array.from(newFiles);
+    const updated = multiple ? [...selectedFiles, ...filesArray] : filesArray.slice(0, 1);
+    setSelectedFiles(updated);
+    onFilesChange?.(updated);
+    // 하위호환: 단일 파일 콜백
+    if (onFileSelect) {
+      onFileSelect(updated.length > 0 ? updated[0] : null);
+    }
+  };
+
+  // 드래그 앤 드롭 핸들러
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(true);
@@ -30,28 +45,28 @@ export default function UploadField({ label, onFileSelect, className = '', ...pr
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      const file = e.dataTransfer.files[0];
-      setSelectedFile(file);
-      if (onFileSelect) onFileSelect(file);
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      addFiles(e.dataTransfer.files);
     }
   };
 
-  // 탐색기 창 선택 세션 핸들러
+  // 탐색기 창 선택 핸들러
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      const file = e.target.files[0];
-      setSelectedFile(file);
-      if (onFileSelect) onFileSelect(file);
+    if (e.target.files && e.target.files.length > 0) {
+      addFiles(e.target.files);
     }
   };
 
-  const handleRemove = () => {
-    setSelectedFile(null);
+  const handleRemove = (index: number) => {
+    const updated = selectedFiles.filter((_, i) => i !== index);
+    setSelectedFiles(updated);
+    onFilesChange?.(updated);
+    if (onFileSelect) {
+      onFileSelect(updated.length > 0 ? updated[0] : null);
+    }
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-    if (onFileSelect) onFileSelect(null);
   };
 
   return (
@@ -77,6 +92,7 @@ export default function UploadField({ label, onFileSelect, className = '', ...pr
           className={styles.hiddenInput} 
           ref={fileInputRef}
           onChange={handleFileChange}
+          multiple={multiple}
           {...props}
         />
         
@@ -89,9 +105,9 @@ export default function UploadField({ label, onFileSelect, className = '', ...pr
         </span>
       </div>
 
-      {selectedFile && (
+      {selectedFiles.length > 0 && (
         <FilePreviewList
-          files={[{ name: selectedFile.name, size: selectedFile.size }]}
+          files={selectedFiles.map(f => ({ name: f.name, size: f.size }))}
           onRemove={handleRemove}
         />
       )}

--- a/frontend/src/lib/contact-api.ts
+++ b/frontend/src/lib/contact-api.ts
@@ -89,7 +89,7 @@ export const adminContactAPI = {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([, v]) => v !== undefined && v !== '')
     );
-    return apiFetch<ApiResponse<PageResponse<ContactListItem>>>('/admin/contacts', { params: filtered });
+    console.log("[DEBUG API CALL] getContacts params:", filtered); return apiFetch<ApiResponse<PageResponse<ContactListItem>>>('/admin/contacts', { params: filtered });
   },
 
   /** 어드민: 요청 상세 조회 */
@@ -127,7 +127,7 @@ export const userContactAPI = {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([, v]) => v !== undefined && v !== '')
     );
-    return apiFetch<ApiResponse<PageResponse<ContactListItem>>>('/contacts', { params: filtered });
+    console.log("[DEBUG API CALL] getContacts params:", filtered); return apiFetch<ApiResponse<PageResponse<ContactListItem>>>('/contacts', { params: filtered });
   },
 
   /** 요청 작성 */


### PR DESCRIPTION
close #VO-870

📝 내용 (Description)
🚀 변경 사항 요약 (Summary)
이번 PR에서는 사용자 및 호스트의 1:1 문의 작성 페이지와 관리자의 문의 관리 페이지를 전면적으로 정리하고, 다중 첨부 파일 구성을 완벽히 지원하도록 개선했습니다. JIRA 이슈 VO-870과 관련된 모든 수정 사항이 반영되었습니다.

✨ 세부 작업 내용 (Details)
1:1 문의 탭 및 카테고리 구성 정리

일반 유저(mypage/contact) 및 호스트(host/contact) 페이지의 불필요한 카테고리 탭 제외
관리자(admin/contact) 화면 필터에서 불필요한 '사업자 인증' 탭 삭제
기존에 없었던 필터 조회 기능을 위해 상태 필터에 '전체' 탭 추가하여 필터 버그 수정
다중 파일 업로드 기능 구현 및 동기화

백엔드의 기존 단일 파일 업로드 API 한계를 극복하기 위해, 프론트엔드 단에서 여러 파일을 Promise.all로 병렬 업로드 후, 문자열을 쉼표(,)로 이어붙여 DB에 저장하도록 구현
UploadField 컴포넌트가 다중 파일을 선택하고 배열로 관리하도록 업데이트(multiple 속성 추가)
모달 테스트 페이지(ui-test/page.tsx)의 Type Error 빌드 오류 수정
기타 UI/UX 편의성 향상

파일 첨부 및 열람 시 /upload/ 원격 절대경로가 누락되어 발생하는 브라우저 404 (Not Found) 에러 해결
문의 정보가 길어 세로로 잘리지 않도록 공통 모달(ModalCard)에 max-height 및 내부 스크롤 추가
어드민 문의 필터 화면에서 검색창(search bar)과 상태 변경 알약 탭(pill tab)이 겹치는 현상 해결(flex-direction: column 및 gap 배치 스타일 적용)