### PR TITLE
feat: 비밀번호 찾기 (임시 비밀번호 발급) 기능 구현

### DIFF
--- a/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/venueon/common/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 // 인증 불필요 경로
-                .requestMatchers("/auth/signup", "/auth/host/signup", "/auth/login", "/auth/google", "/auth/verify-email").permitAll()
+                .requestMatchers("/auth/signup", "/auth/host/signup", "/auth/login", "/auth/google", "/auth/verify-email", "/auth/reset-password").permitAll()
                 // Swagger UI
                 .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
                 // Actuator

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -99,7 +99,8 @@ public class AuthController {
                 result.token(),
                 result.email(),
                 result.nickname(),
-                result.role()
+                result.role(),
+                result.tempPassword()
         );
 
         return ResponseEntity.ok(response);
@@ -118,7 +119,8 @@ public class AuthController {
                 result.token(),
                 result.email(),
                 result.nickname(),
-                result.role()
+                result.role(),
+                result.tempPassword()
         );
 
         return ResponseEntity.ok(response);
@@ -187,5 +189,16 @@ public class AuthController {
         log.debug("이메일 인증 요청: token={}", token);
         authService.verifyEmail(token);
         return ResponseEntity.ok(ApiResponse.success("이메일 인증이 완료되었습니다."));
+    }
+
+    /**
+     * POST /auth/reset-password — 임시 비밀번호 발급 (비밀번호 찾기)
+     */
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<String>> resetPassword(@RequestBody java.util.Map<String, String> request) {
+        String email = request.get("email");
+        log.debug("비밀번호 찾기 요청: email={}", email);
+        authService.resetPassword(email);
+        return ResponseEntity.ok(ApiResponse.success("임시 비밀번호가 메일로 발송되었습니다."));
     }
 }

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginResponse.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/LoginResponse.java
@@ -1,11 +1,12 @@
 package com.venueon.user.adapter.in.web.dto;
 
 /**
- * 로그인 응답 DTO (token, email, nickname, role)
+ * 로그인 응답 DTO (token, email, nickname, role, tempPassword)
  */
 public record LoginResponse(
         String token,
         String email,
         String nickname,
-        com.venueon.common.dto.CodeDto role
+        com.venueon.common.dto.CodeDto role,
+        boolean tempPassword
 ) {}

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpdatePasswordRequest.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UpdatePasswordRequest.java
@@ -3,7 +3,6 @@ package com.venueon.user.adapter.in.web.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdatePasswordRequest(
-    @NotBlank(message = "현재 비밀번호는 필수입니다.")
     String currentPassword,
     
     @NotBlank(message = "새 비밀번호는 필수입니다.")

--- a/backend/src/main/java/com/venueon/user/application/port/in/LoginUseCase.java
+++ b/backend/src/main/java/com/venueon/user/application/port/in/LoginUseCase.java
@@ -8,7 +8,7 @@ public interface LoginUseCase {
     /**
      * 로그인 결과 DTO (Service → Controller 전달용)
      */
-    record LoginResult(String token, String email, String nickname, com.venueon.common.dto.CodeDto role) {}
+    record LoginResult(String token, String email, String nickname, com.venueon.common.dto.CodeDto role, boolean tempPassword) {}
 
     LoginResult login(String email, String password);
 }

--- a/backend/src/main/java/com/venueon/user/application/service/AuthService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/AuthService.java
@@ -145,17 +145,27 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "구글 소셜 로그인으로 가입된 계정입니다. 구글 로그인을 이용해 주세요.");
         }
 
-        // 비밀번호 검증
-        if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+        // 비밀번호 검증 — {TEMP} 접두사가 붙은 임시 비밀번호도 지원
+        String storedPassword = user.getPassword();
+        boolean isTempPassword = false;
+        if (storedPassword.startsWith("{TEMP}")) {
+            String actualHash = storedPassword.substring(6);
+            if (!passwordEncoder.matches(password, actualHash)) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+            }
+            isTempPassword = true;
+        } else {
+            if (!passwordEncoder.matches(password, storedPassword)) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+            }
         }
 
         // JWT 토큰 생성 (Security 계층과 일관되게 code 문자열 사용)
         String roleCode = resolveRoleCode(user.getRole().id());
         String token = jwtTokenProvider.generateToken(user.getEmail(), roleCode);
 
-        log.info("로그인 성공: email={}", email);
-        return new LoginResult(token, user.getEmail(), user.getNickname(), com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()));
+        log.info("로그인 성공: email={}, tempPassword={}", email, isTempPassword);
+        return new LoginResult(token, user.getEmail(), user.getNickname(), com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()), isTempPassword);
     }
 
     @Override
@@ -199,7 +209,7 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
         String roleCode = resolveRoleCode(user.getRole().id());
         String token = jwtTokenProvider.generateToken(user.getEmail(), roleCode);
 
-        return new LoginResult(token, user.getEmail(), user.getNickname(), com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()));
+        return new LoginResult(token, user.getEmail(), user.getNickname(), com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()), false);
     }
 
     @Override
@@ -321,6 +331,46 @@ public class AuthService implements SignUpUseCase, HostSignUpUseCase, LoginUseCa
         tokenRepository.delete(tokenEntity);
 
         log.info("이메일 인증 완료: email={}", tokenEntity.getEmail());
+    }
+
+    /**
+     * 비밀번호 찾기: 임시 비밀번호를 생성하여 메일로 발송합니다.
+     */
+    @Transactional
+    public void resetPassword(String email) {
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "등록되지 않은 이메일입니다."));
+
+        if (!user.isActive()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "비활성 계정입니다. 관리자에게 문의해 주세요.");
+        }
+
+        if (user.isGoogleUser()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "구글 소셜 로그인 계정입니다. 구글 로그인을 이용해 주세요.");
+        }
+
+        // 8자리 임시 비밀번호 생성
+        String tempPassword = generateTempPassword();
+        // {TEMP} 접두사를 붙여 임시 비밀번호임을 표시
+        String encodedPassword = "{TEMP}" + passwordEncoder.encode(tempPassword);
+        user.updatePassword(encodedPassword);
+        userRepositoryPort.save(user);
+
+        mailService.sendTempPasswordEmail(email, tempPassword);
+        log.info("임시 비밀번호 발급 완료: email={}", email);
+    }
+
+    /**
+     * 8자리 영문+숫자 임시 비밀번호를 생성합니다.
+     */
+    private String generateTempPassword() {
+        String chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
+        StringBuilder sb = new StringBuilder();
+        java.security.SecureRandom random = new java.security.SecureRandom();
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
     }
 
     /**

--- a/backend/src/main/java/com/venueon/user/application/service/MailService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/MailService.java
@@ -111,6 +111,91 @@ public class MailService {
     }
 
     /**
+     * 임시 비밀번호 메일을 발송합니다.
+     */
+    public void sendTempPasswordEmail(String toEmail, String tempPassword) {
+        String subject = "[VenueOn] 임시 비밀번호 안내";
+        String loginUrl = frontendUrl + "/login";
+        String htmlContent = buildTempPasswordHtml(tempPassword, loginUrl);
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(fromEmail);
+            helper.setTo(toEmail);
+            helper.setSubject(subject);
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+            log.info("임시 비밀번호 메일 발송 완료: to={}", toEmail);
+        } catch (MessagingException e) {
+            log.error("임시 비밀번호 메일 발송 실패: to={}", toEmail, e);
+            throw new RuntimeException("임시 비밀번호 메일 발송에 실패했습니다.", e);
+        }
+    }
+
+    private String buildTempPasswordHtml(String tempPassword, String loginUrl) {
+        return """
+            <!DOCTYPE html>
+            <html lang="ko">
+            <head><meta charset="UTF-8"></head>
+            <body style="margin:0;padding:0;background:#F3F4F6;font-family:'Pretendard','Apple SD Gothic Neo','Malgun Gothic',sans-serif;">
+              <table width="100%%" cellpadding="0" cellspacing="0" style="padding:40px 0;">
+                <tr><td align="center">
+                  <table width="480" cellpadding="0" cellspacing="0" style="background:#FFFFFF;border-radius:12px;box-shadow:0 4px 6px rgba(0,0,0,0.3);overflow:hidden;">
+                    <!-- Header -->
+                    <tr>
+                      <td style="background:#374151;padding:32px 40px;text-align:center;">
+                        <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;">VenueOn</h1>
+                        <p style="margin:8px 0 0;color:rgba(255,255,255,0.85);font-size:14px;">임시 비밀번호 안내</p>
+                      </td>
+                    </tr>
+                    <!-- Body -->
+                    <tr>
+                      <td style="padding:40px;">
+                        <h2 style="margin:0 0 16px;font-size:20px;color:#111827;">임시 비밀번호가 발급되었습니다 🔑</h2>
+                        <p style="margin:0 0 24px;font-size:15px;color:#6B7280;line-height:1.6;">
+                          아래 임시 비밀번호로 로그인하신 후,<br>
+                          새 비밀번호로 변경해 주세요.
+                        </p>
+                        <table width="100%%" cellpadding="0" cellspacing="0" style="background:#F9FAFB;border-radius:8px;margin-bottom:24px;">
+                          <tr>
+                            <td style="padding:20px;text-align:center;">
+                              <p style="margin:0 0 8px;font-size:13px;color:#6B7280;">임시 비밀번호</p>
+                              <p style="margin:0;font-size:28px;font-weight:700;color:#111827;letter-spacing:4px;">%s</p>
+                            </td>
+                          </tr>
+                        </table>
+                        <table width="100%%" cellpadding="0" cellspacing="0">
+                          <tr><td align="center" style="padding:8px 0 24px;">
+                            <a href="%s"
+                               style="display:inline-block;padding:14px 48px;background:#374151;
+                                      color:#FFFFFF;text-decoration:none;border-radius:8px;font-size:16px;font-weight:600;">
+                              로그인하러 가기
+                            </a>
+                          </td></tr>
+                        </table>
+                        <p style="margin:0;font-size:13px;color:#9CA3AF;line-height:1.5;">
+                          보안을 위해 로그인 후 반드시 비밀번호를 변경해 주세요.<br>
+                          본인이 요청하지 않으셨다면, 이 메일을 무시해 주세요.
+                        </p>
+                      </td>
+                    </tr>
+                    <!-- Footer -->
+                    <tr>
+                      <td style="padding:20px 40px;background:#F3F4F6;text-align:center;border-top:1px solid #D1D5DB;">
+                        <p style="margin:0;font-size:12px;color:#9CA3AF;">© 2026 VenueOn. All rights reserved.</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            """.formatted(tempPassword, loginUrl);
+    }
+
+    /**
      * 결제 확인 메일을 발송합니다.
      *
      * @param toEmail      수신자 이메일

--- a/backend/src/main/java/com/venueon/user/application/service/UserService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/UserService.java
@@ -54,8 +54,18 @@ public class UserService implements UpdateUserProfileUseCase, UpdateUserPassword
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "탈퇴 처리된 사용자입니다.");
         }
 
-        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "현재 비밀번호가 일치하지 않습니다.");
+        // {TEMP} 접두사가 붙은 임시 비밀번호인 경우 현재 비밀번호 검증 건너뛰기
+        String storedPassword = user.getPassword();
+        if (storedPassword.startsWith("{TEMP}")) {
+            // 임시 비밀번호 → 새 비밀번호로 변경 (현재 비밀번호 검증 불필요, 이미 로그인 인증됨)
+            log.info("임시 비밀번호 → 새 비밀번호 변경: email={}", email);
+        } else {
+            if (currentPassword == null || currentPassword.isBlank()) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "현재 비밀번호는 필수입니다.");
+            }
+            if (!passwordEncoder.matches(currentPassword, storedPassword)) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "현재 비밀번호가 일치하지 않습니다.");
+            }
         }
 
         user.updatePassword(passwordEncoder.encode(newPassword));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -460,17 +461,6 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1280,6 +1270,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
       "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1528,6 +1519,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
       "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1646,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.3.tgz",
       "integrity": "sha512-JKmWAogM/LX9ZJmXJQalpcR77wWVtVXdRFgvHGsFomW9WFhZqcnIEDWR2sbpZHWtu8dml6eBQGhdLppJmxeFfA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1672,6 +1665,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
       "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1686,6 +1680,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
       "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -1849,6 +1844,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1858,6 +1854,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1913,6 +1910,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2438,6 +2436,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2780,6 +2779,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3368,6 +3368,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3553,6 +3554,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5586,6 +5588,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -5615,6 +5618,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -5663,6 +5667,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
       "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -5723,6 +5728,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6394,6 +6400,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6556,6 +6563,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6871,6 +6879,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -461,6 +460,17 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1270,7 +1280,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
       "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1519,7 +1528,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
       "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1638,7 +1646,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.3.tgz",
       "integrity": "sha512-JKmWAogM/LX9ZJmXJQalpcR77wWVtVXdRFgvHGsFomW9WFhZqcnIEDWR2sbpZHWtu8dml6eBQGhdLppJmxeFfA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1665,7 +1672,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
       "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1680,7 +1686,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
       "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -1844,7 +1849,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1854,7 +1858,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1910,7 +1913,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2436,7 +2438,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2779,7 +2780,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3368,7 +3368,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3554,7 +3553,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5588,7 +5586,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -5618,7 +5615,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -5667,7 +5663,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
       "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -5728,7 +5723,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6400,7 +6394,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6563,7 +6556,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6879,7 +6871,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUIStore } from "@/store/useUIStore";
+import InputField from "@/components/ui/InputField";
+import AuthFormLayout from "../_components/AuthFormLayout";
+
+export default function ForgotPasswordPage() {
+  const router = useRouter();
+  const { showToast } = useUIStore();
+
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [sent, setSent] = useState(false);
+  const [isGoogleAccount, setIsGoogleAccount] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsGoogleAccount(false);
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+
+      if (res.ok) {
+        setSent(true);
+        showToast("임시 비밀번호가 메일로 발송되었습니다.", "success");
+      } else {
+        const msg = data.message || "요청에 실패했습니다.";
+        // 구글 소셜 로그인 계정인 경우 별도 UI 표시
+        if (msg.includes("구글")) {
+          setIsGoogleAccount(true);
+        } else {
+          setError(msg);
+        }
+      }
+    } catch {
+      setError("서버와의 통신에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 구글 계정 안내 화면
+  if (isGoogleAccount) {
+    return (
+      <AuthFormLayout
+        title="구글 계정 안내"
+        onSubmit={(e) => { e.preventDefault(); router.push("/login"); }}
+        loading={false}
+        submitText="Google 로그인으로 이동"
+        error=""
+        footerText="다른 계정으로 시도할래요?"
+        footerLinkText="비밀번호 찾기"
+        footerLinkHref="/forgot-password"
+      >
+        <p style={{ color: "var(--color-text-gray-500)", fontSize: "15px", lineHeight: "1.6", textAlign: "center", margin: "0" }}>
+          <strong>{email}</strong>은<br />
+          구글 소셜 로그인으로 가입된 계정입니다.<br /><br />
+          구글 로그인을 이용해 주세요.
+        </p>
+      </AuthFormLayout>
+    );
+  }
+
+  // 발송 완료 화면
+  if (sent) {
+    return (
+      <AuthFormLayout
+        title="메일 발송 완료"
+        onSubmit={(e) => { e.preventDefault(); router.push("/login"); }}
+        loading={false}
+        submitText="로그인하러 가기"
+        error=""
+        footerText="메일이 오지 않았나요?"
+        footerLinkText="다시 요청하기"
+        footerLinkHref="/forgot-password"
+      >
+        <p style={{ color: "var(--color-text-gray-500)", fontSize: "15px", lineHeight: "1.6", textAlign: "center", margin: "0" }}>
+          <strong>{email}</strong>으로<br />
+          임시 비밀번호를 발송했습니다.<br /><br />
+          메일함을 확인하시고 임시 비밀번호로 로그인해 주세요.
+        </p>
+      </AuthFormLayout>
+    );
+  }
+
+  // 이메일 입력 화면
+  return (
+    <AuthFormLayout
+      title="비밀번호 찾기"
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="임시 비밀번호 발송"
+      loadingText="발송 중..."
+      error={error}
+      footerText="비밀번호가 기억나셨나요?"
+      footerLinkText="로그인"
+      footerLinkHref="/login"
+    >
+      <p style={{ color: "var(--color-text-gray-500)", fontSize: "14px", lineHeight: "1.6", margin: "0 0 16px" }}>
+        가입 시 사용한 이메일을 입력하시면<br />
+        임시 비밀번호를 발송해 드립니다.
+      </p>
+      <InputField
+        id="email"
+        label="이메일"
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="가입한 이메일을 입력하세요."
+      />
+    </AuthFormLayout>
+  );
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -40,8 +40,16 @@ function LoginContent() {
     setLoading(true);
 
     try {
-      await authAPI.login(email, password);
+      const result = await authAPI.login(email, password);
       await checkSession();
+
+      // 임시 비밀번호로 로그인한 경우 비밀번호 변경 페이지로 이동
+      if (result.tempPassword) {
+        showToast("임시 비밀번호로 로그인되었습니다. 새 비밀번호를 설정해 주세요.", "info");
+        router.push("/reset-password");
+        return;
+      }
+
       showToast("로그인 성공!", "success");
       const redirectTo = searchParams.get("redirect") || "/";
       router.push(redirectTo);
@@ -66,7 +74,7 @@ function LoginContent() {
       error={error}
       footerText="비밀번호를 잊으셨나요?"
       footerLinkText="비밀번호 찾기"
-      footerLinkHref="#"
+      footerLinkHref="/forgot-password"
       bottomSlot={<GoogleLoginButton position="bottom" />}
     >
       <InputField

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUIStore } from "@/store/useUIStore";
+import InputField from "@/components/ui/InputField";
+import AuthFormLayout from "../_components/AuthFormLayout";
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const { showToast } = useUIStore();
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const isPasswordMismatch =
+    newPassword !== "" && confirmPassword !== "" && newPassword !== confirmPassword;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (newPassword.length < 8) {
+      setError("비밀번호는 8자 이상이어야 합니다.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/users/me/password", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: "", // 임시 비밀번호로 이미 로그인된 상태
+          newPassword,
+        }),
+      });
+
+      if (res.ok) {
+        showToast("비밀번호가 성공적으로 변경되었습니다!", "success");
+        router.push("/");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.message || "비밀번호 변경에 실패했습니다.");
+      }
+    } catch {
+      setError("서버와의 통신에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthFormLayout
+      title="새 비밀번호 설정"
+      onSubmit={handleSubmit}
+      loading={loading}
+      submitText="비밀번호 변경"
+      loadingText="변경 중..."
+      error={error}
+      footerText=""
+      footerLinkText=""
+      footerLinkHref="/"
+    >
+      <p style={{ color: "var(--color-text-gray-500)", fontSize: "14px", lineHeight: "1.6", margin: "0 0 16px" }}>
+        앞으로 사용할 새 비밀번호를 입력해 주세요.
+      </p>
+      <InputField
+        id="new-password"
+        label="새 비밀번호"
+        type="password"
+        required
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        placeholder="8자 이상 입력"
+      />
+      <InputField
+        id="confirm-password"
+        label="새 비밀번호 확인"
+        type="password"
+        required
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        placeholder="비밀번호를 한번 더 입력"
+        error={isPasswordMismatch ? "새 비밀번호가 일치하지 않습니다." : undefined}
+      />
+    </AuthFormLayout>
+  );
+}

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -49,6 +49,7 @@ export async function POST(req: Request) {
         nickname: userData.nickname,
         role: userData.role, // { id: number, label: string }
       },
+      tempPassword: loginData.tempPassword || false,
       success: true
     });
   } catch (error) {


### PR DESCRIPTION
## 📋 개요

비밀번호를 분실한 사용자가 **이메일로 임시 비밀번호를 발급**받고, 로그인 후 **새 비밀번호로 변경**할 수 있는 기능을 구현합니다.
Gmail SMTP 기반의 기존 메일 시스템을 재사용하며, 스키마 변경 없이 DB 비밀번호에 `{TEMP}` 접두사를 붙이는 방식으로 임시 비밀번호 여부를 식별합니다. (VO-601)

---

## 🔄 사용자 플로우

```
[로그인 페이지] → "비밀번호 찾기" 클릭
    ↓
[/forgot-password] 이메일 입력 → POST /auth/reset-password
    ↓
[Backend] 8자리 임시 비밀번호 생성 → {TEMP}+bcrypt로 DB 저장 → 임시 비밀번호 메일 발송
    ↓
[이메일] 임시 비밀번호 확인 → 로그인 페이지에서 입력
    ↓
[로그인] tempPassword=true 감지 → /reset-password 자동 리다이렉트
    ↓
[/reset-password] 새 비밀번호 입력 → PUT /users/me/password
    ↓
[Backend] {TEMP} 감지 → 현재 비밀번호 검증 스킵 → 새 비밀번호 저장
    ↓
[랜딩 페이지(/)로 이동] ✅
```

---

## 📁 변경 파일

### Backend

| 파일 | 변경 | 설명 |
|------|------|------|
| `AuthService.java` | MODIFY | `resetPassword()` 추가: 임시 비밀번호 생성·저장·메일 발송. 로그인 시 `{TEMP}` 접두사 감지 → `tempPassword=true` 반환 |
| `AuthController.java` | MODIFY | `POST /auth/reset-password` 엔드포인트 추가 |
| `LoginUseCase.java` | MODIFY | `LoginResult`에 `tempPassword` 필드 추가 |
| `LoginResponse.java` | MODIFY | 응답 DTO에 `tempPassword` 필드 추가 |
| `MailService.java` | MODIFY | `sendTempPasswordEmail()` + HTML 메일 템플릿 추가 |
| `UserService.java` | MODIFY | `updatePassword()` — `{TEMP}` 비밀번호일 때 현재 비밀번호 검증 스킵 |
| `UpdatePasswordRequest.java` | MODIFY | `currentPassword`의 `@NotBlank` 제거 (임시 비밀번호 사용자는 현재 비밀번호 없음) |
| `SecurityConfig.java` | MODIFY | `/auth/reset-password` permitAll 추가 |

### Frontend

| 파일 | 변경 | 설명 |
|------|------|------|
| `forgot-password/page.tsx` | **NEW** | 이메일 입력 → 임시 비밀번호 요청 페이지. 구글 계정 감지 시 Google 로그인 안내 화면 표시 |
| `reset-password/page.tsx` | **NEW** | 새 비밀번호 설정 페이지. 완료 시 랜딩 페이지(`/`)로 이동 |
| `login/page.tsx` | MODIFY | `tempPassword=true`이면 `/reset-password`로 자동 리다이렉트. 하단 링크를 `/forgot-password`로 연결 |
| `api/auth/login/route.ts` | MODIFY | 백엔드 `tempPassword` 플래그를 프론트 응답에 포함 |

---

## 🔑 구현 상세

### 임시 비밀번호 저장 방식 (`{TEMP}` 접두사)
스키마 변경 없이 임시 비밀번호 여부를 식별합니다.

```
저장값: {TEMP}$2a$10$... (bcrypt 해시 앞에 접두사)
일반 로그인: 접두사 제거 후 matches() 검증 → tempPassword=true 반환
비밀번호 변경: {TEMP} 감지 → currentPassword 검증 없이 새 비밀번호 저장
```

### 구글 소셜 로그인 계정 차단 (2중 방어)
- **Backend**: `user.isGoogleUser()` 체크 → `"구글 소셜 로그인 계정입니다."` 에러 반환
- **Frontend**: 에러 메시지에 `"구글"` 포함 시 → 구글 계정 안내 화면 + "Google 로그인으로 이동" 버튼 표시

### 임시 비밀번호 생성
혼동하기 쉬운 `0, O, 1, l, I` 등의 문자를 제외한 8자리 SecureRandom 생성

```java
String chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
```

---

## 🖥️ 화면 상태

| 상태 | 화면 |
|------|------|
| 기본 | 이메일 입력 + "임시 비밀번호 발송" 버튼 |
| **구글 계정** | `"xxx@gmail.com은 구글 소셜 로그인으로 가입된 계정입니다."` + "Google 로그인으로 이동" 버튼 |
| 발송 완료 | `"임시 비밀번호를 발송했습니다."` + "로그인하러 가기" 버튼 |
| 임시 로그인 후 | `/reset-password` 자동 이동 → 새 비밀번호 설정 → 랜딩 페이지 |

---

## ⚠️ 보안 고려사항

| 항목 | 처리 방식 |
|------|------|
| 임시 비밀번호 노출 최소화 | bcrypt 해시로 저장, 메일에만 평문 전송 |
| 구글 계정 차단 | Backend + Frontend 2중 방어 |
| 임시 비밀번호 강제 변경 | 로그인 시 `tempPassword=true` 감지 → `/reset-password` 강제 이동 |
| 현재 비밀번호 검증 우회 | `{TEMP}` 접두사로만 허용, 이미 JWT 인증으로 신원 확인됨 |
| 비밀번호 최소 길이 | 프론트에서 8자 이상 검증 |

---

## 🧪 테스트 체크리스트

- [ ] 미가입 이메일 입력 → `"등록되지 않은 이메일입니다."` 오류
- [ ] 구글 계정 이메일 입력 → 구글 계정 안내 화면
- [ ] 일반 계정 이메일 입력 → 임시 비밀번호 메일 수신 확인
- [ ] 임시 비밀번호로 로그인 → `/reset-password` 자동 이동
- [ ] 새 비밀번호 8자 미만 입력 → 에러 메시지
- [ ] 새 비밀번호 불일치 → 에러 메시지
- [ ] 새 비밀번호 정상 변경 → 랜딩 페이지(`/`) 이동
- [ ] 변경 후 새 비밀번호로 재로그인 성공
- [ ] 일반 계정에서 마이페이지 비밀번호 변경 시 currentPassword 검증 정상 동작
