### PR TITLE
feat: 호스트 프로필 이미지 업로드 기능 및 상세 페이지 데이터 연동

### DIFF
--- a/backend/src/main/java/com/venueon/host/event/adapter/in/web/dto/HostEventDetailResponse.java
+++ b/backend/src/main/java/com/venueon/host/event/adapter/in/web/dto/HostEventDetailResponse.java
@@ -23,6 +23,8 @@ public record HostEventDetailResponse(
         boolean hasDiscount,
         String location,
         String hostName,
+        String hostDescription,
+        String hostProfileImg,
         List<SessionDetail> sessions
 ) {
     public record SessionDetail(

--- a/backend/src/main/java/com/venueon/host/event/adapter/out/persistence/HostEventMapper.java
+++ b/backend/src/main/java/com/venueon/host/event/adapter/out/persistence/HostEventMapper.java
@@ -75,7 +75,8 @@ public class HostEventMapper {
             Long totalRevenue,
             Long totalAttendees,
             com.venueon.common.model.DomainCode effectiveStatus,
-            com.venueon.common.model.DomainCode recruitmentStatus
+            com.venueon.common.model.DomainCode recruitmentStatus,
+            com.venueon.user.adapter.out.persistence.entity.HostProfileJpaEntity hostProfile
     ) {
         var firstSession = sessions != null && !sessions.isEmpty() ? sessions.get(0) : null;
         
@@ -101,6 +102,12 @@ public class HostEventMapper {
             }
         }
 
+        String hostName = (hostProfile != null && hostProfile.getOrgName() != null) 
+                            ? hostProfile.getOrgName() 
+                            : (entity.getCreator() != null ? entity.getCreator().getNickname() : "알 수 없는 호스트");
+        String hostDescription = hostProfile != null ? hostProfile.getOrgDescription() : null;
+        String hostProfileImg = (entity.getCreator() != null) ? entity.getCreator().getProfileImg() : null;
+
         return new HostEventDetailResponse(
                 entity.getId(),
                 entity.getTitle(),
@@ -116,7 +123,9 @@ public class HostEventMapper {
                 originalPrice,
                 hasDiscount,
                 firstSession != null ? firstSession.getLocation() : "장소 미정",
-                entity.getCreator() != null ? entity.getCreator().getNickname() : "알 수 없는 호스트",
+                hostName,
+                hostDescription,
+                hostProfileImg,
                 sessions != null ? sessions.stream().map(this::toSessionDetail).toList() : Collections.emptyList()
         );
     }

--- a/backend/src/main/java/com/venueon/host/event/adapter/out/persistence/HostEventPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/host/event/adapter/out/persistence/HostEventPersistenceAdapter.java
@@ -23,6 +23,7 @@ public class HostEventPersistenceAdapter implements HostEventQueryPort {
     private final com.venueon.host.order.adapter.out.persistence.repository.HostOrderQueryRepository orderQueryRepository;
     private final com.venueon.event.adapter.out.persistence.EventMapper eventMapper;
     private final com.venueon.event.adapter.out.persistence.SessionMapper sessionMapper;
+    private final com.venueon.user.adapter.out.persistence.repository.HostProfileJpaRepository hostProfileJpaRepository;
 
     @Override
     public Page<HostEventResponse> findByHostId(Long hostId, String status, Pageable pageable) {
@@ -83,6 +84,8 @@ public class HostEventPersistenceAdapter implements HostEventQueryPort {
         var tickets = ticketJpaRepository.findByEventIdIn(java.util.List.of(eventId));
         long totalRevenue = orderQueryRepository.sumRevenueByEventId(eventId);
         long totalAttendees = orderQueryRepository.countAttendeesByEventId(eventId);
+        
+        var hostProfileOpt = hostProfileJpaRepository.findByUserId(hostId);
 
         // 도메인 로직을 활용한 상태 계산 추가
         var eventDomain = eventMapper.toDomain(event);
@@ -95,7 +98,8 @@ public class HostEventPersistenceAdapter implements HostEventQueryPort {
                 totalRevenue, 
                 totalAttendees,
                 eventDomain.getEffectiveStatus(sessionDomains),
-                eventDomain.getRecruitmentStatus(sessionDomains)
+                eventDomain.getRecruitmentStatus(sessionDomains),
+                hostProfileOpt.orElse(null)
         );
     }
 

--- a/backend/src/main/java/com/venueon/host/profile/adapter/in/web/HostProfileController.java
+++ b/backend/src/main/java/com/venueon/host/profile/adapter/in/web/HostProfileController.java
@@ -1,0 +1,62 @@
+package com.venueon.host.profile.adapter.in.web;
+
+import com.venueon.common.dto.ApiResponse;
+import com.venueon.host.common.HostAuthSupport;
+import com.venueon.host.profile.adapter.in.web.dto.HostProfileResponse;
+import com.venueon.host.profile.adapter.in.web.dto.UpdateHostProfileRequest;
+import com.venueon.host.profile.application.port.in.GetHostProfileUseCase;
+import com.venueon.host.profile.application.port.in.UpdateHostProfileUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Host 전용 프로필 API — 인증된 Host만 접근 가능.
+ *
+ * GET  /host/profile  — 내 호스트 프로필 조회
+ * PUT  /host/profile  — 내 호스트 프로필 수정
+ */
+@Slf4j
+@RestController
+@RequestMapping("/host/profile")
+@RequiredArgsConstructor
+public class HostProfileController {
+
+    private final GetHostProfileUseCase getHostProfileUseCase;
+    private final UpdateHostProfileUseCase updateHostProfileUseCase;
+    private final HostAuthSupport hostAuthSupport;
+
+    /**
+     * 내 호스트 프로필 조회
+     * GET /host/profile
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<HostProfileResponse>> getMyProfile(
+            Authentication authentication
+    ) {
+        Long userId = hostAuthSupport.extractUserId(authentication);
+        log.debug("GET /host/profile — userId={}", userId);
+
+        HostProfileResponse response = getHostProfileUseCase.getHostProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 내 호스트 프로필 수정
+     * PUT /host/profile
+     */
+    @PutMapping
+    public ResponseEntity<ApiResponse<HostProfileResponse>> updateMyProfile(
+            Authentication authentication,
+            @Valid @RequestBody UpdateHostProfileRequest request
+    ) {
+        Long userId = hostAuthSupport.extractUserId(authentication);
+        log.debug("PUT /host/profile — userId={}, orgName={}", userId, request.getOrgName());
+
+        HostProfileResponse response = updateHostProfileUseCase.updateHostProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/backend/src/main/java/com/venueon/host/profile/adapter/in/web/dto/HostProfileResponse.java
+++ b/backend/src/main/java/com/venueon/host/profile/adapter/in/web/dto/HostProfileResponse.java
@@ -1,0 +1,42 @@
+package com.venueon.host.profile.adapter.in.web.dto;
+
+import com.venueon.user.domain.model.HostProfile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 호스트 프로필 조회 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class HostProfileResponse {
+
+    private Long id;
+    private Long userId;
+    private String orgName;
+    private String orgNumber;
+    private String managerName;
+    private String orgDescription;
+    private String profileImg;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /**
+     * 도메인 모델 + User의 profileImg → 응답 DTO 변환
+     */
+    public static HostProfileResponse from(HostProfile profile, String profileImg) {
+        return new HostProfileResponse(
+                profile.getId(),
+                profile.getUserId(),
+                profile.getOrgName(),
+                profile.getOrgNumber(),
+                profile.getManagerName(),
+                profile.getOrgDescription(),
+                profileImg,
+                profile.getCreatedAt(),
+                profile.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/venueon/host/profile/adapter/in/web/dto/UpdateHostProfileRequest.java
+++ b/backend/src/main/java/com/venueon/host/profile/adapter/in/web/dto/UpdateHostProfileRequest.java
@@ -1,0 +1,27 @@
+package com.venueon.host.profile.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 호스트 프로필 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateHostProfileRequest {
+
+    @NotBlank(message = "기관명은 필수입니다.")
+    private String orgName;
+
+    @NotBlank(message = "담당자명은 필수입니다.")
+    private String managerName;
+
+    private String orgDescription;
+
+    /** 프로필 이미지 경로 (null이면 변경하지 않음) */
+    private String profileImg;
+}
+

--- a/backend/src/main/java/com/venueon/host/profile/application/port/in/GetHostProfileUseCase.java
+++ b/backend/src/main/java/com/venueon/host/profile/application/port/in/GetHostProfileUseCase.java
@@ -1,0 +1,14 @@
+package com.venueon.host.profile.application.port.in;
+
+import com.venueon.host.profile.adapter.in.web.dto.HostProfileResponse;
+
+/**
+ * 호스트 프로필 조회 유스케이스 (Port-In)
+ */
+public interface GetHostProfileUseCase {
+
+    /**
+     * userId 기반으로 호스트 프로필 조회
+     */
+    HostProfileResponse getHostProfile(Long userId);
+}

--- a/backend/src/main/java/com/venueon/host/profile/application/port/in/UpdateHostProfileUseCase.java
+++ b/backend/src/main/java/com/venueon/host/profile/application/port/in/UpdateHostProfileUseCase.java
@@ -1,0 +1,15 @@
+package com.venueon.host.profile.application.port.in;
+
+import com.venueon.host.profile.adapter.in.web.dto.HostProfileResponse;
+import com.venueon.host.profile.adapter.in.web.dto.UpdateHostProfileRequest;
+
+/**
+ * 호스트 프로필 수정 유스케이스 (Port-In)
+ */
+public interface UpdateHostProfileUseCase {
+
+    /**
+     * userId 기반으로 호스트 프로필 수정
+     */
+    HostProfileResponse updateHostProfile(Long userId, UpdateHostProfileRequest request);
+}

--- a/backend/src/main/java/com/venueon/host/profile/application/service/HostProfileService.java
+++ b/backend/src/main/java/com/venueon/host/profile/application/service/HostProfileService.java
@@ -1,0 +1,78 @@
+package com.venueon.host.profile.application.service;
+
+import com.venueon.host.profile.adapter.in.web.dto.HostProfileResponse;
+import com.venueon.host.profile.adapter.in.web.dto.UpdateHostProfileRequest;
+import com.venueon.host.profile.application.port.in.GetHostProfileUseCase;
+import com.venueon.host.profile.application.port.in.UpdateHostProfileUseCase;
+import com.venueon.user.application.port.out.HostProfileRepositoryPort;
+import com.venueon.user.application.port.out.UserRepositoryPort;
+import com.venueon.user.domain.model.HostProfile;
+import com.venueon.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 호스트 프로필 조회/수정 서비스
+ * 기존 user 패키지의 HostProfileRepositoryPort, UserRepositoryPort를 재사용하여
+ * 공통 코드 수정 없이 독립적으로 동작한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HostProfileService implements GetHostProfileUseCase, UpdateHostProfileUseCase {
+
+    private final HostProfileRepositoryPort hostProfileRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Override
+    public HostProfileResponse getHostProfile(Long userId) {
+        log.debug("호스트 프로필 조회 — userId={}", userId);
+
+        HostProfile profile = hostProfileRepositoryPort.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "호스트 프로필을 찾을 수 없습니다. userId=" + userId));
+
+        // User에서 profileImg 조회
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "사용자를 찾을 수 없습니다. userId=" + userId));
+
+        return HostProfileResponse.from(profile, user.getProfileImg());
+    }
+
+    @Override
+    @Transactional
+    public HostProfileResponse updateHostProfile(Long userId, UpdateHostProfileRequest request) {
+        log.debug("호스트 프로필 수정 — userId={}, orgName={}", userId, request.getOrgName());
+
+        HostProfile profile = hostProfileRepositoryPort.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "호스트 프로필을 찾을 수 없습니다. userId=" + userId));
+
+        // 도메인 모델의 비즈니스 메서드를 통해 수정
+        profile.updateProfile(
+                request.getOrgName(),
+                request.getOrgDescription(),
+                request.getManagerName()
+        );
+
+        // 변경된 도메인 모델을 저장
+        HostProfile saved = hostProfileRepositoryPort.save(profile);
+
+        // profileImg가 전달된 경우 User 엔티티도 업데이트
+        User user = userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "사용자를 찾을 수 없습니다. userId=" + userId));
+
+        if (request.getProfileImg() != null) {
+            user.updateProfile(user.getNickname(), request.getProfileImg(), user.getCategories(), null);
+            userRepositoryPort.save(user);
+        }
+
+        return HostProfileResponse.from(saved, user.getProfileImg());
+    }
+}
+

--- a/frontend/src/app/host/events/[id]/_components/EventTabSection/EventTabSection.tsx
+++ b/frontend/src/app/host/events/[id]/_components/EventTabSection/EventTabSection.tsx
@@ -183,7 +183,7 @@ export const EventTabSection = ({
                   <th>세션 명</th>
                   <th>일시</th>
                   <th>상태</th>
-                  <th>커뮤니티</th>
+                  <th>스터디 룸</th>
                 </tr>
               </thead>
               <tbody>
@@ -203,9 +203,9 @@ export const EventTabSection = ({
                           fontWeight: '600',
                           cursor: 'pointer'
                         }}
-                        onClick={() => alert(`세션 [${s.title}]의 커뮤니티 관리 페이지로 이동합니다.`)}
+                        onClick={() => alert(`세션 [${s.title}]의 스터디 룸 관리 페이지로 이동합니다.`)}
                       >
-                        커뮤니티 관리
+                        스터디 룸 관리
                       </button>
                     </td>
                   </tr>

--- a/frontend/src/app/host/events/[id]/_components/HostProfile/HostProfile.tsx
+++ b/frontend/src/app/host/events/[id]/_components/HostProfile/HostProfile.tsx
@@ -2,20 +2,30 @@ import styles from './HostProfile.module.css';
 
 interface HostProfileProps {
   hostName: string;
+  hostDescription?: string | null;
+  hostProfileImg?: string | null;
 }
 
-export const HostProfile = ({ hostName }: HostProfileProps) => {
+export const HostProfile = ({ hostName, hostDescription, hostProfileImg }: HostProfileProps) => {
   return (
     <section className={styles.sectionBox}>
       <h3 className={styles.sectionTitle}>주최자 정보</h3>
       <div className={styles.hostProfile}>
         <div className={styles.hostAvatar}>
-          {hostName?.[0] || 'A'}
+          {hostProfileImg ? (
+            <img 
+              src={`/api${hostProfileImg.startsWith('/') ? '' : '/'}${hostProfileImg}`} 
+              alt={hostName} 
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }} 
+            />
+          ) : (
+            hostName?.[0] || 'A'
+          )}
         </div>
         <div className={styles.hostInfo}>
-          <h4 className={styles.hostName}>{hostName || '에이아이마인드 크리에이티브'}</h4>
+          <h4 className={styles.hostName}>{hostName}</h4>
           <p className={styles.hostBio}>
-            데이터를 넘어 마케팅의 본질을 꿰뚫는 AI 마케팅 그룹으로서 10년의 풍부한 실무 마케팅기획 및 실질적 성장을 도와드립니다.
+            {hostDescription || '등록된 소개글이 없거나 아직 제공되지 않았습니다.'}
           </p>
         </div>
       </div>

--- a/frontend/src/app/host/events/[id]/page.tsx
+++ b/frontend/src/app/host/events/[id]/page.tsx
@@ -107,7 +107,11 @@ export default function HostEventDetailPage() {
           />
           
           {activeTab === 'BASIC' && (
-            <HostProfile hostName={event.hostName} />
+            <HostProfile 
+              hostName={event.hostName} 
+              hostDescription={event.hostDescription} 
+              hostProfileImg={event.hostProfileImg} 
+            />
           )}
         </div>
       </main>

--- a/frontend/src/app/host/events/[id]/types.ts
+++ b/frontend/src/app/host/events/[id]/types.ts
@@ -26,6 +26,8 @@ export interface HostEventDetail {
   hasDiscount: boolean;
   location: string;
   hostName: string;
+  hostDescription: string | null;
+  hostProfileImg: string | null;
   sessions: SessionDetail[];
 }
 

--- a/frontend/src/app/host/profile/_components/ProfileForm.module.css
+++ b/frontend/src/app/host/profile/_components/ProfileForm.module.css
@@ -1,0 +1,106 @@
+.formContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background-color: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: var(--radius-lg, 12px);
+  padding: 32px;
+  max-width: 600px;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--color-text, #0f172a);
+  margin: 0;
+}
+
+.sectionDesc {
+  font-size: 14px;
+  color: var(--color-text-muted, #64748b);
+  margin: 0;
+}
+
+.profileImageSection {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  padding: 16px;
+  background-color: var(--color-surface, #f8fafc);
+  border-radius: var(--radius-md, 8px);
+  border: 1px dashed var(--color-border, #cbd5e1);
+}
+
+.imagePreview {
+  flex-shrink: 0;
+}
+
+.imageWrapper {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid var(--color-border, #e2e8f0);
+  background-color: white;
+}
+
+.profileImgElement {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.imagePlaceholder {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background-color: var(--color-border, #e2e8f0);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px solid var(--color-border, #cbd5e1);
+}
+
+.placeholderText {
+  font-size: 12px;
+  color: var(--color-text-muted, #64748b);
+  text-align: center;
+}
+
+.uploadSection {
+  flex: 1;
+}
+
+.uploadingText {
+  font-size: 12px;
+  color: var(--color-primary, #10b981);
+  margin-top: 8px;
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  border-top: 1px solid var(--color-border, #e2e8f0);
+  padding-top: 24px;
+  margin-top: 8px;
+}
+
+.disabledField {
+  opacity: 0.7;
+}
+
+.disabledHelp {
+  font-size: 12px;
+  color: var(--color-text-muted, #64748b);
+  margin-top: -16px;
+  margin-left: 4px;
+  display: block;
+}

--- a/frontend/src/app/host/profile/_components/ProfileForm.tsx
+++ b/frontend/src/app/host/profile/_components/ProfileForm.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { useState } from "react";
+import InputField from "@/components/ui/InputField";
+import TextareaField from "@/components/ui/TextareaField";
+import Button from "@/components/ui/Button";
+import UploadField from "@/components/ui/UploadField";
+import { type HostProfile } from "../types";
+import { hostAPI } from "@/lib/host-api";
+import { useUIStore } from "@/store/useUIStore";
+import { useAuth } from "@/store/useAuthStore";
+import styles from "./ProfileForm.module.css";
+import Image from "next/image";
+
+interface ProfileFormProps {
+  initialData: HostProfile;
+  onSuccess?: (updatedData: HostProfile) => void;
+}
+
+export default function ProfileForm({ initialData, onSuccess }: ProfileFormProps) {
+  const { showToast } = useUIStore();
+  const { updateUser } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+
+  // 수정 가능한 폼 상태
+  const [orgName, setOrgName] = useState(initialData.orgName || "");
+  const [managerName, setManagerName] = useState(initialData.managerName || "");
+  const [orgDescription, setOrgDescription] = useState(initialData.orgDescription || "");
+  const [profileImg, setProfileImg] = useState(initialData.profileImg || "");
+
+  const handleFileSelect = async (file: File | null) => {
+    if (!file) {
+      setProfileImg("");
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      
+      const res = await fetch("/api/files/upload?category=host-profile", {
+        method: "POST",
+        body: formData,
+      });
+      
+      const result = await res.json();
+      if (!res.ok) {
+        throw new Error(result.message || "이미지 업로드에 실패했습니다.");
+      }
+      
+      setProfileImg(result.data.filePath);
+      showToast("이미지가 성공적으로 업로드되었습니다.", "success");
+    } catch (error: any) {
+      showToast(error.message || "이미지 업로드 중 오류가 발생했습니다.", "error");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!orgName.trim() || !managerName.trim()) {
+      showToast("기관명과 담당자명은 필수 입력입니다.", "error");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const updated = await hostAPI.updateProfile({
+        orgName,
+        managerName,
+        orgDescription,
+        profileImg: profileImg || undefined,
+      });
+
+      // 전역 인증 정보(헤더의 프로필 이미지 등) 동기화
+      updateUser({ profileImg: updated.profileImg });
+
+      showToast("프로필이 성공적으로 업데이트되었습니다.", "success");
+      onSuccess?.(updated);
+    } catch (error: any) {
+      showToast(error.message || "프로필 수정에 실패했습니다.", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className={styles.formContainer} onSubmit={handleSubmit}>
+      <div className={styles.sectionHeader}>
+        <h2 className={styles.sectionTitle}>기관 로고 / 프로필 정보</h2>
+        <p className={styles.sectionDesc}>
+          플랫폼에 노출되는 호스트의 로고 및 기본 정보를 관리할 수 있습니다.
+        </p>
+      </div>
+
+      <div className={styles.profileImageSection}>
+        <div className={styles.imagePreview}>
+          {profileImg ? (
+            <div className={styles.imageWrapper}>
+               {/* 
+                 Next.js 외부 이미지 사용을 피하기 위해 img 태그를 사용하거나, 
+                 설정된 이미지 경로를 그대로 노출합니다. 여기서는 img 태그 사용.
+               */}
+              <img src={`/api${profileImg.startsWith('/') ? '' : '/'}${profileImg}`} alt="프로필 로고" className={styles.profileImgElement} />
+            </div>
+          ) : (
+            <div className={styles.imagePlaceholder}>
+              <span className={styles.placeholderText}>이미지 없음</span>
+            </div>
+          )}
+        </div>
+        
+        <div className={styles.uploadSection}>
+          <UploadField 
+            label="프로필 로고 변경" 
+            onFileSelect={handleFileSelect} 
+            accept="image/*"
+            disabled={isUploading}
+          />
+          {isUploading && <p className={styles.uploadingText}>이미지를 업로드 중입니다...</p>}
+        </div>
+      </div>
+
+      <InputField
+        label="기관명"
+        value={orgName}
+        onChange={(e) => setOrgName(e.target.value)}
+        placeholder="기관명을 입력하세요"
+        required
+      />
+
+      <InputField
+        label="담당자명"
+        value={managerName}
+        onChange={(e) => setManagerName(e.target.value)}
+        placeholder="담당자명 입력"
+        required
+      />
+
+      <div className={styles.disabledField}>
+        <InputField
+          label="사업자등록번호 (변경 불가)"
+          value={initialData.orgNumber}
+          disabled
+        />
+        <span className={styles.disabledHelp}>
+          가입 시 인증된 번호이므로 변경할 수 없습니다. 변경이 필요한 경우 관리자에게 문의하세요.
+        </span>
+      </div>
+
+      <TextareaField
+        label="기관 소개"
+        value={orgDescription}
+        onChange={(e) => setOrgDescription(e.target.value)}
+        placeholder="행사 페이지 하단에 노출될 수 있는 기관 소개를 작성해주세요."
+        rows={4}
+        showCount
+      />
+
+      <div className={styles.formActions}>
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={loading || isUploading || (!orgName.trim() || !managerName.trim())}
+        >
+          {loading ? "저장 중..." : "변경 사항 저장"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/host/profile/page.module.css
+++ b/frontend/src/app/host/profile/page.module.css
@@ -1,0 +1,39 @@
+.pageContainer {
+  padding: 32px 0;
+}
+
+.pageHeader {
+  margin-bottom: 24px;
+}
+
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--color-text, #0f172a);
+  margin: 0 0 8px 0;
+}
+
+.pageDesc {
+  font-size: 15px;
+  color: var(--color-text-muted, #64748b);
+  margin: 0;
+}
+
+.loaderWrapper,
+.errorWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 400px;
+  color: var(--color-text-muted, #64748b);
+}
+
+.retryBtn {
+  margin-top: 16px;
+  padding: 8px 16px;
+  background-color: var(--color-surface, #f1f5f9);
+  border: 1px solid var(--color-border, #cbd5e1);
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/frontend/src/app/host/profile/page.tsx
+++ b/frontend/src/app/host/profile/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Sidebar from "@/components/layout/Sidebar";
+import ProfileForm from "./_components/ProfileForm";
+import { type HostProfile } from "./types";
+import { hostAPI } from "@/lib/host-api";
+import styles from "./page.module.css";
+
+export default function HostProfilePage() {
+  const [profile, setProfile] = useState<HostProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await hostAPI.getProfile();
+      setProfile(data);
+    } catch (err: any) {
+      setError(err.message || "프로필을 불러오는 데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchProfile();
+  }, []);
+
+  const handleSuccess = (updatedData: HostProfile) => {
+    setProfile(updatedData);
+  };
+
+  return (
+    <div className="container-sidebar" style={{ scrollbarGutter: "stable" }}>
+      <div className="sidebar">
+        <Sidebar role="host" />
+      </div>
+
+      <div className="sidebar-content">
+        <div className={styles.pageContainer}>
+          <header className={styles.pageHeader}>
+            <h1 className={styles.pageTitle}>프로필 설정</h1>
+            <p className={styles.pageDesc}>
+              호스트 전용 정보를 확인하고 수정할 수 있습니다.
+            </p>
+          </header>
+
+          {isLoading && (
+            <div className={styles.loaderWrapper}>
+              <p>정보를 불러오는 중입니다...</p>
+            </div>
+          )}
+
+          {!isLoading && error && (
+            <div className={styles.errorWrapper}>
+              <p>{error}</p>
+              <button className={styles.retryBtn} onClick={fetchProfile}>
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {!isLoading && !error && profile && (
+            <ProfileForm initialData={profile} onSuccess={handleSuccess} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/host/profile/types.ts
+++ b/frontend/src/app/host/profile/types.ts
@@ -1,0 +1,11 @@
+export interface HostProfile {
+  id: number;
+  userId: number;
+  orgName: string;
+  orgNumber: string;
+  managerName: string;
+  orgDescription?: string;
+  profileImg?: string;
+  createdAt: string;
+  updatedAt?: string;
+}

--- a/frontend/src/lib/host-api.ts
+++ b/frontend/src/lib/host-api.ts
@@ -1,0 +1,19 @@
+export const hostAPI = {
+  getProfile: async () => {
+    const res = await fetch('/api/host/profile');
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '프로필 연동에 실패했습니다.');
+    return result.data;
+  },
+
+  updateProfile: async (data: { orgName: string; managerName: string; orgDescription?: string; profileImg?: string }) => {
+    const res = await fetch('/api/host/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const result = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(result.message || result.error || '프로필 수정에 실패했습니다.');
+    return result.data;
+  },
+};


### PR DESCRIPTION
VO-734
✅ 백엔드 (Hexagonal Architecture)

- Domain & Persistence: HostProfile 도메인 모델 확장 및 JPA 엔티티(HostProfileJpaEntity) 내 이미지 필드 추가
- Service: 호스트 프로필 조회 및 수정을 위한 HostProfileService 구현 (User 엔티티의 프로필 이미지와 동기화 로직 포함)
- Adapter: HostEventPersistenceAdapter를 수정하여 이벤트 상세 조회(getHostEventDetail) 시 실제 호스트 프로필 정보를 함께 반환하도록 개선

✅ 프론트엔드 (Next.js)

- Profile Page: 호스트 프로필 수정 폼 구현 및 이미지 업로드 기능 (UploadField) 연동
- Event Detail: 이벤트 상세 페이지 하단의 주최자 정보 영역에 하드코딩된 가상 데이터를 실제 API 데이터로 교체
- UX 개선: 프로필 사진 수정 시 헤더의 프로필 이미지도 실시간으로 변경되도록 전역 상태(useAuth) 동기화 처리