### PR TITLE
fix: 결제 성공 페이지에서 리다이렉트 버튼 url 수정

### DIFF
--- a/frontend/src/app/orders/checkout/success/page.tsx
+++ b/frontend/src/app/orders/checkout/success/page.tsx
@@ -120,17 +120,17 @@ function CheckoutSuccessContent() {
             variant="outlined"
             size="large"
             style={{ flex: 1, backgroundColor: '#FFFFFF', borderColor: 'var(--color-gray-200, #E5E7EB)' }}
-            onClick={() => window.location.href = '/mypage/orders'}
+            onClick={() => window.location.href = '/mypage/events'}
           >
-            내 세션 목록
+            내 이벤트 목록
           </Button>
           <Button
             variant="primary"
             size="large"
             style={{ flex: 1, backgroundColor: 'var(--color-gray-900, #111827)', color: 'white', border: 'none' }}
-            onClick={() => window.location.href = '/'}
+            onClick={() => window.location.href = '/community'}
           >
-            커뮤니티 입장
+            커뮤니티 탐색
           </Button>
         </div>
 


### PR DESCRIPTION
결제 성공 페이지에서 리다이렉트 버튼 url 수정했습니다. VO-869


1. '커뮤니티 탐색' 버튼 클릭 시, 커뮤니티(/community)으로 리다이렉트 되도록 라우팅을 수정.
2. '내 이벤트 목록' 버튼 클릭 시 '결제 내역' 페이지로 잘못 이동하고 있던 것을 -> 실제 사용자의 '내 세션 목록' 페이지(/mypage/events )로 리다이렉트 되도록 라우팅을 수정. 
 