### PR TITLE
feat:커뮤니티 게시글 에디터(Tiptap) 적용 및 DB 설정 업데이트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
       # JPA — MVP: create-drop (실 서비스 시 validate + Flyway 전환)
-      - SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
       - SPRING_JPA_SHOW_SQL=false
       # JWT
       - JWT_SECRET=${JWT_SECRET}

--- a/frontend/src/app/community/[id]/posts/[postId]/edit/page.tsx
+++ b/frontend/src/app/community/[id]/posts/[postId]/edit/page.tsx
@@ -2,9 +2,12 @@
 
 import React, { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
-import { InputField, TextareaField, Dropdown, Button } from '@/components/ui';
+import { InputField, Dropdown, Button } from '@/components/ui';
 import { useUIStore } from '@/store/useUIStore';
+import dynamic from 'next/dynamic';
 import styles from '../../../../components/CommunityForm.module.css';
+
+const TiptapEditor = dynamic(() => import('@/components/editor/TiptapEditor'), { ssr: false });
 
 interface Props {
   params: Promise<{ id: string; postId: string }>;
@@ -48,7 +51,7 @@ export default function PostEditPage({ params }: Props) {
   }, [postId, router, showToast]);
 
   const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
+    if (!title.trim() || !content.trim() || content === '<p></p>') {
       showToast('입력 오류', 'error', '제목과 내용을 모두 입력해주세요.');
       return;
     }
@@ -121,14 +124,15 @@ export default function PostEditPage({ params }: Props) {
           onChange={(e) => setTitle(e.target.value)}
         />
 
-        <TextareaField
-          label="본문 내용 (필수)"
-          placeholder="이곳에 내용을 자세히 적어주세요."
-          defaultValue={content}
-          onChange={(e) => setContent(e.target.value)}
-          showCount={true}
-          rows={12}
-        />
+        <div className={styles.editorWrapper}>
+          <label className={styles.label}>본문 내용 (필수)</label>
+          <TiptapEditor 
+            content={content} 
+            onChange={(html) => setContent(html)} 
+            placeholder="이곳에 내용을 자세히 적어주세요."
+            category="community-post"
+          />
+        </div>
 
         <div style={{ display: 'flex', gap: '12px', marginTop: '16px' }}>
           <Button 

--- a/frontend/src/app/community/[id]/write/page.module.css
+++ b/frontend/src/app/community/[id]/write/page.module.css
@@ -4,7 +4,6 @@
   padding: 60px 24px;
 }
 
-/*  */
 .formSection {
   background: #ffffff;
   padding: 40px;
@@ -27,4 +26,16 @@
   font-size: 28px;
   font-weight: 700;
   color: #111827;
+}
+
+.editorWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
 }

--- a/frontend/src/app/community/[id]/write/page.tsx
+++ b/frontend/src/app/community/[id]/write/page.tsx
@@ -2,9 +2,12 @@
 
 import React, { useState, use } from 'react';
 import { useRouter } from 'next/navigation';
-import { InputField, TextareaField, Dropdown, Button } from '@/components/ui';
+import { InputField, Dropdown, Button } from '@/components/ui';
 import { useUIStore } from '@/store/useUIStore';
+import dynamic from 'next/dynamic';
 import styles from './page.module.css';
+
+const TiptapEditor = dynamic(() => import('@/components/editor/TiptapEditor'), { ssr: false });
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -23,7 +26,7 @@ export default function CommunityWritePage({ params }: Props) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
+    if (!title.trim() || !content.trim() || content === '<p></p>') {
       showToast('입력 오류', 'error', '제목과 내용을 모두 입력해주세요.');
       return;
     }
@@ -89,14 +92,15 @@ export default function CommunityWritePage({ params }: Props) {
           onChange={(e) => setTitle(e.target.value)}
         />
 
-        <TextareaField
-          label="본문 내용 (필수)"
-          placeholder="이곳에 내용을 자세히 적어주세요."
-          defaultValue={content}
-          onChange={(e) => setContent(e.target.value)}
-          showCount={true}
-          rows={15}
-        />
+        <div className={styles.editorWrapper}>
+          <label className={styles.label}>본문 내용 (필수)</label>
+          <TiptapEditor 
+            content={content} 
+            onChange={(html) => setContent(html)} 
+            placeholder="이곳에 내용을 자세히 적어주세요."
+            category="community-post"
+          />
+        </div>
 
         <div style={{ display: 'flex', gap: '12px', marginTop: '16px' }}>
           <Button 

--- a/frontend/src/app/community/components/CommunityForm.module.css
+++ b/frontend/src/app/community/components/CommunityForm.module.css
@@ -20,3 +20,15 @@
     padding: var(--space-16);
   }
 }
+
+.editorWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}

--- a/frontend/src/app/community/components/CommunityPostContainer.module.css
+++ b/frontend/src/app/community/components/CommunityPostContainer.module.css
@@ -229,6 +229,74 @@
   min-height: 200px;
 }
 
+.richContent {
+  margin-top: var(--space-16, 16px);
+  font-size: 16px;
+  line-height: 1.6;
+  color: #111827;
+}
+
+.richContent h2 {
+  font-size: 1.5em;
+  font-weight: 700;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.richContent h3 {
+  font-size: 1.25em;
+  font-weight: 600;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+}
+
+.richContent p {
+  margin-bottom: 1em;
+}
+
+.richContent ul,
+.richContent ol {
+  padding-left: 1.5em;
+  margin-bottom: 1em;
+}
+
+.richContent ul {
+  list-style-type: disc;
+}
+
+.richContent ol {
+  list-style-type: decimal;
+}
+
+.richContent blockquote {
+  border-left: 4px solid #4F46E5;
+  padding: 0.5em 1em;
+  margin: 0;
+  font-style: italic;
+  color: #4B5563;
+  background-color: #F9FAFB;
+}
+
+.richContent img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 1em 0;
+  display: inline-block;
+}
+
+.richContent img[style*="text-align: center"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.richContent img[style*="text-align: right"] {
+  display: block;
+  margin-left: auto;
+  margin-right: 0;
+}
+
 .inlineReplyInput {
   position: relative;
   margin-top: 8px;

--- a/frontend/src/app/community/components/CommunityPostContainer.tsx
+++ b/frontend/src/app/community/components/CommunityPostContainer.tsx
@@ -568,9 +568,16 @@ export default function CommunityPostContainer({ communityId, canManage, canWrit
 
               <div className={styles.bodySection}>
                 <div className={styles.contentWrapper}>
-                  {selectedPost.content?.split('\n').map((line, index) => (
-                    <React.Fragment key={index}>{line}<br /></React.Fragment>
-                  ))}
+                  {selectedPost.content && (
+                    <div
+                      className={styles.richContent}
+                      dangerouslySetInnerHTML={{ 
+                        __html: selectedPost.content.includes('<') && selectedPost.content.includes('>') 
+                          ? selectedPost.content 
+                          : selectedPost.content.replace(/\n/g, '<br />')
+                      }}
+                    />
+                  )}
                 </div>
               </div>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
   const [activeRecruitmentStatus, setActiveRecruitmentStatus] = useState('all');
   const [activeEventStatus, setActiveEventStatus] = useState('all');
 
-  const [categoryOptions, setCategoryOptions] = useState<{value: string, label: string}[]>([
+  const [categoryOptions, setCategoryOptions] = useState<{ value: string, label: string }[]>([
     { value: 'all', label: '카테고리: 전체' }
   ]);
 
@@ -87,13 +87,13 @@ export default function Home() {
   }, []);
 
   const fetchEvents = async (
-      page: number, 
-      keyword: string = '', 
-      categoryId: string = 'all',
-      isOnline: string = 'all',
-      recruitmentStatusId: string = 'all',
-      eventStatusId: string = 'all'
-    ) => {
+    page: number,
+    keyword: string = '',
+    categoryId: string = 'all',
+    isOnline: string = 'all',
+    recruitmentStatusId: string = 'all',
+    eventStatusId: string = 'all'
+  ) => {
     setLoading(true);
     try {
       // Backend pagination is 0-indexed, UI is 1-indexed
@@ -217,27 +217,27 @@ export default function Home() {
 
           <div className={styles.activeFilters}>
             {activeCategory !== 'all' && (
-              <FilterChip 
-                label={categoryOptions.find(o => o.value === activeCategory)?.label || ''} 
-                onClose={() => setActiveCategory('all')} 
+              <FilterChip
+                label={categoryOptions.find(o => o.value === activeCategory)?.label || ''}
+                onClose={() => setActiveCategory('all')}
               />
             )}
             {activeIsOnline !== 'all' && (
-              <FilterChip 
-                label={isOnlineOptions.find(o => o.value === activeIsOnline)?.label || ''} 
-                onClose={() => setActiveIsOnline('all')} 
+              <FilterChip
+                label={isOnlineOptions.find(o => o.value === activeIsOnline)?.label || ''}
+                onClose={() => setActiveIsOnline('all')}
               />
             )}
             {activeRecruitmentStatus !== 'all' && (
-              <FilterChip 
-                label={recruitmentOptions.find(o => o.value === activeRecruitmentStatus)?.label || ''} 
-                onClose={() => setActiveRecruitmentStatus('all')} 
+              <FilterChip
+                label={recruitmentOptions.find(o => o.value === activeRecruitmentStatus)?.label || ''}
+                onClose={() => setActiveRecruitmentStatus('all')}
               />
             )}
             {activeEventStatus !== 'all' && (
-              <FilterChip 
-                label={eventStatusOptions.find(o => o.value === activeEventStatus)?.label || ''} 
-                onClose={() => setActiveEventStatus('all')} 
+              <FilterChip
+                label={eventStatusOptions.find(o => o.value === activeEventStatus)?.label || ''}
+                onClose={() => setActiveEventStatus('all')}
               />
             )}
           </div>
@@ -258,7 +258,7 @@ export default function Home() {
                 if (event.startDate) {
                   try {
                     dateTimeStr = format(new Date(event.startDate), 'yyyy년 M월 d일 a h시');
-                  } catch(e) {}
+                  } catch (e) { }
                 }
 
                 // 모집상태별 D-Day 기준 분기
@@ -273,13 +273,13 @@ export default function Home() {
                   dDayData = diffDays > 0 ? diffDays : (diffDays === 0 ? 'D-Day' : undefined);
                 }
                 // 모집마감(id===3)이면 D-Day 표시 안 함
-                
+
                 // 간단한 카테고리 맵핑 (프론트에서 관리하는 카테고리가 있다면 가져옴)
                 const categoryLabel = categoryOptions.find(c => c.value === String(event.categoryId))?.label || '기타';
 
                 return (
-                  <div 
-                    key={event.id} 
+                  <div
+                    key={event.id}
                     style={{ cursor: 'pointer' }}
                     onClick={() => router.push(`/events/${event.id}`)}
                   >

--- a/frontend/src/components/editor/TiptapEditor.tsx
+++ b/frontend/src/components/editor/TiptapEditor.tsx
@@ -13,9 +13,10 @@ interface TiptapEditorProps {
   content: string;
   onChange: (html: string) => void;
   placeholder?: string;
+  category?: string;
 }
 
-export default function TiptapEditor({ content, onChange, placeholder }: TiptapEditorProps) {
+export default function TiptapEditor({ content, onChange, placeholder, category = 'event-detail' }: TiptapEditorProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const editor = useEditor({
@@ -56,7 +57,7 @@ export default function TiptapEditor({ content, onChange, placeholder }: TiptapE
     try {
       const formData = new FormData();
       formData.append('file', file);
-      formData.append('category', 'event-detail');
+      formData.append('category', category);
 
       const response = await fetch('/api/files/upload', {
         method: 'POST',


### PR DESCRIPTION
📝 작업 내용

1. 커뮤니티 게시글 Tiptap 에디터 도입
글쓰기/수정 페이지 적용: 기존 Textarea 방식에서 팁탭(Tiptap) 리치 텍스트 에디터로 교체하여 서식 있는 게시글 작성이 가능하도록 개선했습니다.
대상: 커뮤니티 글쓰기, 게시글 수정 페이지
이미지 업로드 최적화: 커뮤니티 게시글 내 이미지 업로드 시 전용 카테고리(community-post)를 사용하도록 설정했습니다.

2. 게시글 상세 보기 HTML 렌더링 지원
리치 텍스트 렌더링: 에디터에서 생성된 HTML 데이터를 상세 페이지에서 올바르게 보여주도록 dangerouslySetInnerHTML 및 richContent 스타일을 적용했습니다.
하위 호환성 처리: 기존에 작성된 일반 텍스트 기반 게시글도 줄바꿈이 깨지지 않도록 자동 변환(\n -> <br>) 로직을 추가했습니다.
스타일링: 제목(H2, H3), 목록, 인용구, 이미지 등 에디터 요소들에 대한 일관된 CSS 스타일을 반영했습니다.

3. 인프라 및 DB 설정 변경
Hibernate DDL-Auto 변경: 데이터 보존을 위해 docker-compose.yml 내 JPA 설정을 create-drop에서 update로 변경했습니다.
데이터 타입 확인: 게시글 본문(content) 컬럼이 TEXT 타입으로 설정되어 있음을 확인하여, 대용량 HTML 데이터 저장에 문제가 없음을 검증했습니다.