### PR TITLE
fix:배포에러수정 최종

### DIFF
--- a/frontend/src/app/admin/community/_components/CommunityList/CommunityList.tsx
+++ b/frontend/src/app/admin/community/_components/CommunityList/CommunityList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CardGrid } from '@/components/ui';
-import CommunityCard from '@/app/community/_components/CommunityCard';
+import CommunityCard from '../../../../community/_components/CommunityCard/CommunityCard';
 import { format } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import styles from './CommunityList.module.css';


### PR DESCRIPTION
상대경로로 수정했습니다.

근거:
Next.js의 Turbopack을 활용해 빌드(Docker 환경 등)할 때 종종 발생하는 경로 Alias(@/) 해석 버그 또는 폴더 대소문자 캐싱 불일치 문제입니다.

로컬 환경(수동 빌드)에서는 에러 없이 완벽히 넘어가지만, CI/Docker 서버로 파일이 복사(rsync 등)되어 빌드될 때 방금 진행하신 커뮤니티 리팩토링(components -> _components 등) 기록 때문에 해당 컴포넌트 폴더나 index 배럴 파일을 Turbopack이 일시적으로 찾지 못하고 뻗어버리는 현상입니다.

이러한 경우 Next.js 내부의 @/ Alias나 폴더별 

index.ts
를 거치지 않고, 원본 파일의 위치를 상대 경로로 수동 지정해 주는 방식(Bypass) 으로 우회할 수 있습니다. 