### PR TITLE
feat: 이벤트 카드 D-Day를 모집상태(예정/중) 기반으로 동적 계산하도록 변경 close #VO-872

### DIFF
--- a/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
+++ b/backend/src/main/java/com/venueon/event/adapter/in/web/dto/EventListResponse.java
@@ -30,7 +30,9 @@ public record EventListResponse(
         boolean hasDiscount,                   // 할인 티켓 존재 여부
         Integer originalPrice,                 // 최저가 티켓의 원래 가격 (할인 시)
         String primaryLocation,                // 대표 세션 장소
-        boolean isOnline                       // 전체 세션이 온라인인지
+        boolean isOnline,                      // 전체 세션이 온라인인지
+        LocalDateTime recruitStartDate,        // 세션들 중 가장 빠른 모집 시작일
+        LocalDateTime recruitEndDate           // 세션들 중 가장 늦은 모집 마감일
 ) {
     /**
      * 세션 정보 없이 생성 (fallback)
@@ -56,6 +58,8 @@ public record EventListResponse(
         com.venueon.common.model.DomainCode recruitmentStatus = com.venueon.common.model.DomainCode.of(com.venueon.common.model.CodeConstants.RECRUIT_STATUS_CLOSED_ID, "모집마감");
         String primaryLocation = null;
         boolean isOnline = false;
+        LocalDateTime recruitStartDate = null;
+        LocalDateTime recruitEndDate = null;
 
         if (sessions != null && !sessions.isEmpty()) {
             startDate = sessions.stream()
@@ -84,6 +88,18 @@ public record EventListResponse(
 
             // 전체 온라인 여부 (모든 세션이 온라인이면 true)
             isOnline = sessions.stream().allMatch(Session::getIsOnline);
+
+            // 모집 시작일/마감일 (세션 종합)
+            recruitStartDate = sessions.stream()
+                    .map(Session::getRecruitStartDate)
+                    .filter(t -> t != null)
+                    .min(LocalDateTime::compareTo)
+                    .orElse(null);
+            recruitEndDate = sessions.stream()
+                    .map(Session::getRecruitEndDate)
+                    .filter(t -> t != null)
+                    .max(LocalDateTime::compareTo)
+                    .orElse(null);
         }
 
         // 티켓 기반 가격 계산 (활성 티켓만)
@@ -133,7 +149,9 @@ public record EventListResponse(
                 hasDiscount,
                 originalPrice,
                 primaryLocation,
-                isOnline
+                isOnline,
+                recruitStartDate,
+                recruitEndDate
         );
     }
 }

--- a/frontend/src/app/events/page.tsx
+++ b/frontend/src/app/events/page.tsx
@@ -22,6 +22,8 @@ interface EventData {
   endDate: string | null;
   categoryId: number;
   creatorId: number;
+  recruitStartDate?: string;  // 모집 시작일
+  recruitEndDate?: string;    // 모집 마감일
 }
 
 export default function EventsPage() {
@@ -110,9 +112,19 @@ export default function EventsPage() {
           ) : (
             <CardGrid layout="3-cols">
               {events.map((event) => {
-                const startTime = event.startDate ? new Date(event.startDate).getTime() : null;
-                const diffDays = startTime ? Math.ceil((startTime - nowTime) / (1000 * 60 * 60 * 24)) : undefined;
-                const dDayData = diffDays !== undefined && diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
+                // 모집상태별 D-Day 기준 분기
+                let dDayData: number | string | undefined = undefined;
+                const recruitStatusId = event.recruitmentStatus?.id;
+                if (recruitStatusId === 1 && event.recruitStartDate) {
+                  // 모집 예정 → 모집 시작일까지 D-Day
+                  const diffDays = Math.ceil((new Date(event.recruitStartDate).getTime() - nowTime) / (1000 * 60 * 60 * 24));
+                  dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
+                } else if (recruitStatusId === 2 && event.recruitEndDate) {
+                  // 모집 중 → 모집 마감일까지 D-Day
+                  const diffDays = Math.ceil((new Date(event.recruitEndDate).getTime() - nowTime) / (1000 * 60 * 60 * 24));
+                  dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
+                }
+                // 모집마감(id===3)이면 D-Day 표시 안 함
                 
                 const categoryLabel = categoryOptions.find(c => c.value === String(event.categoryId))?.label || '기타';
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -26,6 +26,8 @@ interface EventData {
   primaryLocation: string | null;
   isOnline: boolean;
   startDate?: string;
+  recruitStartDate?: string;  // 모집 시작일
+  recruitEndDate?: string;    // 모집 마감일
 }
 
 export default function Home() {
@@ -254,13 +256,23 @@ export default function Home() {
                 let dateTimeStr = '일정 미정';
 
                 if (event.startDate) {
-                  const startTime = new Date(event.startDate).getTime();
-                  const diffDays = Math.ceil((startTime - nowTime) / (1000 * 60 * 60 * 24));
-                  dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
                   try {
                     dateTimeStr = format(new Date(event.startDate), 'yyyy년 M월 d일 a h시');
                   } catch(e) {}
                 }
+
+                // 모집상태별 D-Day 기준 분기
+                const recruitStatusId = event.recruitmentStatus?.id;
+                if (recruitStatusId === 1 && event.recruitStartDate) {
+                  // 모집 예정 → 모집 시작일까지 D-Day
+                  const diffDays = Math.ceil((new Date(event.recruitStartDate).getTime() - nowTime) / (1000 * 60 * 60 * 24));
+                  dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
+                } else if (recruitStatusId === 2 && event.recruitEndDate) {
+                  // 모집 중 → 모집 마감일까지 D-Day
+                  const diffDays = Math.ceil((new Date(event.recruitEndDate).getTime() - nowTime) / (1000 * 60 * 60 * 24));
+                  dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
+                }
+                // 모집마감(id===3)이면 D-Day 표시 안 함
                 
                 // 간단한 카테고리 맵핑 (프론트에서 관리하는 카테고리가 있다면 가져옴)
                 const categoryLabel = categoryOptions.find(c => c.value === String(event.categoryId))?.label || '기타';

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -93,11 +93,11 @@ export default function Card({
           )}
 
           <div className={styles.topRight}>
-            {/* 모집상태 뱃지 (default variant에서만 표시) */}
-            {variant === 'default' && recruitmentStatus && (
+            {/* 모집상태 뱃지 */}
+            {recruitmentStatus && (
               <StatusTag domain="recruitment" status={recruitmentStatus} />
             )}
-            {/* 강의상태 뱃지 (default variant에서만, DRAFT/PUBLISHED 제외) */}
+            {/* 강의상태 뱃지 (DRAFT/PUBLISHED 제외) */}
             {variant === 'default' && status && status !== 'DRAFT' && status !== 'PUBLISHED' && (
               <StatusTag domain="course" status={status} />
             )}


### PR DESCRIPTION
Closes #VO-872

**1. 배경 및 목적**
* 기존 이벤트 카드의 D-Day가 무조건 '이벤트 시작일(startDate)'만을 기준으로 계산되어, 실제 사용자에게 가장 중요한 정보인 '신청 기간'에 대한 정보를 명확히 주지 못하고 있었습니다.
* 사용자에게 '모집이 언제 시작하는지(모집 예정)'와 '모집이 언제 마감되는지(모집 중)'를 정확하게 인지시켜, 수강 신청 및 구매 전환율을 극대화하고자 합니다.

**2. 작업 내용**
* **백엔드 DTO (`EventListResponse`) 필드 고도화**
  * 각 세션 데이터의 최소 모집 시작일(`recruitStartDate`)과 최대 모집 마감일(`recruitEndDate`)을 계산하여 프론트엔드로 전달하도록 필드 추가
* **프론트엔드 동적 D-Day 분기 로직 (`page.tsx`, `events/page.tsx`)**
  * `[모집 예정]` 상태: (모집 시작일 - 오늘)을 기준으로 D-Day 노출
  * `[모집 중]` 상태: (모집 마감일 - 오늘)을 기준으로 D-Day 노출
  * `[모집 마감]` 상태: D-Day 숨김 처리
* **렌더링 버그 픽스 (`Card.tsx`)**
  * `<Card>` 컴포넌트가 `landing` variant로 쓰일 경우, 하드코딩된 조건식(`variant === 'default'`) 때문에 모집상태(모집 예정/중/마감) 뱃지가 보이지 않던 렌더링 누락 문제 해결

**3. 기대 효과**
* 카테고리, 모집 상태, D-Day가 시각적으로 통합 제공되어 카드 뷰의 완성도 증가
* 직관적인 모집 마감/시작 시점 안내로 인해 사용자의 플랫폼 이용 편의성과 신청 긴박감(Urgency) 부여


