### PR TITLE
feat: 뱃지 발급 로직 개선, 단일 이벤트 기간설정 UI, 상세페이지 UX 개선 #VO-868

### DIFF
--- a/backend/src/main/java/com/venueon/badge/application/service/BadgeIssueService.java
+++ b/backend/src/main/java/com/venueon/badge/application/service/BadgeIssueService.java
@@ -4,6 +4,8 @@ import com.venueon.badge.application.port.in.IssueBadgesUseCase;
 import com.venueon.badge.application.port.out.BadgeRepositoryPort;
 import com.venueon.badge.domain.model.Badge;
 import com.venueon.common.annotation.UseCase;
+import com.venueon.common.model.CodeConstants;
+import com.venueon.event.adapter.out.persistence.entity.EventStatusJpaEntity;
 import com.venueon.event.adapter.out.persistence.entity.EventJpaEntity;
 import com.venueon.event.adapter.out.persistence.entity.SessionJpaEntity;
 import com.venueon.event.adapter.out.persistence.repository.EventJpaRepository;
@@ -26,7 +28,10 @@ import java.util.stream.Collectors;
  * 뱃지 발급 서비스 (Lazy Issuance)
  * 사용자가 뱃지 조회 시 미발급 뱃지를 그 자리에서 발급
  *
- * 발급 조건: 사용자가 구매한 티켓에 포함된 세션이 모두 종료(endTime < now)되면 발급
+ * 발급 조건: 사용자가 구매한 티켓에 포함된 세션이 모두 종료되면 발급
+ * 세션 종료 판별:
+ *   1. forcedSessionStatus가 "종료됨"(ID=4) 또는 "취소됨"(ID=5)이면 종료로 간주 (수동 종료)
+ *   2. endTime이 현재 시각 이전이면 종료로 간주 (자동 종료)
  * - isAllSessions=true 티켓: 해당 이벤트의 전체 세션이 종료되어야 함
  * - isAllSessions=false 티켓: ticket_sessions에 매핑된 세션만 종료되면 됨
  */
@@ -112,14 +117,15 @@ public class BadgeIssueService implements IssueBadgesUseCase {
                 }
             }
 
-            // 모든 대상 세션의 endTime이 존재하고, 현재 시각보다 이전인지 확인
+            // 모든 대상 세션이 종료되었는지 확인 (endTime 자동 만료 또는 forcedSessionStatus 수동 종료)
             boolean allSessionsEnded = targetSessions.stream()
-                    .allMatch(s -> s.getEndTime() != null && s.getEndTime().isBefore(now));
+                    .allMatch(s -> isSessionEnded(s, now));
 
             if (allSessionsEnded) {
-                // 뱃지 취득일 = 마지막 세션 종료 시각
+                // 뱃지 취득일 = 마지막 세션 종료 시각 (endTime이 null이면 현재 시각 사용)
                 LocalDateTime earnedAt = targetSessions.stream()
                         .map(SessionJpaEntity::getEndTime)
+                        .filter(Objects::nonNull)
                         .max(LocalDateTime::compareTo)
                         .orElse(now);
 
@@ -146,5 +152,24 @@ public class BadgeIssueService implements IssueBadgesUseCase {
         }
 
         return issuedCount;
+    }
+
+    /**
+     * 세션 종료 여부 판별
+     * 1. 호스트가 수동으로 종료 상태(forcedSessionStatus)를 세팅한 경우 → 종료
+     *    (취소됨은 뱃지 발급 대상이 아님)
+     * 2. endTime이 존재하고 현재 시각을 지난 경우 → 종료 (자동)
+     */
+    private boolean isSessionEnded(SessionJpaEntity session, LocalDateTime now) {
+        // 1. forcedSessionStatus가 "종료됨"(ID=4)이면 종료로 간주
+        EventStatusJpaEntity forcedStatus = session.getForcedSessionStatus();
+        if (forcedStatus != null) {
+            Long statusId = forcedStatus.getId();
+            if (CodeConstants.EVENT_STATUS_ENDED_ID.equals(statusId)) {
+                return true;
+            }
+        }
+        // 2. endTime 기반 자동 판별 (기존 로직)
+        return session.getEndTime() != null && session.getEndTime().isBefore(now);
     }
 }

--- a/frontend/src/app/events/[id]/_components/BackButton.tsx
+++ b/frontend/src/app/events/[id]/_components/BackButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import styles from '../page.module.css';
+
+export default function BackButton() {
+  const router = useRouter();
+  return (
+    <button 
+      onClick={() => router.back()}
+      className={styles.backButton}
+    >
+      ← 이전 페이지로 이동
+    </button>
+  );
+}

--- a/frontend/src/app/events/[id]/_components/EventReviewSection.tsx
+++ b/frontend/src/app/events/[id]/_components/EventReviewSection.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ReviewItem, Button } from '@/components/ui';
-import { ReviewModal } from '@/components/modal';
+import { ReviewItem } from '@/components/ui';
 import { useUIStore } from '@/store/useUIStore';
 
 interface EventReviewSectionProps {
@@ -11,7 +10,6 @@ interface EventReviewSectionProps {
 }
 
 export default function EventReviewSection({ eventId, eventTitle }: EventReviewSectionProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const { showToast } = useUIStore();
 
   const [reviews, setReviews] = useState<any[]>([]);
@@ -33,30 +31,12 @@ export default function EventReviewSection({ eventId, eventTitle }: EventReviewS
     fetchReviews();
   }, [eventId]);
 
-  const handleWriteClick = async () => {
-    try {
-      const res = await fetch(`/api/events/${eventId}/reviews/can-review`);
-      const data = await res.json();
-      if (data.success && data.data === true) {
-        setIsModalOpen(true);
-      } else {
-        showToast("이벤트를 수강하신 분들만 리뷰를 작성할 수 있어요!", "error");
-      }
-    } catch (e) {
-      console.error('Failed to check eligibility', e);
-      showToast("권한 확인에 실패했습니다.", "error");
-    }
-  };
-
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
         <h3 style={{ font: 'var(--text-h2-bold)', color: 'var(--color-text-gray-900)', margin: 0 }}>
           참석자 후기 <span style={{ color: 'var(--color-primary)' }}>{reviews.length}</span>
         </h3>
-        <Button variant="outlined" size="medium" onClick={handleWriteClick}>
-          내 후기 작성하기 ✎
-        </Button>
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -70,19 +50,6 @@ export default function EventReviewSection({ eventId, eventTitle }: EventReviewS
           </div>
         )}
       </div>
-
-      {/* 후기 작성 모달 */}
-      <ReviewModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        eventId={eventId}
-        eventTitle={eventTitle}
-        onSubmitSuccess={() => {
-          setIsModalOpen(false);
-          showToast('성공적으로 후기가 등록되었습니다!', 'success');
-          fetchReviews();
-        }}
-      />
     </>
   );
 }

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -8,6 +8,7 @@ import { format } from 'date-fns';
 import EventActionMenu from './_components/EventActionMenu';
 import TicketList from './_components/TicketList';
 import EventReviewSection from './_components/EventReviewSection';
+import BackButton from './_components/BackButton';
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
@@ -106,9 +107,7 @@ export default async function EventDetailPage({ params }: Props) {
 
       {/* 뒤로 가기 바 */}
       <div className={styles.topBar}>
-        <Link href="/" className={styles.backButton}>
-          ← 이벤트 목록 보기
-        </Link>
+        <BackButton />
       </div>
 
 

--- a/frontend/src/app/events/new/_components/EventForm.tsx
+++ b/frontend/src/app/events/new/_components/EventForm.tsx
@@ -73,9 +73,15 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     description: initialData?.description || '',
     detailContent: initialData?.detailContent || '',
     price: initialData?.price !== undefined ? initialData.price.toString() : '',
-    date: initialData?.startDate ? initialData.startDate.substring(0, 10) : '',
-    isOnlineStr: initialData?.isOnline !== undefined ? String(initialData.isOnline) : '',
     location: initialData?.location || '',
+    isOnlineStr: initialData?.isOnline !== undefined ? String(initialData.isOnline) : '',
+    startDate: initialData?.startDate ? initialData.startDate.substring(0, 10) : '',
+    startTimeOnly: initialData?.startDate ? initialData.startDate.substring(11, 16) : '10:00',
+    endDate: initialData?.endDate ? initialData.endDate.substring(0, 10) : '',
+    endTimeOnly: initialData?.endDate ? initialData.endDate.substring(11, 16) : '18:00',
+    useRecruitPeriod: initialData?.useRecruitPeriod || false,
+    recruitStartDate: initialData?.recruitStartDate ? initialData.recruitStartDate.substring(0, 10) : '',
+    recruitEndDate: initialData?.recruitEndDate ? initialData.recruitEndDate.substring(0, 10) : '',
     addressRoad: '',
     addressDetail: '',
     regionSido: '',
@@ -193,13 +199,8 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     try {
       const isOnline = formData.isOnlineStr === 'true';
 
-      // 날짜 파싱 (임시로 시작일 10시, 종료일 18시 셋팅)
-      let startDateStr = new Date().toISOString();
-      let endDateStr = new Date().toISOString();
-      if (formData.date) {
-        startDateStr = `${formData.date}T10:00:00`;
-        endDateStr = `${formData.date}T18:00:00`;
-      }
+      // (날짜 계산은 이제 단일/복합 분기 후 페이로드에 합쳐서 발송되므로 이벤트 생성 자체에는 불필요하지만,
+      // 과거 하위 호환을 대비해 그대로 더미값으로 진행하거나 제거해도 무방합니다.)
 
       // API 요청 분기 (create / edit)
       const payload = {
@@ -311,6 +312,55 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             const sessData = await sessRes.json();
             if (sessData?.data?.id) {
               savedSessionIds.push(sessData.data.id);
+            }
+          }
+        }
+      } else {
+        // 단일 이벤트인 경우, 백엔드가 자동 생성한 default 세션을 조회해서 날짜/시간 업데이트
+        const defaultSessRes = await fetch(`/api/events/${targetId}/sessions`);
+        if (defaultSessRes.ok) {
+          const dsData = await defaultSessRes.json();
+          const defaultSession = dsData.data && dsData.data[0];
+          if (defaultSession) {
+            let startTime = null;
+            let endTime = null;
+            if (formData.startDate) startTime = `${formData.startDate}T${formData.startTimeOnly || '10:00'}:00`;
+            if (formData.endDate) endTime = `${formData.endDate}T${formData.endTimeOnly || '18:00'}:00`;
+
+            let recruitStartDate = null;
+            let recruitEndDate = null;
+            if (formData.useRecruitPeriod) {
+              if (formData.recruitStartDate) recruitStartDate = `${formData.recruitStartDate}T00:00:00`;
+              if (formData.recruitEndDate) recruitEndDate = `${formData.recruitEndDate}T23:59:00`;
+            }
+
+            const sessionPayload = {
+              title: formData.title,
+              description: formData.description,
+              sortOrder: 0,
+              startTime,
+              endTime,
+              location: formData.isOnlineStr === 'true' ? '온라인 진행' : formData.location || '',
+              regionSido: formData.regionSido || '서울',
+              regionSigungu: formData.regionSigungu || '강남구',
+              addressRoad: formData.addressRoad || '',
+              addressDetail: formData.addressDetail || '',
+              isOnline: formData.isOnlineStr === 'true',
+              onlineLink: '', // 단일 폼엔 현재 필드가 별도 없음
+              maxAttendees: 0,
+              recruitStartDate,
+              recruitEndDate,
+            };
+
+            const putRes = await fetch(`/api/host/events/${targetId}/sessions/${defaultSession.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(sessionPayload)
+            });
+            if (putRes.ok) {
+              savedSessionIds.push(defaultSession.id);
+            } else {
+               console.error(`[DEBUG] Default Session PUT failed:`, putRes.status, await putRes.text().catch(() => ''));
             }
           }
         }
@@ -470,7 +520,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       </div>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>세션 제목</label>
+        <label className={styles.label}>이벤트 제목</label>
         <input
           type="text"
           name="title"
@@ -482,7 +532,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       </div>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>세션 이미지</label>
+        <label className={styles.label}>이벤트 메인배너(썸네일)</label>
         {previewUrl ? (
           <div className={styles.previewWrapper}>
             <img src={previewUrl} alt="미리보기" className={styles.previewImage} />
@@ -526,13 +576,13 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       <div className={styles.formGroup}>
         <div className={styles.labelRow}>
-          <label className={styles.label}>세션 정보</label>
+          <label className={styles.label}>이벤트 정보</label>
           <span className={styles.charCount}>{formData.description.length}/300</span>
         </div>
         <textarea
           name="description"
           className={styles.textarea}
-          placeholder="세션 정보를 입력하세요."
+          placeholder="이벤트 정보를 입력하세요."
           maxLength={300}
           value={formData.description}
           onChange={handleChange}
@@ -581,14 +631,14 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
         <div className={styles.grid2}>
 
-          <div className={styles.formGroup}>
+          <div className={styles.formGroup} style={{ visibility: hasSession ? 'visible' : 'hidden', display: hasSession ? 'block' : 'none' }}>
             <label className={styles.label}>{hasSession ? '기본 날짜' : '날짜'}</label>
             <input
               type="date"
               name="date"
               className={styles.dateInput}
-              value={formData.date}
-              onChange={handleChange}
+              value={formData.startDate}
+              onChange={(e) => setFormData(prev => ({ ...prev, startDate: e.target.value }))}
             />
           </div>
 
@@ -597,7 +647,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             <select
               name="isOnlineStr"
               className={styles.selectInput}
-              value={formData.isOnlineStr}
+              value={formData.isOnlineStr || ''}
               onChange={handleChange}
             >
               <option value="">옵션을 선택하세요.</option>
@@ -670,6 +720,97 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
           </div>
         )}
 
+        {/* ── 단일 이벤트 세션 기간 설정 (복합세션과 동일 패턴) ── */}
+        {!hasSession && (
+          <div style={{ marginTop: '2rem', paddingTop: '2rem', borderTop: '1px solid #ddd' }}>
+            <div style={{ fontSize: '0.85rem', fontWeight: '700', color: '#333', marginBottom: '0.75rem' }}>📅 이벤트 기간 <span style={{ fontWeight: 'normal', color: '#999', fontSize: '0.75rem' }}>미설정 시 호스트가 수동으로 시작/종료 관리</span></div>
+            <div style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(2, 1fr)', marginBottom: '1.5rem', background: '#fff', padding: '1rem', borderRadius: '4px', border: '1px solid #e5e5e5' }}>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>시작 날짜</label>
+                <input
+                  type="date"
+                  name="startDate"
+                  value={formData.startDate}
+                  onChange={handleChange}
+                  className={styles.dateInput}
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>시작 시간</label>
+                <input
+                  type="time"
+                  name="startTimeOnly"
+                  value={formData.startTimeOnly}
+                  onChange={handleChange}
+                  className={styles.dateInput}
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>종료 날짜</label>
+                <input
+                  type="date"
+                  name="endDate"
+                  value={formData.endDate}
+                  onChange={handleChange}
+                  className={styles.dateInput}
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>종료 시간</label>
+                <input
+                  type="time"
+                  name="endTimeOnly"
+                  value={formData.endTimeOnly}
+                  onChange={handleChange}
+                  className={styles.dateInput}
+                  style={{ width: '100%' }}
+                />
+              </div>
+            </div>
+
+            {/* 단일 모집 기간 섹션 */}
+            <div style={{ fontSize: '0.85rem', fontWeight: '700', color: '#333', marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <span>📋 모집 기간 세부 설정</span>
+              <label className={styles.checkboxLabel} style={{ fontSize: '0.75rem', fontWeight: 'normal' }}>
+                <input
+                  type="checkbox"
+                  checked={formData.useRecruitPeriod}
+                  onChange={(e) => setFormData(prev => ({ ...prev, useRecruitPeriod: e.target.checked }))}
+                />
+                모집 기간 별도 설정하기
+              </label>
+            </div>
+            {formData.useRecruitPeriod && (
+              <div style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(2, 1fr)', background: '#fff', padding: '1rem', borderRadius: '4px', border: '1px solid #e5e5e5' }}>
+                <div>
+                  <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>모집 시작일</label>
+                  <input
+                    type="date"
+                    name="recruitStartDate"
+                    value={formData.recruitStartDate}
+                    onChange={handleChange}
+                    className={styles.dateInput}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div>
+                  <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>모집 마감일</label>
+                  <input
+                    type="date"
+                    name="recruitEndDate"
+                    value={formData.recruitEndDate}
+                    onChange={handleChange}
+                    className={styles.dateInput}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
       </div>
 

--- a/frontend/src/app/mypage/badges/page.module.css
+++ b/frontend/src/app/mypage/badges/page.module.css
@@ -18,7 +18,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   justify-items: center;
-  gap: var(--space-32) 0;
+  gap: var(--space-32);
   width: 100%;
 }
 


### PR DESCRIPTION
## 변경 사항

### 🏅 뱃지 발급 로직 개선 (Backend)
- `BadgeIssueService`: 수동 세션 종료(`forcedSessionStatus`) 감지 로직 추가
- 자동 종료(`endTime`)와 수동 종료 모두를 고려한 `isSessionEnded()` 메서드 구현
- 취소된 세션(`CANCELLED`)은 뱃지 발급 대상에서 제외

### 📅 단일 이벤트 기간 설정 UI (Frontend)
- 단일 세션 이벤트에 시작/종료 날짜+시간 입력 필드 추가
- 모집 기간 세부 설정(체크박스 토글) 추가
- `handleSubmit`에서 백엔드 default 세션 자동 조회 후 업데이트 로직 연동
- CSS Grid 기반 레이아웃으로 입력 필드 깨짐 현상 수정

### 🔧 이벤트 상세페이지 UX 개선
- '이벤트 목록 보기' 버튼 → '이전 페이지로 이동' (`router.back()`) 으로 교체
- `BackButton` 클라이언트 컴포넌트 신규 생성
- 후기 작성 버튼 및 `ReviewModal` 연동 제거

### 🎨 뱃지 목록 레이아웃
- 뱃지 카드 간 가로 간격(`gap`) 추가

## 수정 파일
| 파일 | 변경 내용 |
|------|-----------|
| `BadgeIssueService.java` | 수동 종료 감지 + 취소 세션 제외 |
| `EventForm.tsx` | 단일 이벤트 기간 설정 UI + submit 로직 |
| `page.tsx (event detail)` | BackButton 컴포넌트 적용 |
| `BackButton.tsx` | 신규 — router.back() 기반 뒤로가기 |
| `EventReviewSection.tsx` | 후기 버튼/모달 제거 |
| `page.module.css (badges)` | 뱃지 그리드 간격 수정 |

close #VO-868