### PR TITLE
fix: 카테고리 하드코딩을 API 동적 매핑으로 수정 fix #VO-886

### DIFF
--- a/frontend/src/app/events/page.tsx
+++ b/frontend/src/app/events/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import styles from './page.module.css';
 import { Card, CardGrid, InputField, Tabs, Pagination } from '@/components/ui';
@@ -34,15 +34,31 @@ export default function EventsPage() {
     }
   };
 
+  const [categoryOptions, setCategoryOptions] = useState<{ value: string, label: string }[]>([
+    { value: 'all', label: '전체보기' }
+  ]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch('/api/categories');
+        const resData = await res.json();
+        if (resData.success && resData.data) {
+          const opts = resData.data.map((c: any) => ({
+            value: String(c.id),
+            label: c.name
+          }));
+          setCategoryOptions([{ value: 'all', label: '전체보기' }, ...opts]);
+        }
+      } catch (error) {
+        console.error('Failed to fetch categories:', error);
+      }
+    };
+    fetchCategories();
+  }, []);
+
   // 💡 최적화: 현재 시간은 카드 개수만큼 여러 번 계산할 필요 없이 한 번만 계산합니다.
   const nowTime = new Date().getTime();
-
-  const categoryOptions = [
-    { value: 'all', label: '전체보기' },
-    { value: '1', label: '디자인' },
-    { value: '2', label: '개발' },
-    { value: '3', label: '마케팅' },
-  ];
 
   return (
     <div className="container-full">

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Tabs, Pagination } from '@/components/ui';
@@ -14,14 +14,29 @@ const TAB_OPTIONS = [
   { value: 'completed', label: '종료' },
 ];
 
-const CATEGORY_MAP: Record<number, string> = {
-  1: '디자인',
-  2: '개발',
-  3: '마케팅',
-};
+
 
 export default function MyPage() {
   const router = useRouter();
+  const [categoryMap, setCategoryMap] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch('/api/categories');
+        const resData = await res.json();
+        if (resData.success && resData.data) {
+          const map: Record<number, string> = {};
+          resData.data.forEach((c: any) => { map[c.id] = c.name; });
+          setCategoryMap(map);
+        }
+      } catch (error) {
+        console.error('Failed to fetch categories:', error);
+      }
+    };
+    fetchCategories();
+  }, []);
+
   const {
     activeTab,
     currentPage,
@@ -63,7 +78,7 @@ export default function MyPage() {
                 <Card
                   key={lecture.orderId}
                   variant="landing"
-                  category={lecture.categoryId ? (CATEGORY_MAP[lecture.categoryId] || '기타') : undefined}
+                  category={lecture.categoryId ? (categoryMap[lecture.categoryId] || '기타') : undefined}
                   status={lecture.status}
                   title={lecture.title}
                   imageUrl={lecture.thumbnailUrl ? `/upload/${lecture.thumbnailUrl}` : undefined}

--- a/frontend/src/app/mypage/wishlist/page.tsx
+++ b/frontend/src/app/mypage/wishlist/page.tsx
@@ -1,20 +1,35 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Pagination } from '@/components/ui';
 import styles from './page.module.css';
 import { useWishlist } from './useWishlist';
 
-const CATEGORY_MAP: Record<number, string> = {
-  1: '디자인',
-  2: '개발',
-  3: '마케팅',
-};
+
 
 export default function WishlistPage() {
   const router = useRouter();
+  const [categoryMap, setCategoryMap] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch('/api/categories');
+        const resData = await res.json();
+        if (resData.success && resData.data) {
+          const map: Record<number, string> = {};
+          resData.data.forEach((c: any) => { map[c.id] = c.name; });
+          setCategoryMap(map);
+        }
+      } catch (error) {
+        console.error('Failed to fetch categories:', error);
+      }
+    };
+    fetchCategories();
+  }, []);
+
   const {
     currentPage,
     lectures,
@@ -41,7 +56,7 @@ export default function WishlistPage() {
                   variant="landing"
                   eventId={lecture.id}
                   isWishlistedProp={true}
-                  category={lecture.categoryId ? (CATEGORY_MAP[lecture.categoryId] || '기타') : undefined}
+                  category={lecture.categoryId ? (categoryMap[lecture.categoryId] || '기타') : undefined}
                   status={lecture.status?.label || lecture.status}
                   recruitmentStatus={lecture.recruitmentStatus?.label || lecture.recruitmentStatus}
                   title={lecture.title}


### PR DESCRIPTION
📌 관련 이슈
closes #VO-886

## 📝 작업 내용

### 문제
- 이벤트 목록, 마이페이지 이벤트, 위시리스트 페이지에서 카테고리 이름이 하드코딩(\`디자인\`, \`개발\`, \`마케팅\`)되어 있어, 새 카테고리 추가 시 코드 수정이 필요했습니다.

### 해결
- \`/api/categories\` API를 호출하여 카테고리 데이터를 동적으로 매핑하도록 수정했습니다.

## 🔧 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| \`frontend/src/app/events/page.tsx\` | 카테고리 필터 옵션을 API 응답 기반 동적 생성으로 변경 |
| \`frontend/src/app/mypage/events/page.tsx\` | \`CATEGORY_MAP\` 상수 제거, API 기반 \`categoryMap\` state로 대체 |
| \`frontend/src/app/mypage/wishlist/page.tsx\` | \`CATEGORY_MAP\` 상수 제거, API 기반 \`categoryMap\` state로 대체 |

## ✅ 체크리스트
- [x] 이벤트 목록 페이지 카테고리 필터 정상 동작 확인
- [x] 마이페이지 이벤트 카드 카테고리 표시 확인
- [x] 위시리스트 카드 카테고리 표시 확인
- [x] 카테고리 API 실패 시 fallback(\`기타\`) 처리 확인"