### PR TITLE
feat: 마이페이지 커뮤니티 참여중/북마크 탭 백엔드 연동 + 마이페이지 리펙토링

### DIFF
--- a/frontend/src/app/community/components/CommunityCard.module.css
+++ b/frontend/src/app/community/components/CommunityCard.module.css
@@ -90,40 +90,40 @@
   background-color: var(--color-text-gray-300);
 }
 
-.keywordSection {
+.infoSection {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  align-content: flex-start;
-  padding: 0;
-  gap: var(--space-8);
-  /* 8px */
+  flex-direction: column;
   width: 100%;
-  height: 98px; /* 고정 공간 확보 (최대 2줄) */
-  overflow: hidden; /* 3줄째로 넘어가면 가림 */
+  padding: 0 var(--space-12);
+  gap: var(--space-4);
+  margin-top: auto;
+  flex: none;
 }
 
-.keywordTag {
+.infoRow {
   display: flex;
   flex-direction: row;
-  justify-content: center;
   align-items: center;
-  padding: var(--space-12) var(--space-24);
-  /* 12px 24px */
-  height: 45px;
-  border: 1px solid var(--color-text-gray-700);
-  /* #374151 */
-  border-radius: 123px;
-  font: var(--text-body-bold);
-  /* 14px 700 */
+  gap: var(--space-8);
   color: var(--color-text-gray-700);
-  /* #374151 */
-  box-sizing: border-box;
+}
+
+.infoIcon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--color-icon-light);
+}
+
+.infoText {
+  font: var(--text-body-regular);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .actionWrapper {
   width: 100%;
-  margin-top: var(--space-8);
+  margin-top: var(--space-16);
   flex: none;
 }

--- a/frontend/src/app/community/components/CommunityCard.tsx
+++ b/frontend/src/app/community/components/CommunityCard.tsx
@@ -3,12 +3,15 @@
 import React from 'react';
 import styles from './CommunityCard.module.css';
 import { Button } from '@/components/ui';
+import { CompanyIcon, CalendarIcon, LocationIcon } from '@/components/icons';
 
 export interface CommunityCardProps {
   postType?: string;
   timeAgo?: string;
   title: string;
-  keywords?: string[];
+  organizer?: string;
+  dateTime?: string;
+  location?: string;
   actionButtonText?: string;
   onActionClick?: () => void;
 }
@@ -17,7 +20,9 @@ export default function CommunityCard({
   postType,
   timeAgo,
   title,
-  keywords = [],
+  organizer,
+  dateTime,
+  location,
   actionButtonText,
   onActionClick
 }: CommunityCardProps) {
@@ -27,6 +32,7 @@ export default function CommunityCard({
         <div className={styles.topRow}>
           {postType && (
             <div className={styles.postType}>
+               {/* 뱃지가 필요한 경우 postTypeDot 사용, 현재 디자인은 그대로 유지 */}
               <span className={styles.postTypeDot} />
               {postType}
             </div>
@@ -36,15 +42,28 @@ export default function CommunityCard({
         <h3 className={styles.title} title={title}>{title}</h3>
       </div>
 
-      {keywords.length > 0 && (
+      {(organizer || dateTime || location) && (
         <div className={styles.bottomSection}>
           <div className={styles.divider} />
-          <div className={styles.keywordSection}>
-            {keywords.map((keyword, index) => (
-              <div key={index} className={styles.keywordTag}>
-                #{keyword}
+          <div className={styles.infoSection}>
+            {organizer && (
+              <div className={styles.infoRow}>
+                <CompanyIcon className={styles.infoIcon} />
+                <span className={styles.infoText}>{organizer}</span>
               </div>
-            ))}
+            )}
+            {dateTime && (
+              <div className={styles.infoRow}>
+                <CalendarIcon className={styles.infoIcon} />
+                <span className={styles.infoText}>{dateTime}</span>
+              </div>
+            )}
+            {location && (
+              <div className={styles.infoRow}>
+                <LocationIcon className={styles.infoIcon} />
+                <span className={styles.infoText}>{location}</span>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/app/mypage/community/page.module.css
+++ b/frontend/src/app/mypage/community/page.module.css
@@ -24,3 +24,21 @@
 .searchBar {
   width: 410px;
 }
+
+.postListContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.emptyState {
+  padding: var(--space-48);
+  text-align: center;
+  color: var(--color-text-gray-500);
+}
+
+.emptyStateGrid {
+  grid-column: 1 / -1;
+  padding: var(--space-48);
+  text-align: center;
+  color: var(--color-text-gray-500);
+}

--- a/frontend/src/app/mypage/community/page.tsx
+++ b/frontend/src/app/mypage/community/page.tsx
@@ -49,13 +49,13 @@ export default function MyCommunityPage() {
 
             {/* participating 탭이면 CommunityListCard(커뮤니티 페이지와 동일), post_bookmark 탭이면 수직 리스트 */}
             {activeTab === 'post_bookmark' ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div className={styles.postListContainer}>
                 {isLoading ? (
-                  <div style={{ padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                  <div className={styles.emptyState}>
                     불러오는 중...
                   </div>
                 ) : communityList.length === 0 ? (
-                  <div style={{ padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                  <div className={styles.emptyState}>
                     해당 항목이 없습니다.
                   </div>
                 ) : (
@@ -77,11 +77,11 @@ export default function MyCommunityPage() {
             ) : (
               <CardGrid layout="2-cols">
                 {isLoading ? (
-                  <div style={{ gridColumn: '1 / -1', padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                  <div className={styles.emptyStateGrid}>
                     불러오는 중...
                   </div>
                 ) : communityList.length === 0 ? (
-                  <div style={{ gridColumn: '1 / -1', padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                  <div className={styles.emptyStateGrid}>
                     해당 항목이 없습니다.
                   </div>
                 ) : (

--- a/frontend/src/app/mypage/community/page.tsx
+++ b/frontend/src/app/mypage/community/page.tsx
@@ -3,61 +3,28 @@
 import React, { useState } from 'react';
 import Sidebar from '@/components/layout/Sidebar';
 import { CardGrid, Pagination, InputField, Tabs } from '@/components/ui';
-import CommunityCard from '@/app/community/components/CommunityCard';
+import CommunityListCard from '@/app/community/components/CommunityListCard';
 import styles from './page.module.css';
+
+import { useCommunity } from './useCommunity';
+
+import CommunityPostItem from '@/app/community/components/CommunityPostItem';
 
 const TAB_OPTIONS = [
   { value: 'participating', label: '참여 중' },
-  { value: 'community_bookmark', label: '커뮤니티 북마크' },
-  { value: 'my_post', label: '내가 쓴 게시물' },
   { value: 'post_bookmark', label: '게시물 북마크' },
 ];
 
-const MOCK_COMMUNITIES = [
-  {
-    id: 1,
-    postType: "프로젝트 모집",
-    timeAgo: "방금 전",
-    title: "함께 사이드 프로젝트 완성할 프론트엔드 개발자 찾습니다 👀",
-    keywords: ['사이드프로젝트', '프론트엔드', '리액트', '주말코딩']
-  },
-  {
-    id: 2,
-    postType: "스터디 모집",
-    timeAgo: "2시간 전",
-    title: "Next.js 14 앱 라우터 뽀개기 스터디 모집",
-    keywords: ['Nextjs', '앱라우터', '스터디', '프론트엔드개발']
-  },
-  {
-    id: 3,
-    postType: "네트워킹",
-    timeAgo: "1일 전",
-    title: "판교 직장인 IT 네트워킹 및 정보 공유 모임",
-    keywords: ['판교', 'IT네트워킹', '직장인모임', '오프라인']
-  },
-  {
-    id: 4,
-    postType: "코드 리뷰",
-    timeAgo: "2일 전",
-    title: "서로 코드리뷰 해주면서 상부상조할 백엔드 개발자 분 모셔요",
-    keywords: ['코드리뷰', '백엔드', 'Java', '스프링부트']
-  }
-];
-
 export default function MyCommunityPage() {
-  const [activeTab, setActiveTab] = useState('participating');
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = 1; // 목업용
-
-  const handleTabChange = (value: string) => {
-    setActiveTab(value);
-    setCurrentPage(1);
-  };
-
-  const handlePageChange = (page: number) => {
-    setCurrentPage(page);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
+  const {
+    activeTab,
+    currentPage,
+    totalPages,
+    communityList,
+    isLoading,
+    handleTabChange,
+    handlePageChange,
+  } = useCommunity();
 
   return (
     <div className="container-sidebar">
@@ -80,17 +47,63 @@ export default function MyCommunityPage() {
               className={styles.searchBar}
             />
 
-            <CardGrid layout="2-cols">
-              {MOCK_COMMUNITIES.map((community) => (
-                <CommunityCard
-                  key={community.id}
-                  postType={community.postType}
-                  timeAgo={community.timeAgo}
-                  title={community.title}
-                  keywords={community.keywords}
-                />
-              ))}
-            </CardGrid>
+            {/* participating 탭이면 CommunityListCard(커뮤니티 페이지와 동일), post_bookmark 탭이면 수직 리스트 */}
+            {activeTab === 'post_bookmark' ? (
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                {isLoading ? (
+                  <div style={{ padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                    불러오는 중...
+                  </div>
+                ) : communityList.length === 0 ? (
+                  <div style={{ padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                    해당 항목이 없습니다.
+                  </div>
+                ) : (
+                  communityList.map((post: any) => (
+                    <CommunityPostItem
+                      key={post.id}
+                      title={post.title}
+                      username={post.username || "익명"}
+                      date={post.date || ""}
+                      avatarUrl={post.avatarUrl}
+                      isNotice={post.isNotice}
+                      isPinned={post.isPinned}
+                      type={post.postType}
+                      onClick={() => { /* 상세 페이지 이동 로직. 추후 구현 */ }}
+                    />
+                  ))
+                )}
+              </div>
+            ) : (
+              <CardGrid layout="2-cols">
+                {isLoading ? (
+                  <div style={{ gridColumn: '1 / -1', padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                    불러오는 중...
+                  </div>
+                ) : communityList.length === 0 ? (
+                  <div style={{ gridColumn: '1 / -1', padding: 'var(--space-48)', textAlign: 'center', color: 'var(--color-text-gray-500)' }}>
+                    해당 항목이 없습니다.
+                  </div>
+                ) : (
+                  communityList.map((community: any) => (
+                    <CommunityListCard
+                      key={community.id}
+                      status="PUBLISHED"
+                      tagText={community.memberCount > 5 ? "인기" : "신규"}
+                      tagVariant={community.memberCount > 5 ? "purple" : "green"}
+                      title={community.name}
+                      organizer={`주최자: ${community.creatorNickname}`}
+                      dateTime={`생성일: ${new Date(community.createdAt).toLocaleDateString()}`}
+                      location={`멤버: ${community.memberCount}명 참여 중`}
+                      price={0}
+                      actionButtonText="커뮤니티 입장하기"
+                      onActionClick={() => window.location.href = `/community/${community.id}`}
+                      onEditClick={community.canManage ? () => window.location.href = `/community/${community.id}/edit` : undefined}
+                    />
+                  ))
+                )}
+              </CardGrid>
+            )}
 
             <Pagination
               currentPage={currentPage}

--- a/frontend/src/app/mypage/community/useCommunity.ts
+++ b/frontend/src/app/mypage/community/useCommunity.ts
@@ -1,0 +1,141 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface CommunityCardItem {
+  id: number;
+  postType: string;
+  timeAgo: string;
+  title: string;
+  
+  // Community Card fields
+  organizer?: string;
+  dateTime?: string;
+  location?: string;
+  
+  // PostItem fields
+  username?: string;
+  date?: string;
+  avatarUrl?: string;
+  isPinned?: boolean;
+  isNotice?: boolean;
+}
+
+const ITEMS_PER_PAGE = 8; // 그리드는 8개씩 노출
+
+// 시간 포맷 변경 함수
+function getTimeAgo(dateString: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  
+  if (diffInSeconds < 60) return '방금 전';
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) return `${diffInHours}시간 전`;
+  const diffInDays = Math.floor(diffInHours / 24);
+  return `${diffInDays}일 전`;
+}
+
+// 날짜 포맷 (예: 2026.03.30 / 10:35)
+function formatDate(dateString: string): string {
+  if (!dateString) return '';
+  const d = new Date(dateString);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} / ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+export function useCommunity() {
+  const [activeTab, setActiveTab] = useState('participating');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [communityList, setCommunityList] = useState<CommunityCardItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchCommunities = useCallback(async (tab: string, page: number) => {
+    setIsLoading(true);
+
+    if (tab === 'participating') {
+      try {
+        const res = await fetch(`/api/communities/me?page=${page - 1}&size=${ITEMS_PER_PAGE}`);
+        if (res.ok) {
+          const json = await res.json();
+          const content = json.content || [];
+          setCommunityList(content);
+          const total = json.totalPages || 1;
+          setTotalPages(total === 0 ? 1 : total);
+        } else {
+          setCommunityList([]);
+          setTotalPages(1);
+        }
+      } catch (err) {
+        console.error('Failed to fetch my communities:', err);
+        setCommunityList([]);
+        setTotalPages(1);
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    if (tab === 'post_bookmark') {
+      try {
+        const res = await fetch(`/api/posts/bookmarks/me?page=${page - 1}&size=${ITEMS_PER_PAGE}`);
+        if (res.ok) {
+          const json = await res.json();
+          // Backend 응답이 Page<PostListResponse> 이므로 배열은 content 에 들어옵니다.
+          const content = json.content || json.data?.content || [];
+          
+          const mappedList: CommunityCardItem[] = content.map((post: any) => ({
+            id: post.id,
+            postType: post.type || "FREE", // PostType enum
+            timeAgo: getTimeAgo(post.createdAt),
+            title: post.title,
+            username: post.authorNickname || "익명",
+            date: formatDate(post.createdAt),
+            avatarUrl: post.authorProfileImg,
+            isPinned: post.isPinned,
+            isNotice: post.isNotice,
+          }));
+
+          setCommunityList(mappedList);
+          
+          const total = json.totalPages || json.data?.totalPages || 1;
+          setTotalPages(total);
+        } else {
+          setCommunityList([]);
+          setTotalPages(1);
+        }
+      } catch (err) {
+        console.error('Failed to fetch bookmarked posts:', err);
+        setCommunityList([]);
+        setTotalPages(1);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCommunities(activeTab, currentPage);
+  }, [activeTab, currentPage, fetchCommunities]);
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return {
+    activeTab,
+    currentPage,
+    totalPages,
+    communityList,
+    isLoading,
+    handleTabChange,
+    handlePageChange,
+  };
+}


### PR DESCRIPTION
close #VO-871 
close #VO-694 
close #VO-697
close #VO-857

## 변경 사항

### 1. 마이페이지 커뮤니티 탭 리팩토링
- 커뮤니티 페이지(`mypage/community/page.tsx`)의 복잡한 상태 관리 및 API 호출 로직을 커스텀 훅(`useCommunity.ts`)으로 분리하여 컴포넌트 복잡도를 낮추고 유지보수성을 향상했습니다.
- 각 탭('참여중', '게시글 북마크')에 따라 알맞은 리스트 UI 요소를 조건부 렌더링하도록 구조를 개선했습니다.

### 2. 커뮤니티 탭 백엔드 API 연동
- **참여중 탭**: `/api/communities/me` API를 연동하여 참여 중인 커뮤니티 목록을 메인 커뮤니티 페이지와 동일한 `CommunityListCard` 컴포넌트로 표시합니다.
- **게시글 북마크 탭**: `/api/posts/bookmarks/me` API를 연동하여 북마크한 게시글을 `CommunityPostItem` 컴포넌트로 표시합니다.

### 주요 변경 파일

| 파일 | 설명 |
|------|------|
| `frontend/src/app/mypage/community/page.tsx` | 커뮤니티 페이지 리팩토링 (탭별 분기 렌더링 적용 등 뷰 로직 집중) |
| `frontend/src/app/mypage/community/useCommunity.ts` | 커뮤니티 데이터 fetching 및 탭 상태 관리용 커스텀 훅 신규 생성 |
| `frontend/src/app/community/components/CommunityCard.tsx` | CommunityCard 컴포넌트 관련 CSS 및 컴포넌트 재사용성 개선 |
| `frontend/src/app/community/components/CommunityCard.module.css` | CommunityCard UI 스타일 조정 |

