### PR TITLE
fix:내가 참여한 커뮤니티 오류 수정

### DIFF
--- a/backend/src/main/java/com/venueon/community/adapter/out/persistence/CommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/community/adapter/out/persistence/CommunityPersistenceAdapter.java
@@ -71,6 +71,27 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
     }
 
     @Override
+    public Page<Community> findJoinedCommunities(java.util.List<Long> memberCommunityIds, java.util.List<Long> eventIds, Pageable pageable) {
+        if ((memberCommunityIds == null || memberCommunityIds.isEmpty()) && (eventIds == null || eventIds.isEmpty())) {
+            return Page.empty(pageable);
+        }
+        
+        // NULL 방지 (Query에서 IN 절에 빈 리스트/null 전달 시 오류 우려)
+        if (memberCommunityIds == null) memberCommunityIds = new java.util.ArrayList<>();
+        if (eventIds == null) eventIds = new java.util.ArrayList<>();
+        
+        // 만약 둘 다 비어있다면 위에서 걸러짐
+        // memberCommunityIds나 eventIds 중 하나가 비어있으면 쿼리 에러가 날 수 있으므로 최소 1개는 더미 데이터를 넣거나 명시적인 처리가 필요함
+        // 하지만 findJoinedCommunities 쿼리 특성상 둘 다 필수로 필요할 수 있음
+        // 빈 리스트일 때 0L 을 넣어주면 ID 0인 데이터는 없으므로 안전하게 쿼리 가능
+        if (memberCommunityIds.isEmpty()) memberCommunityIds = java.util.List.of(0L);
+        if (eventIds.isEmpty()) eventIds = java.util.List.of(0L);
+
+        return communityJpaRepository.findJoinedCommunities(memberCommunityIds, eventIds, pageable)
+                .map(this::mapToDomain);
+    }
+
+    @Override
     public Optional<Community> findById(Long id) {
         return communityJpaRepository.findById(id).map(this::mapToDomain);
     }

--- a/backend/src/main/java/com/venueon/community/adapter/out/persistence/repository/CommunityJpaRepository.java
+++ b/backend/src/main/java/com/venueon/community/adapter/out/persistence/repository/CommunityJpaRepository.java
@@ -16,4 +16,12 @@ public interface CommunityJpaRepository extends JpaRepository<CommunityJpaEntity
 
     List<CommunityJpaEntity> findByCreatorId(Long creatorId);
     Page<CommunityJpaEntity> findByIdIn(List<Long> ids, Pageable pageable);
+    
+    @org.springframework.data.jpa.repository.Query("SELECT c FROM CommunityJpaEntity c " +
+        "LEFT JOIN c.event e " +
+        "WHERE c.id IN :ids OR e.id IN :eventIds")
+    Page<CommunityJpaEntity> findJoinedCommunities(
+        @org.springframework.data.repository.query.Param("ids") List<Long> ids, 
+        @org.springframework.data.repository.query.Param("eventIds") List<Long> eventIds, 
+        Pageable pageable);
 }

--- a/backend/src/main/java/com/venueon/community/application/port/out/CommunityRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/community/application/port/out/CommunityRepositoryPort.java
@@ -10,5 +10,6 @@ public interface CommunityRepositoryPort {
     Community save(Community community);
     Page<Community> findPublicCommunities(Pageable pageable);
     Page<Community> findByIdIn(java.util.List<Long> ids, Pageable pageable);
+    Page<Community> findJoinedCommunities(java.util.List<Long> memberCommunityIds, java.util.List<Long> eventIds, Pageable pageable);
     Optional<Community> findById(Long id);
 }

--- a/backend/src/main/java/com/venueon/community/application/service/CommunityQueryService.java
+++ b/backend/src/main/java/com/venueon/community/application/service/CommunityQueryService.java
@@ -10,6 +10,8 @@ import com.venueon.user.domain.model.User;
 import com.venueon.member.application.port.out.MemberRepositoryPort;
 import com.venueon.post.application.port.out.PostRepositoryPort;
 import lombok.RequiredArgsConstructor;
+import com.venueon.order.application.port.out.OrderRepositoryPort;
+import com.venueon.badge.application.port.out.BadgeRepositoryPort;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,8 @@ public class CommunityQueryService implements GetCommunityQuery {
     private final MemberRepositoryPort memberRepositoryPort;
     private final CommunityPermissionService communityPermissionService;
     private final PostRepositoryPort postRepositoryPort;
+    private final OrderRepositoryPort orderRepositoryPort;
+    private final BadgeRepositoryPort badgeRepositoryPort;
 
     @Override
     @Transactional(readOnly = true)
@@ -41,8 +45,30 @@ public class CommunityQueryService implements GetCommunityQuery {
         User user = userRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
         
-        java.util.List<Long> joinedIds = memberRepositoryPort.findCommunityIdsByUserId(user.getId());
-        return communityRepositoryPort.findByIdIn(joinedIds, pageable)
+        Long userId = user.getId();
+
+        // 1. 멤버 테이블에서 가입된 커뮤니티 ID들
+        java.util.List<Long> memberCommunityIds = memberRepositoryPort.findCommunityIdsByUserId(userId);
+
+        // 2. 유효 주문(PAID, REGISTERED)이 있는 이벤트 ID들
+        java.util.List<Long> orderEventIds = orderRepositoryPort.findAllValidOrdersByUserId(userId).stream()
+                .map(o -> o.getEventId())
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+
+        // 3. 뱃지를 보유한 이벤트 ID들
+        java.util.List<Long> badgeEventIds = badgeRepositoryPort.findByUserId(userId).stream()
+                .map(b -> b.getEventId())
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+
+        // 합집합용 이벤트 ID 리스트
+        java.util.Set<Long> allEventIds = new java.util.HashSet<>(orderEventIds);
+        allEventIds.addAll(badgeEventIds);
+
+        return communityRepositoryPort.findJoinedCommunities(memberCommunityIds, new java.util.ArrayList<>(allEventIds), pageable)
                 .map(community -> toResponse(community, email));
     }
 


### PR DESCRIPTION
기존 로직은 member 테이블에 사용자가 직접 가입된 데이터만 조회하고 있었습니다. 하지만 우리 서비스의 커뮤니티(HOST_AUTO, BADGE_CREATED 타입)는 이벤트 티켓 구매(주문) 또는 뱃지 획득 시 별도의 가입 절차 없이 권한이 부여되는데, 이 경우 member 테이블에는 데이터가 남지 않아 '참여 목록'에서 누락되는 현상이 있었습니다.

수정 사항

백엔드 쿼리 고도화:
CommunityQueryService에서 참여 목록 조회 시 다음 세 가지 조건을 모두 합산하도록 수정했습니다.
사용자가 직접 가입하거나 매니저인 커뮤니티 (member 테이블) 
사용자가 결제 완료한 이벤트와 연결된 커뮤니티 (order 테이블 기반)
사용자가 수료하여 뱃지를 보유한 이벤트와 연결된 커뮤니티 (badge 테이블 기반)

Repository 확장:
CommunityJpaRepository와 PersistenceAdapter에 커뮤니티 ID와 이벤트 ID를 동시에 고려하여 검색할 수 있는 findJoinedCommunities
 메서드를 추가했습니다.