### PR TITLE
feat(VO-881): 온라인 세션 링크 접근 기능 구현

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderDetailResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderDetailResponse.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * v6: ticket 정보 필드 추가
+ * v7: 온라인 세션 정보 추가 (구매자에게만 제공)
  */
 @Getter
 @AllArgsConstructor
@@ -28,4 +30,24 @@ public class OrderDetailResponse {
     private String organizer;
     private String location;
     private com.venueon.common.dto.CodeDto eventStatus;
+
+    // 온라인 세션 입장 정보 (구매자 전용, 종료된 세션은 제외)
+    private List<OnlineSessionInfo> onlineSessions;
+
+    /**
+     * 온라인 세션 입장 정보 DTO
+     * - 구매한 티켓에 연결된 온라인 세션의 링크를 제공
+     * - 세션이 종료(endTime 경과)되면 응답에서 제외됨
+     */
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class OnlineSessionInfo {
+        private Long sessionId;
+        private String title;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String onlineLink;
+        private boolean isLive; // 현재 진행 중 여부
+    }
 }

--- a/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/venueon/order/adapter/in/web/dto/OrderSummaryResponse.java
@@ -31,4 +31,5 @@ public class OrderSummaryResponse {
     private int amount; // 단일 금액 (UI 역호환성)
     private String thumbnailUrl; // 이벤트 썸네일 이미지
     private Long categoryId; // 카테고리 ID (프론트에서 라벨 매핑)
+    private boolean hasOnlineSessions; // 온라인 세션 존재 여부 (런타임 계산)
 }

--- a/backend/src/main/java/com/venueon/order/application/service/OrderService.java
+++ b/backend/src/main/java/com/venueon/order/application/service/OrderService.java
@@ -431,6 +431,11 @@ public class OrderService {
                         .orElse(null);
             }
 
+            // 온라인 세션 존재 여부 (런타임 계산, DB 컬럼 아님)
+            final List<com.venueon.event.domain.model.Session> finalTargetSessions = orderEvent != null ? (order.getTicketId() != null ? ticketRepositoryPort.findById(order.getTicketId()).map(this::resolveTicketSessions).orElse(sessionPort.findByEventId(orderEvent.getId())) : sessionPort.findByEventId(orderEvent.getId())) : List.of();
+            boolean hasOnline = finalTargetSessions.stream()
+                    .anyMatch(s -> s.getIsOnline() && s.getOnlineLink() != null && !s.getOnlineLink().isBlank());
+
             return OrderSummaryResponse.builder()
                     .orderId(order.getId())
                     .tossOrderId(order.getTossOrderId())
@@ -449,6 +454,7 @@ public class OrderService {
                     .amount(order.getAmount())
                     .thumbnailUrl(orderEvent != null ? orderEvent.getThumbnailUrl() : null)
                     .categoryId(orderEvent != null ? orderEvent.getCategoryId() : null)
+                    .hasOnlineSessions(hasOnline)
                     .build();
         }).collect(Collectors.toList());
 
@@ -585,11 +591,32 @@ public class OrderService {
         // 티켓 정보 조회
         String ticketName = "-";
         int ticketPrice = 0;
+        List<OrderDetailResponse.OnlineSessionInfo> onlineSessions = List.of();
+
         if (order.getTicketId() != null) {
             Ticket ticket = ticketRepositoryPort.findById(order.getTicketId()).orElse(null);
             if (ticket != null) {
                 ticketName = ticket.getName();
                 ticketPrice = ticket.getPrice();
+
+                // 온라인 세션 정보 조회 (구매자 전용)
+                List<Session> sessions = resolveTicketSessions(ticket);
+                LocalDateTime now = LocalDateTime.now();
+                onlineSessions = sessions.stream()
+                        .filter(Session::getIsOnline)
+                        .filter(s -> s.getOnlineLink() != null && !s.getOnlineLink().isBlank())
+                        // 종료된 세션 제외: endTime이 지난 세션은 응답에 포함하지 않음
+                        .filter(s -> s.getEndTime() == null || !now.isAfter(s.getEndTime()))
+                        .map(s -> OrderDetailResponse.OnlineSessionInfo.builder()
+                                .sessionId(s.getId())
+                                .title(s.getTitle())
+                                .startTime(s.getStartTime())
+                                .endTime(s.getEndTime())
+                                .onlineLink(s.getOnlineLink())
+                                .isLive(s.getStartTime() != null && s.getEndTime() != null
+                                        && now.isAfter(s.getStartTime()) && now.isBefore(s.getEndTime()))
+                                .build())
+                        .toList();
             }
         }
 
@@ -608,6 +635,7 @@ public class OrderService {
                 .organizer(organizer)
                 .location(location)
                 .eventStatus(event != null && event.getStatus() != null ? com.venueon.common.dto.CodeDto.of(event.getStatus().id(), event.getStatus().label()) : com.venueon.common.dto.CodeDto.of(com.venueon.common.model.CodeConstants.EVENT_STATUS_DRAFT_ID, "임시저장"))
+                .onlineSessions(onlineSessions)
                 .build();
     }
 

--- a/frontend/src/app/host/events/[id]/_components/EventForm/EventForm.module.css
+++ b/frontend/src/app/host/events/[id]/_components/EventForm/EventForm.module.css
@@ -82,16 +82,21 @@
 .previewWrapper {
   position: relative;
   width: 100%;
-  height: 300px;
+  min-height: 300px;
+  background-color: #f8f9fa;
   border: 1px solid var(--color-text-gray-300);
   border-radius: var(--radius-md);
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .previewImage {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
+  max-height: 800px;
+  object-fit: contain;
 }
 
 .uploadingOverlay {

--- a/frontend/src/app/host/events/[id]/_components/EventForm/EventForm.tsx
+++ b/frontend/src/app/host/events/[id]/_components/EventForm/EventForm.tsx
@@ -86,6 +86,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
     addressDetail: '',
     regionSido: '',
     regionSigungu: '',
+    onlineLink: initialData?.onlineLink || '',
   });
 
   React.useEffect(() => {
@@ -249,26 +250,32 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       if (hasSession && sessions.length > 0) {
         for (let i = 0; i < sessions.length; i++) {
           const session = sessions[i];
-          // 세션 기간: 날짜+시간을 합쳐서 ISO 형식 생성
+          // 세션 기간: 개별 설정이 없으면 공통 설정(formData)으로 폴백
           let startTime = null;
           let endTime = null;
-          if (session.startDate) {
-            startTime = `${session.startDate}T${session.startTimeOnly || '10:00'}:00`;
+          
+          const sDate = session.startDate || formData.startDate;
+          const sTime = session.startDate ? (session.startTimeOnly || '10:00') : (formData.startTimeOnly || '10:00');
+          if (sDate) {
+            startTime = `${sDate}T${sTime}:00`;
           }
-          if (session.endDate) {
-            endTime = `${session.endDate}T${session.endTimeOnly || '18:00'}:00`;
+          
+          const eDate = session.endDate || formData.endDate;
+          const eTime = session.endDate ? (session.endTimeOnly || '18:00') : (formData.endTimeOnly || '18:00');
+          if (eDate) {
+            endTime = `${eDate}T${eTime}:00`;
           }
 
-          // 모집 기간
+          // 모집 기간: 개별 설정이 없으면 공통 설정(formData)으로 폴백
           let recruitStartDate = null;
           let recruitEndDate = null;
+          
           if (session.useRecruitPeriod) {
-            if (session.recruitStartDate) {
-              recruitStartDate = `${session.recruitStartDate}T00:00:00`;
-            }
-            if (session.recruitEndDate) {
-              recruitEndDate = `${session.recruitEndDate}T23:59:00`;
-            }
+            if (session.recruitStartDate) recruitStartDate = `${session.recruitStartDate}T00:00:00`;
+            if (session.recruitEndDate) recruitEndDate = `${session.recruitEndDate}T23:59:00`;
+          } else if (formData.useRecruitPeriod) {
+            if (formData.recruitStartDate) recruitStartDate = `${formData.recruitStartDate}T00:00:00`;
+            if (formData.recruitEndDate) recruitEndDate = `${formData.recruitEndDate}T23:59:00`;
           }
 
           const sessionPayload = {
@@ -282,7 +289,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
             regionSigungu: session.useCustomAddress ? session.regionSigungu : formData.regionSigungu || '강남구',
             addressRoad: session.useCustomAddress ? session.addressRoad : formData.addressRoad || '',
             addressDetail: session.useCustomAddress ? session.addressDetail : formData.addressDetail || '',
-            isOnline: formData.isOnlineStr === 'true',
+            isOnline: hasSession ? session.isOnline : (formData.isOnlineStr === 'true'),
             onlineLink: session.onlineLink || '',
             maxAttendees: Number(session.maxAttendees) || 0,
             recruitStartDate,
@@ -345,7 +352,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
               addressRoad: formData.addressRoad || '',
               addressDetail: formData.addressDetail || '',
               isOnline: formData.isOnlineStr === 'true',
-              onlineLink: '',
+              onlineLink: formData.isOnlineStr === 'true' ? formData.onlineLink : '',
               maxAttendees: 0,
               recruitStartDate,
               recruitEndDate,
@@ -520,7 +527,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       </div>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>세션 제목</label>
+        <label className={styles.label}>이벤트 제목</label>
         <input
           type="text"
           name="title"
@@ -532,7 +539,7 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
       </div>
 
       <div className={styles.formGroup}>
-        <label className={styles.label}>세션 이미지</label>
+        <label className={styles.label}>이벤트 이미지</label>
         {previewUrl ? (
           <div className={styles.previewWrapper}>
             <img src={previewUrl} alt="미리보기" className={styles.previewImage} />
@@ -576,13 +583,13 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
 
       <div className={styles.formGroup}>
         <div className={styles.labelRow}>
-          <label className={styles.label}>세션 정보</label>
+          <label className={styles.label}>이벤트 요약 정보</label>
           <span className={styles.charCount}>{formData.description.length}/300</span>
         </div>
         <textarea
           name="description"
           className={styles.textarea}
-          placeholder="세션 정보를 입력하세요."
+          placeholder="이벤트 요약 정보를 300자 이내로 간략하게 입력하세요."
           maxLength={300}
           value={formData.description}
           onChange={handleChange}
@@ -630,17 +637,6 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
         </h3>
 
         <div className={styles.grid2}>
-
-          <div className={styles.formGroup} style={{ display: hasSession ? 'block' : 'none' }}>
-            <label className={styles.label}>{hasSession ? '기본 날짜' : '날짜'}</label>
-            <input
-              type="date"
-              name="date"
-              className={styles.dateInput}
-              value={formData.startDate}
-              onChange={(e) => setFormData(prev => ({ ...prev, startDate: e.target.value }))}
-            />
-          </div>
 
           <div className={styles.formGroup}>
             <label className={styles.label}>온라인/오프라인</label>
@@ -717,13 +713,30 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
               value="온라인 진행"
               disabled
             />
+            {!hasSession && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <label className={styles.label}>
+                  온라인 접속 링크
+                  <span style={{ fontWeight: 'normal', color: '#666', fontSize: '0.8rem', marginLeft: '0.5rem' }}>
+                    (구매 완료 고객에게만 공개됩니다)
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  name="onlineLink"
+                  className={styles.standardInput}
+                  placeholder="Zoom, Google Meet 등 접속 링크를 입력해주세요"
+                  value={formData.onlineLink}
+                  onChange={handleChange}
+                />
+              </div>
+            )}
           </div>
         )}
 
-        {/* ── 단일 이벤트 세션 기간 설정 (복합세션과 동일 패턴) ── */}
-        {!hasSession && (
-          <div style={{ marginTop: '2rem', paddingTop: '2rem', borderTop: '1px solid #ddd' }}>
-            <div style={{ fontSize: '0.85rem', fontWeight: '700', color: '#333', marginBottom: '0.75rem' }}>📅 이벤트 기간 <span style={{ fontWeight: 'normal', color: '#999', fontSize: '0.75rem' }}>미설정 시 호스트가 수동으로 시작/종료 관리</span></div>
+        {/* ── 공통 날짜/기간 설정 ── */}
+        <div style={{ marginTop: '2rem', paddingTop: '2rem', borderTop: '1px solid #ddd' }}>
+          <div style={{ fontSize: '0.85rem', fontWeight: '700', color: '#333', marginBottom: '0.75rem' }}>📅 {hasSession ? '공통 이벤트 기간' : '이벤트 기간'} <span style={{ fontWeight: 'normal', color: '#999', fontSize: '0.75rem' }}>미설정 시 개별 세션에서 설정하거나 수동으로 시작/종료 관리</span></div>
             <div style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(2, 1fr)', marginBottom: '1.5rem', background: '#fff', padding: '1rem', borderRadius: '4px', border: '1px solid #e5e5e5' }}>
               <div>
                 <label style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#555' }}>시작 날짜</label>
@@ -810,7 +823,6 @@ export default function EventForm({ mode = 'create', eventId, initialData }: Eve
               </div>
             )}
           </div>
-        )}
 
       </div>
 

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -78,14 +78,18 @@ export default function MyPage() {
                   price={lecture.price}
                   onCardClick={() => router.push(`/events/${lecture.eventId}`)}
                   actionButtonText={
-                    canWriteReview(lecture.eventId) 
-                      ? '리뷰 작성하기' 
-                      : activeTab === 'enrolled' 
-                        ? '입장하기' 
-                        : '상세 보기'
+                    lecture.hasOnlineSessions 
+                      ? '온라인 입장'
+                      : canWriteReview(lecture.eventId) 
+                        ? '리뷰 작성하기' 
+                        : activeTab === 'enrolled' 
+                          ? '입장하기' 
+                          : '상세 보기'
                   }
                   onActionClick={() => {
-                    if (canWriteReview(lecture.eventId)) {
+                    if (lecture.hasOnlineSessions) {
+                      router.push(`/mypage/orders/${lecture.orderId}`);
+                    } else if (canWriteReview(lecture.eventId)) {
                       openReviewModal(lecture.eventId, lecture.title);
                     } else {
                       router.push(`/events/${lecture.eventId}`);

--- a/frontend/src/app/mypage/events/useEvents.ts
+++ b/frontend/src/app/mypage/events/useEvents.ts
@@ -11,6 +11,7 @@ export interface LectureItem {
   eventId: number;
   thumbnailUrl?: string;
   categoryId?: number;
+  hasOnlineSessions: boolean;
 }
 
 const ITEMS_PER_PAGE = 8; // 2열 × 4줄
@@ -57,6 +58,7 @@ export function useEvents() {
           price: item.amount,
           thumbnailUrl: item.thumbnailUrl || undefined,
           categoryId: item.categoryId || undefined,
+          hasOnlineSessions: item.hasOnlineSessions || false,
         }));
         setLectures(mappedLectures);
         setTotalPages(data.totalPages || 1);

--- a/frontend/src/app/mypage/orders/[id]/_components/OnlineSessionCard.module.css
+++ b/frontend/src/app/mypage/orders/[id]/_components/OnlineSessionCard.module.css
@@ -1,0 +1,70 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  padding: var(--space-16);
+  border: 1px solid var(--color-gray-disabled-fill);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-secondary, #fafafa);
+  margin-bottom: var(--space-12);
+}
+
+.card:last-child {
+  margin-bottom: 0;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font: var(--text-h3-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.time {
+  font: var(--text-body-regular);
+  color: var(--color-text-gray-500);
+  margin: 0;
+}
+
+.liveBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-error-light, #fee2e2);
+  color: var(--color-error, #ef4444);
+  font: var(--text-small-bold);
+  font-size: 11px;
+}
+
+.pulse {
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-error, #ef4444);
+  border-radius: 50%;
+  animation: pulse-animation 1.5s infinite;
+}
+
+@keyframes pulse-animation {
+  0% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-8);
+  margin-top: var(--space-8);
+}

--- a/frontend/src/app/mypage/orders/[id]/_components/OnlineSessionCard.tsx
+++ b/frontend/src/app/mypage/orders/[id]/_components/OnlineSessionCard.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React from 'react';
+import { Button, Toast } from '@/components/ui';
+import styles from './OnlineSessionCard.module.css';
+import { OnlineSessionInfo } from '../useOrderDetail';
+import { useUIStore } from '@/store/useUIStore';
+
+interface Props {
+  session: OnlineSessionInfo;
+}
+
+export function OnlineSessionCard({ session }: Props) {
+  const { showToast } = useUIStore();
+
+  const formatDate = (dateString: string) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleString('ko-KR', {
+      month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit'
+    });
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(session.onlineLink).then(() => {
+      showToast('링크 복사', 'success', '온라인 접속 링크가 클립보드에 복사되었습니다.');
+    }).catch(() => {
+      showToast('오류', 'error', '링크 복사에 실패했습니다.');
+    });
+  };
+
+  const handleEnterSession = () => {
+    window.open(session.onlineLink, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.header}>
+        <h3 className={styles.title}>{session.title}</h3>
+        {session.isLive && (
+          <div className={styles.liveBadge}>
+            <span className={styles.pulse}></span>
+            LIVE
+          </div>
+        )}
+      </div>
+      <div>
+        <p className={styles.time}>
+          {formatDate(session.startTime)} ~ {formatDate(session.endTime)}
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <Button variant="primary" onClick={handleEnterSession}>
+          입장하기
+        </Button>
+        <Button variant="secondary" onClick={handleCopyLink}>
+          링크 복사
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/mypage/orders/[id]/page.tsx
+++ b/frontend/src/app/mypage/orders/[id]/page.tsx
@@ -1,84 +1,23 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import React from 'react';
 import Sidebar from '@/components/layout/Sidebar';
-import { Button, StatusTag, Toast } from '@/components/ui';
+import { Button, StatusTag } from '@/components/ui';
 import RefundModal from '../components/RefundModal';
 import mypageStyles from '../../page.module.css';
 import styles from './page.module.css';
-import { useUIStore } from '@/store/useUIStore';
-
-// 백엔드 API 응답 타입 (OrderController.OrderDetailResponse)
-interface OrderDetailResponse {
-  orderId: number;
-  eventId: number;
-  eventTitle: string;
-  ticketName: string;
-  ticketPrice: number;
-  status: string;
-  quantity: number;
-  amount: number;
-  paymentMethod: string;
-  orderedAt: string;
-  paidAt: string | null;
-}
+import { useOrderDetail } from './useOrderDetail';
+import { OnlineSessionCard } from './_components/OnlineSessionCard';
 
 export default function OrderDetailPage() {
-  const router = useRouter();
-  const params = useParams();
-  const { showToast } = useUIStore();
-  const orderId = params.id as string;
-
-  const [order, setOrder] = useState<OrderDetailResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
-
-  const fetchOrderDetail = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/orders/${orderId}`);
-      if (res.ok) {
-        const json = await res.json();
-        setOrder(json.data);
-      } else {
-        showToast('오류', 'error', '결제 상세 내역을 불러오는데 실패했습니다.');
-        router.push('/mypage/orders');
-      }
-    } catch (err) {
-      console.error(err);
-      showToast('오류', 'error', '오류가 발생했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, [orderId, router]);
-
-  useEffect(() => {
-    fetchOrderDetail();
-  }, [fetchOrderDetail]);
-
-  const submitRefund = async (reason: string) => {
-    try {
-      const res = await fetch(`/api/orders/${orderId}/refund`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ reason })
-      });
-
-      if (res.ok) {
-        showToast('환불 제출 완료', 'success', '환불 신청이 완료되었습니다.');
-        setIsRefundModalOpen(false);
-        fetchOrderDetail(); // 데이터 리프레시
-      } else {
-        const errorData = await res.json();
-        showToast('환불 신청 실패', 'error', errorData.message || '환불 신청 중 오류가 발생했습니다.');
-      }
-    } catch (e) {
-      console.error(e);
-      showToast('통신 오류', 'error', '서버와의 통신에 실패했습니다.');
-    }
-  };
+  const {
+    order,
+    loading,
+    isRefundModalOpen,
+    setIsRefundModalOpen,
+    submitRefund,
+    router
+  } = useOrderDetail();
 
   if (loading) {
     return (
@@ -99,8 +38,6 @@ export default function OrderDetailPage() {
       hour: '2-digit', minute: '2-digit'
     });
   };
-
-  // getStatusTag는 공통 StatusTag를 사용하므로 제거
 
   const canRefund = order.status === 'PAID' || order.status === 'REGISTERED';
 
@@ -147,7 +84,17 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-            {/* 3. 결제 정보 섹션 */}
+            {/* 3. 온라인 세션 정보 섹션 (조건부 노출) */}
+            {order.onlineSessions && order.onlineSessions.length > 0 && (
+              <div className={styles.section}>
+                <h2 className={styles.sectionTitle}>온라인 세션 입장</h2>
+                {order.onlineSessions.map(session => (
+                  <OnlineSessionCard key={session.sessionId} session={session} />
+                ))}
+              </div>
+            )}
+
+            {/* 4. 결제 정보 섹션 */}
             <div className={styles.section}>
               <h2 className={styles.sectionTitle}>결제 정보</h2>
               <div className={styles.row}>

--- a/frontend/src/app/mypage/orders/[id]/useOrderDetail.ts
+++ b/frontend/src/app/mypage/orders/[id]/useOrderDetail.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useUIStore } from '@/store/useUIStore';
+
+export interface OnlineSessionInfo {
+  sessionId: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+  onlineLink: string;
+  isLive: boolean;
+}
+
+export interface OrderDetailResponse {
+  orderId: number;
+  eventId: number;
+  eventTitle: string;
+  ticketName: string;
+  ticketPrice: number;
+  status: string;
+  quantity: number;
+  amount: number;
+  paymentMethod: string;
+  orderedAt: string;
+  paidAt: string | null;
+  organizer: string;
+  location: string;
+  eventStatus: {
+    id: number;
+    label: string;
+  };
+  onlineSessions?: OnlineSessionInfo[];
+}
+
+export function useOrderDetail() {
+  const router = useRouter();
+  const params = useParams();
+  const { showToast } = useUIStore();
+  const orderId = params.id as string;
+
+  const [order, setOrder] = useState<OrderDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
+
+  const fetchOrderDetail = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/orders/${orderId}`);
+      if (res.ok) {
+        const json = await res.json();
+        setOrder(json.data);
+      } else {
+        showToast('오류', 'error', '결제 상세 내역을 불러오는데 실패했습니다.');
+        router.push('/mypage/orders');
+      }
+    } catch (err) {
+      console.error(err);
+      showToast('오류', 'error', '오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orderId, router, showToast]);
+
+  useEffect(() => {
+    fetchOrderDetail();
+  }, [fetchOrderDetail]);
+
+  const submitRefund = async (reason: string) => {
+    try {
+      const res = await fetch(`/api/orders/${orderId}/refund`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ reason })
+      });
+
+      if (res.ok) {
+        showToast('환불 제출 완료', 'success', '환불 신청이 완료되었습니다.');
+        setIsRefundModalOpen(false);
+        fetchOrderDetail(); // 데이터 리프레시
+      } else {
+        const errorData = await res.json();
+        showToast('환불 신청 실패', 'error', errorData.message || '환불 신청 중 오류가 발생했습니다.');
+      }
+    } catch (e) {
+      console.error(e);
+      showToast('통신 오류', 'error', '서버와의 통신에 실패했습니다.');
+    }
+  };
+
+  return {
+    order,
+    loading,
+    isRefundModalOpen,
+    setIsRefundModalOpen,
+    submitRefund,
+    router
+  };
+}


### PR DESCRIPTION
## 📋 개요
티켓 구매자가 온라인 이벤트 세션에 안전하게 접근할 수 있도록 백엔드 API와 프론트엔드 UI를 구현합니다.

## ✅ 변경 사항

### Backend
| 파일 | 변경 내용 |
|------|-----------|
| `OrderDetailResponse.java` | `onlineSessions` 필드 + `OnlineSessionInfo` DTO 추가 |
| `OrderSummaryResponse.java` | `hasOnlineSessions` boolean 플래그 추가 (런타임 계산) |
| `OrderService.java` | 티켓 기반 세션 조회, 온라인/종료 필터링, `isLive` 상태 계산 |

### Frontend - 주문 상세 (`mypage/orders/[id]`)
- `useOrderDetail` 커스텀 훅 생성 (주문 데이터 fetch + 환불 로직 분리)
- `OnlineSessionCard` 컴포넌트 (링크 복사 및 입장 기능)

### Frontend - 내 이벤트 (`mypage/events`)
- `useEvents`에 `hasOnlineSessions` 매핑 추가
- '온라인 입장' 버튼 노출 기준: `location === '온라인'` → `hasOnlineSessions`

### Frontend - 이벤트 생성/수정 폼 (`host/events`)
- 단일 이벤트 온라인 모드에서 **온라인 링크 입력 필드** 추가
- 복합 이벤트 **공통 기간(시작/종료)** 입력 폼 노출
- 세션 페이로드 날짜/모집기간 **폴백(Fallback)** 로직 구현
- 복합 이벤트 `isOnline`을 세션 개별 값 우선 반영
- UI 용어 수정 (세션 제목 → 이벤트 제목 등)
- 이미지 미리보기 원본 비율 유지

## 🔐 보안 정책
- 온라인 링크는 **구매자 본인의 주문 상세 응답에만** 포함
- 종료 시간(endTime) 경과한 세션은 API 응답에서 **자동 제외**

## 🧪 테스트 방법
1. 호스트: 이벤트 생성 시 온라인 세션 → 링크 입력
2. 구매자: 마이페이지 → 내 이벤트 → '온라인 입장' 버튼
3. 주문 상세 페이지에서 온라인 세션 카드 확인