### PR TITLE
fix: 위시리스트 카드 연동 + 본인 작성 리뷰 최상단 고정 및 도메인 용어 일괄 통일 #VO-693 #VO-871 

### DIFF
--- a/backend/src/main/java/com/venueon/review/adapter/in/web/ReviewController.java
+++ b/backend/src/main/java/com/venueon/review/adapter/in/web/ReviewController.java
@@ -50,6 +50,7 @@ public class ReviewController {
             String profileUrl = reviewer != null ? (reviewer.getProfileImg() != null ? "/upload/" + reviewer.getProfileImg() : null) : null;
             return ReviewResponse.builder()
                     .id(r.getId())
+                    .authorId(r.getReviewerId())
                     .authorName(authorName)
                     .authorProfileUrl(profileUrl)
                     .rating(r.getRating())

--- a/backend/src/main/java/com/venueon/review/adapter/in/web/dto/ReviewResponse.java
+++ b/backend/src/main/java/com/venueon/review/adapter/in/web/dto/ReviewResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 @Getter @Setter @Builder @AllArgsConstructor @NoArgsConstructor
 public class ReviewResponse {
     private Long id;
+    private Long authorId;
     private String authorName;
     private String authorProfileUrl;
     private int rating;

--- a/backend/src/main/java/com/venueon/wishlist/adapter/in/web/dto/WishlistResponse.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/in/web/dto/WishlistResponse.java
@@ -10,6 +10,9 @@ import java.time.format.DateTimeFormatter;
 public class WishlistResponse {
     private Long id;
     private com.venueon.common.dto.CodeDto status;
+    private com.venueon.common.dto.CodeDto recruitmentStatus;
+    private Long categoryId;
+    private String thumbnailUrl;
     private String title;
     private String organizer;
     private String dateTime;
@@ -17,23 +20,52 @@ public class WishlistResponse {
     private int price;
     private Long wishlistId;
 
-    public static WishlistResponse of(WishlistItem item, Event event, HostInfo host) {
+    public static WishlistResponse of(WishlistItem item, Event event, HostInfo host, 
+        java.util.List<com.venueon.event.domain.model.Session> sessions, 
+        java.util.List<com.venueon.ticket.domain.model.Ticket> tickets) {
+        
         com.venueon.common.dto.CodeDto eventStatus = event.getStatus() != null ? 
             com.venueon.common.dto.CodeDto.of(event.getStatus().id(), event.getStatus().label()) : 
             com.venueon.common.dto.CodeDto.of(com.venueon.common.model.CodeConstants.EVENT_STATUS_ONGOING_ID, "진행중");
+            
+        com.venueon.common.model.DomainCode recruitCode = event.getRecruitmentStatus(sessions);
+        com.venueon.common.dto.CodeDto recruitStatusDto = recruitCode != null ? 
+            com.venueon.common.dto.CodeDto.of(recruitCode.id(), recruitCode.label()) : null;
+
         String organizerName = (host != null && host.nickname() != null) ? host.nickname() : "알 수 없는 호스트";
-        // v6: startDate, location, price는 Session/Ticket으로 이동
-        String dateStr = "-"; // TODO: Session 기반으로 변경
         
+        // 날짜/장소는 첫 번째 세션 기준
+        String dateStr = "-";
+        String locStr = "-";
+        if (sessions != null && !sessions.isEmpty()) {
+            java.time.LocalDateTime startDate = event.getStartDate(sessions);
+            if (startDate != null) {
+                java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy년 M월 d일 a h시").withLocale(java.util.Locale.KOREAN);
+                dateStr = startDate.format(formatter);
+            }
+            // 장소 (오프라인이면 location, 온라인이면 온라인)
+            com.venueon.event.domain.model.Session firstSession = sessions.get(0);
+            locStr = firstSession.getIsOnline() ? "온라인 진행" : (firstSession.getLocation() != null ? firstSession.getLocation() : "-");
+        }
+
+        // 가격은 첫 번째 티켓 기준
+        int minPrice = 0;
+        if (tickets != null && !tickets.isEmpty()) {
+            minPrice = tickets.get(0).getPrice();
+        }
+
         return WishlistResponse.builder()
             .id(event.getId())
             .wishlistId(item.getId())
             .status(eventStatus)
+            .recruitmentStatus(recruitStatusDto)
+            .categoryId(event.getCategoryId())
+            .thumbnailUrl(event.getThumbnailUrl())
             .title(event.getTitle())
             .organizer(organizerName)
             .dateTime(dateStr)
-            .location("-") // TODO: Session 기반으로 변경
-            .price(0) // TODO: Ticket 기반으로 변경
+            .location(locStr)
+            .price(minPrice)
             .build();
     }
 }

--- a/backend/src/main/java/com/venueon/wishlist/adapter/out/client/EventClientAdapter.java
+++ b/backend/src/main/java/com/venueon/wishlist/adapter/out/client/EventClientAdapter.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EventClientAdapter implements LoadEventPort {
     private final EventQueryService eventQueryService;
+    private final com.venueon.event.application.port.out.SessionPort sessionPort;
+    private final com.venueon.ticket.application.port.out.TicketRepositoryPort ticketRepositoryPort;
     
     @Override
     public Event loadEvent(Long eventId) {
@@ -19,5 +21,15 @@ public class EventClientAdapter implements LoadEventPort {
     @Override
     public HostInfo loadHost(Long creatorId) {
         return eventQueryService.getHostInfoByCreatorId(creatorId);
+    }
+
+    @Override
+    public java.util.List<com.venueon.event.domain.model.Session> loadSessions(Long eventId) {
+        return sessionPort.findByEventId(eventId);
+    }
+
+    @Override
+    public java.util.List<com.venueon.ticket.domain.model.Ticket> loadTickets(Long eventId) {
+        return ticketRepositoryPort.findByEventId(eventId);
     }
 }

--- a/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadEventPort.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/port/out/LoadEventPort.java
@@ -4,4 +4,6 @@ import com.venueon.event.application.port.out.LoadHostInfoPort.HostInfo;
 public interface LoadEventPort {
     Event loadEvent(Long eventId);
     HostInfo loadHost(Long creatorId);
+    java.util.List<com.venueon.event.domain.model.Session> loadSessions(Long eventId);
+    java.util.List<com.venueon.ticket.domain.model.Ticket> loadTickets(Long eventId);
 }

--- a/backend/src/main/java/com/venueon/wishlist/application/service/WishlistService.java
+++ b/backend/src/main/java/com/venueon/wishlist/application/service/WishlistService.java
@@ -46,7 +46,9 @@ public class WishlistService implements ToggleWishlistUseCase, GetWishlistUseCas
                 .map(item -> {
                     Event event = loadEventPort.loadEvent(item.getEventId());
                     HostInfo host = loadEventPort.loadHost(event.getCreatorId());
-                    return WishlistResponse.of(item, event, host);
+                    java.util.List<com.venueon.event.domain.model.Session> sessions = loadEventPort.loadSessions(event.getId());
+                    java.util.List<com.venueon.ticket.domain.model.Ticket> tickets = loadEventPort.loadTickets(event.getId());
+                    return WishlistResponse.of(item, event, host, sessions, tickets);
                 });
     }
 

--- a/frontend/src/app/events/[id]/_components/EventReviewSection.tsx
+++ b/frontend/src/app/events/[id]/_components/EventReviewSection.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { ReviewItem, Button } from '@/components/ui';
 import { ReviewModal } from '@/components/modal';
+import { useAuth } from '@/store/useAuthStore';
 import { useUIStore } from '@/store/useUIStore';
 
 interface EventReviewSectionProps {
@@ -13,6 +14,7 @@ interface EventReviewSectionProps {
 export default function EventReviewSection({ eventId, eventTitle }: EventReviewSectionProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { showToast } = useUIStore();
+  const { user } = useAuth(); // 로그인 유저 정보 가져오기
 
   const [reviews, setReviews] = useState<any[]>([]);
 
@@ -22,7 +24,16 @@ export default function EventReviewSection({ eventId, eventTitle }: EventReviewS
       const res = await fetch(`/api/events/${eventId}/reviews`);
       const data = await res.json();
       if (data.success && data.data) {
-        setReviews(data.data);
+        let fetchedReviews = data.data;
+        if (user && user.id) {
+            // 본인이 작성한 후기를 최상단으로 올리는 정렬 로직
+            fetchedReviews.sort((a: any, b: any) => {
+                if (a.authorId === user.id && b.authorId !== user.id) return -1;
+                if (b.authorId === user.id && a.authorId !== user.id) return 1;
+                return 0; // 본인 후기가 아니면 기존 순서(최신순 등) 유지
+            });
+        }
+        setReviews(fetchedReviews);
       }
     } catch (e) {
       console.error('Failed to fetch reviews', e);

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -256,7 +256,7 @@ export default async function EventDetailPage({ params }: Props) {
       </section>
 
       {/* 수강생 후기 섹션 */}
-      <section className={styles.section}>
+      <section id="review-section" className={styles.section}>
         <EventReviewSection eventId={Number(event.id)} eventTitle={event.title} />
       </section>
 

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -152,7 +152,7 @@ export default function MyPage() {
       <div className="sidebar-content">
         <div className={styles.content}>
           {/* 페이지 타이틀 */}
-          <h1 className={styles.pageTitle}>내 세션 목록</h1>
+          <h1 className={styles.pageTitle}>내 이벤트 목록</h1>
 
           {/* 탭 + 카드 + 페이지네이션 */}
           <div className={styles.listSection}>
@@ -185,9 +185,11 @@ export default function MyPage() {
                   price={lecture.price}
                   onCardClick={() => router.push(`/events/${lecture.eventId}`)}
                   actionButtonText={
-                    canWriteReview(lecture.eventId) ? '리뷰 작성하기' :
-                      activeTab === 'enrolled' ? '입장하기' :
-                        '상세 보기'
+                    canWriteReview(lecture.eventId) 
+                      ? '리뷰 작성하기' 
+                      : activeTab === 'enrolled' 
+                        ? '입장하기' 
+                        : '상세 보기'
                   }
                   onActionClick={() => {
                     if (canWriteReview(lecture.eventId)) {
@@ -210,7 +212,7 @@ export default function MyPage() {
 
             {!loading && lectures.length === 0 && (
               <p style={{ color: 'var(--color-text-gray-500)', textAlign: 'center', width: '100%', padding: 'var(--space-48) 0' }}>
-                해당 탭에 세션이 없습니다.
+                해당 탭에 이벤트가 없습니다.
               </p>
             )}
 

--- a/frontend/src/app/mypage/orders/components/RefundModal.tsx
+++ b/frontend/src/app/mypage/orders/components/RefundModal.tsx
@@ -84,7 +84,7 @@ export default function RefundModal({
         {/* 유의사항 동의 체크박스 (표준 Styling) */}
         <div className={styles.checkboxContainer}>
           <Checkbox 
-            label="[필수] 환불 시 세션 참여가 취소되며, 처리 후에는 복구할 수 없습니다."
+            label="[필수] 환불 시 이벤트 참여가 취소되며, 처리 후에는 복구할 수 없습니다."
             checked={isConfirmed}
             onChange={(e) => setIsConfirmed(e.target.checked)}
           />

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -52,11 +52,11 @@ export default function MyPageDashboard() {
           {/* 요약 박스 (3개 가로 배치) */}
           <div className={styles.summaryContainer}>
             <div className={styles.summaryBox}>
-              <span className={styles.summaryTitle}>참여 중인 세션</span>
+              <span className={styles.summaryTitle}>참여 중인 이벤트</span>
               <span className={styles.summaryContent}>{summaryData.ongoingCourseCount}개</span>
             </div>
             <div className={styles.summaryBox}>
-              <span className={styles.summaryTitle}>리뷰를 기다리는 세션</span>
+              <span className={styles.summaryTitle}>리뷰를 기다리는 이벤트</span>
               <span className={styles.summaryContent}>{summaryData.pendingReviewCount}개</span>
             </div>
             <div className={styles.summaryBox}>
@@ -106,7 +106,7 @@ export default function MyPageDashboard() {
             {activeTab === 'schedule' && (
               <Table columns="1fr 120px 180px 88px">
                 <TableHeader>
-                  <TableCell header>세션 일정 명</TableCell>
+                  <TableCell header>이벤트 명</TableCell>
                   <TableCell header>호스트</TableCell>
                   <TableCell header>일시</TableCell>
                   <TableCell header>상태</TableCell>

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -306,7 +306,7 @@ export default function ProfileSettingsPage() {
           <div className={styles.sectionBlock}>
             <div className={styles.headerGroup}>
               <h1 className={styles.pageTitle}>관심 카테고리 설정</h1>
-              <p className={styles.subtitle}>관심있는 카테고리를 선택해주세요. 맞춤 세션을 추천해 드립니다.</p>
+              <p className={styles.subtitle}>관심있는 카테고리를 선택해주세요. 맞춤 이벤트를 추천해 드립니다.</p>
             </div>
             <div className={styles.categoryPills}>
               {availableCategories.map(cat => (

--- a/frontend/src/app/mypage/wishlist/page.tsx
+++ b/frontend/src/app/mypage/wishlist/page.tsx
@@ -6,6 +6,12 @@ import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Pagination, InputField } from '@/components/ui';
 import styles from '../events/page.module.css';
 
+const CATEGORY_MAP: Record<number, string> = {
+  1: '디자인',
+  2: '개발',
+  3: '마케팅',
+};
+
 export default function WishlistPage() {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
@@ -58,16 +64,19 @@ export default function WishlistPage() {
               {lectures.map((lecture) => (
                 <Card
                   key={lecture.wishlistId}
+                  variant="landing"
                   eventId={lecture.id}
                   isWishlistedProp={true}
-                  status={lecture.status}
+                  category={lecture.categoryId ? (CATEGORY_MAP[lecture.categoryId] || '기타') : undefined}
+                  status={lecture.status?.label || lecture.status}
+                  recruitmentStatus={lecture.recruitmentStatus?.label || lecture.recruitmentStatus}
                   title={lecture.title}
+                  imageUrl={lecture.thumbnailUrl ? `/upload/${lecture.thumbnailUrl}` : undefined}
                   organizer={lecture.organizer}
                   dateTime={lecture.dateTime}
                   location={lecture.location}
                   price={lecture.price}
-                  actionButtonText="장바구니 담기"
-                  onActionClick={() => router.push(`/events/${lecture.id}`)}
+                  onCardClick={() => router.push(`/events/${lecture.id}`)}
                 />
               ))}
             </CardGrid>

--- a/frontend/src/app/mypage/wishlist/page.tsx
+++ b/frontend/src/app/mypage/wishlist/page.tsx
@@ -83,7 +83,7 @@ export default function WishlistPage() {
 
             {!loading && lectures.length === 0 && (
               <p style={{ color: 'var(--color-text-gray-500)', textAlign: 'center', width: '100%', padding: 'var(--space-48) 0' }}>
-                아직 찜한 세션이 없습니다.
+                아직 찜한 이벤트가 없습니다.
               </p>
             )}
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -99,7 +99,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
           { label: '대시보드', href: '/admin/dashboard', icon: DashboardIcon },
           { label: '사용자 관리', href: '/admin/users', icon: ProfileIcon },
           { label: '시스템 설정', href: '/admin/settings', icon: SettingIcon },
-          { label: '세션 관리', href: '/admin/events', icon: SeminarSettingIcon },
+          { label: '이벤트 관리', href: '/admin/events', icon: SeminarSettingIcon },
           { label: '커뮤니티 관리', href: '/admin/community', icon: CommunityIcon },
           { label: '신고 관리', href: '/admin/reports', icon: ReportIcon },
           { label: '문의 관리', href: '/admin/contact', icon: RequestIcon },
@@ -108,7 +108,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
       case 'host':
         return [
           { label: '대시보드', href: '/host', icon: DashboardIcon },
-          { label: '내 강의 목록', href: '/host/events', icon: SeminarIcon },
+          { label: '내 이벤트 목록', href: '/host/events', icon: SeminarIcon },
           { label: '프로필 설정', href: '/host/profile', icon: ProfileIcon },
           { label: '1:1 문의', href: '/host/contact', icon: ContactIcon },
           { label: '로그아웃', href: '/logout', icon: LogoutIcon },
@@ -117,7 +117,7 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
       default:
         return [
           { label: '대시보드', href: '/mypage', icon: DashboardIcon },
-          { label: '내 세션 목록', href: '/mypage/events', icon: SeminarIcon },
+          { label: '내 이벤트 목록', href: '/mypage/events', icon: SeminarIcon },
           { label: '결제 내역', href: '/mypage/orders', icon: OrderIcon },
           { label: '찜 목록', href: '/mypage/wishlist', icon: WishlistIcon },
           { label: '내 커뮤니티', href: '/mypage/community', icon: CommunityIcon },


### PR DESCRIPTION
Close #VO-983 #VO-693

**1. 배경 및 목적**
* 위시리스트 이벤트 카드의 데이터(썸네일, 카테고리 등) 누락 문제 개선
* 리뷰 작성 이후 본인의 후기를 가장 먼저 확인할 수 있도록 가시성 개선
* 시스템 전반(특히 마이페이지 전역)의 '세션' 용어를 '이벤트'로 일괄 통일하여 혼동 방지

**2. 작업 내용**
* **위시리스트 카드 리팩토링**: 썸네일, 모집 상태뱃지, 카테고리, 일정/장소 정보를 매핑하고 혼동을 주는 '장바구니 담기' 버튼 삭제
* **내 리뷰 최상단 고정**: 이벤트 상세 페이지(`EventReviewSection`)에서 후기 목록을 렌더링할 때, 유저의 `authorId`와 일치하는 리뷰를 최상단(Index 0)으로 가져오는 정렬 로직 추가
* **도메인 용어 통일**: 마이페이지 영역(이벤트 목록, 위시리스트, 환불 모달 등) 내 하드코딩된 '세션' 텍스트들과 공통 사이드바(`Sidebar.tsx`)의 '세션 관리', '내 강의 목록', '내 세션 목록' 메뉴명을 전부 '이벤트'로 변경

**3. 기대 효과**
* 찜한 이벤트의 디테일을 명확하게 표시해 결제 전환 유도 강화
* 작성한 리뷰는 목록의 가장 위에서 바로 확인 가능
* 서비스가 지향하는 '이벤트'라는 도메인 정체성 및 일관성 확립


