### PR TITLE
feat: Google 소셜 로그인 유저 대상 '계정 보안' 메뉴 사이드바 숨김 처리 #VO-873

### DIFF
--- a/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/AuthController.java
@@ -51,7 +51,8 @@ public class AuthController {
                 user.getRole() != null ? com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()) : null,
                 user.getProfileImg(),
                 user.getCategories(),
-                user.isBadgeVisible()
+                user.isBadgeVisible(),
+                user.getProvider() != null ? user.getProvider().name() : "LOCAL"
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
@@ -80,7 +81,8 @@ public class AuthController {
                 user.getRole() != null ? com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()) : null,
                 user.getProfileImg(),
                 user.getCategories(),
-                user.isBadgeVisible()
+                user.isBadgeVisible(),
+                user.getProvider() != null ? user.getProvider().name() : "LOCAL"
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
@@ -152,7 +154,8 @@ public class AuthController {
                 user.getRole() != null ? com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()) : null,
                 user.getProfileImg(),
                 user.getCategories(),
-                user.isBadgeVisible()
+                user.isBadgeVisible(),
+                user.getProvider() != null ? user.getProvider().name() : "LOCAL"
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -175,7 +178,8 @@ public class AuthController {
                 user.getRole() != null ? com.venueon.common.dto.CodeDto.of(user.getRole().id(), user.getRole().label()) : null,
                 user.getProfileImg(),
                 user.getCategories(),
-                user.isBadgeVisible()
+                user.isBadgeVisible(),
+                user.getProvider() != null ? user.getProvider().name() : "LOCAL"
         );
 
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/UserController.java
@@ -51,7 +51,8 @@ public class UserController {
                 updatedUser.getRole() != null ? com.venueon.common.dto.CodeDto.of(updatedUser.getRole().id(), updatedUser.getRole().label()) : null,
                 updatedUser.getProfileImg(),
                 updatedUser.getCategories(),
-                updatedUser.isBadgeVisible()
+                updatedUser.isBadgeVisible(),
+                updatedUser.getProvider() != null ? updatedUser.getProvider().name() : "LOCAL"
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
+++ b/backend/src/main/java/com/venueon/user/adapter/in/web/dto/UserInfoResponse.java
@@ -10,5 +10,6 @@ public record UserInfoResponse(
         com.venueon.common.dto.CodeDto role,
         String profileImg,
         java.util.List<String> categories,
-        Boolean showBadge
+        Boolean showBadge,
+        String provider       // LOCAL | GOOGLE
 ) {}

--- a/frontend/src/app/api/auth/google/route.ts
+++ b/frontend/src/app/api/auth/google/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: Request) {
     session.profileImg = userData.profileImg;
     session.role = userData.role;
     session.userId = userData.id;
+    session.provider = userData.provider || 'GOOGLE';
     session.isLoggedIn = true;
     await session.save();
 

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: Request) {
     session.profileImg = userData.profileImg;
     session.role = userData.role;
     session.userId = userData.id;
+    session.provider = userData.provider || 'LOCAL';
     session.isLoggedIn = true;
     await session.save();
 

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
         nickname: session.nickname,
         profileImg: session.profileImg,
         role: session.role,
+        provider: session.provider || 'LOCAL',
       },
     });
   } else {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -84,13 +84,16 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
   const router = useRouter();
 
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
 
   // 로그아웃 확인 클릭 시 동작
   const handleLogoutConfirm = async () => {
     setIsLogoutModalOpen(false);
     await logout();
   };
+
+  // Google 소셜 로그인 유저 여부
+  const isSocialUser = user?.provider === 'GOOGLE';
 
   const getMenus = () => {
     switch (role) {
@@ -123,7 +126,8 @@ export default function Sidebar({ role = 'user', className = '', fakePathname }:
           { label: '내 커뮤니티', href: '/mypage/community', icon: CommunityIcon },
           { label: '내 뱃지', href: '/mypage/badges', icon: BadgeIcon },
           { label: '프로필 설정', href: '/mypage/profile', icon: ProfileIcon },
-          { label: '계정 보안', href: '/mypage/security', icon: SecurityIcon },
+          // 소셜 로그인 유저는 비밀번호가 없으므로 계정 보안 메뉴 숨김
+          ...(!isSocialUser ? [{ label: '계정 보안', href: '/mypage/security', icon: SecurityIcon }] : []),
           { label: '1:1 문의', href: '/mypage/contact', icon: ContactIcon },
           { label: '로그아웃', href: '/logout', icon: LogoutIcon },
         ];

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -11,6 +11,7 @@ export interface SessionData {
   nickname?: string;
   profileImg?: string;
   role?: { id: number; label: string };
+  provider?: string;    // LOCAL | GOOGLE
   isLoggedIn: boolean;
 }
 

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -7,6 +7,7 @@ interface User {
   nickname?: string;
   profileImg?: string;
   role?: { id: number; label: string };
+  provider?: string;   // LOCAL | GOOGLE
 }
 
 interface AuthState {


### PR DESCRIPTION
closes #VO-873

**1. 배경 및 목적**
* Google OAuth로 가입한 유저는 서비스 자체 비밀번호를 보유하고 있지 않아, '계정 보안(비밀번호 변경)' 메뉴 진입 시 혼란이나 에러가 발생할 수 있음
* 소셜 로그인 유저와 로컬 가입 유저의 계정 관리 동선을 명확히 분리하여 UX 완성도를 높이고자 함

**2. 작업 내용**

**백엔드**
* `UserInfoResponse` DTO에 `provider` 필드(`LOCAL` / `GOOGLE`) 추가
* `AuthController`, `UserController`의 모든 `UserInfoResponse` 생성자 호출부에 `provider` 값 전달

**BFF (Next.js API Route)**
* `SessionData`에 `provider` 필드 추가
* 로컬 로그인(`login/route.ts`), Google 로그인(`google/route.ts`) 시 `provider`를 iron-session에 저장
* `GET /api/auth/session` 응답에 `provider` 포함

**프론트엔드**
* `useAuthStore`의 `User` 인터페이스에 `provider` 추가
* `Sidebar.tsx`에서 `user.provider === 'GOOGLE'`인 경우 `계정 보안` 메뉴 조건부 제외

**3. 데이터 흐름**
Backend User.provider → /auth/me → BFF iron-session → GET /api/auth/session → useAuth → Sidebar


**4. 영향 범위**
* admin / host 사이드바에는 원래 '계정 보안' 메뉴가 없으므로 영향 없음
* user(마이페이지) 사이드바에서만 Google 유저 대상 메뉴 숨김 적용

Closes #VO-873
