### PR TITLE
fix: 마이페이지 대시보드 진행/리뷰/배지 통계 및 탭 이동 연동 #VO-887

### DIFF
--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/OrderPersistenceAdapter.java
@@ -160,6 +160,11 @@ public class OrderPersistenceAdapter implements OrderRepositoryPort {
     }
 
     @Override
+    public long countCompletedWithoutReviewByUserId(Long userId) {
+        return orderJpaRepository.countCompletedWithoutReviewByUserId(userId);
+    }
+
+    @Override
     public List<Order> findAllValidOrdersByUserId(Long userId) {
         return orderJpaRepository.findAllValidOrdersByUserId(userId).stream()
                 .map(this::toDomain)

--- a/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
+++ b/backend/src/main/java/com/venueon/order/adapter/out/persistence/repository/OrderJpaRepository.java
@@ -126,6 +126,12 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
            "o.event.status.code = 'ENDED'")
     long countCompletedByUserId(@Param("userId") Long userId);
 
+    @Query("SELECT COUNT(DISTINCT o.event.id) FROM OrderJpaEntity o WHERE o.user.id = :userId AND " +
+           "(o.status = 'PAID' OR o.status = 'REGISTERED') AND " +
+           "o.event.status.code = 'ENDED' AND " +
+           "o.event.id NOT IN (SELECT r.eventId FROM ReviewJpaEntity r WHERE r.reviewerId = :userId)")
+    long countCompletedWithoutReviewByUserId(@Param("userId") Long userId);
+
     @Query("SELECT COUNT(o) FROM OrderJpaEntity o " +
            "JOIN o.event e " +
            "WHERE e.creator.id = :hostId " +

--- a/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
+++ b/backend/src/main/java/com/venueon/order/application/port/out/OrderRepositoryPort.java
@@ -35,6 +35,8 @@ public interface OrderRepositoryPort {
 
     long countCompletedByUserId(Long userId);
 
+    long countCompletedWithoutReviewByUserId(Long userId);
+
     List<Order> findAllValidOrdersByUserId(Long userId);
 
     boolean existsByUserIdAndEventIdAndStatusIn(Long userId, Long eventId, List<OrderStatus> statuses);

--- a/backend/src/main/java/com/venueon/user/application/service/MyPageService.java
+++ b/backend/src/main/java/com/venueon/user/application/service/MyPageService.java
@@ -1,5 +1,6 @@
 package com.venueon.user.application.service;
 
+import com.venueon.badge.application.port.out.BadgeRepositoryPort;
 import com.venueon.common.exception.BusinessException;
 import com.venueon.common.exception.ErrorCode;
 import com.venueon.order.application.port.out.OrderRepositoryPort;
@@ -18,6 +19,7 @@ public class MyPageService implements GetMyPageSummaryUseCase {
 
     private final UserRepositoryPort userRepositoryPort;
     private final OrderRepositoryPort orderRepositoryPort;
+    private final BadgeRepositoryPort badgeRepositoryPort;
 
     @Override
     public MyPageSummaryResponse getSummary(String email) {
@@ -26,15 +28,14 @@ public class MyPageService implements GetMyPageSummaryUseCase {
 
         Long userId = user.getId();
 
-        // 1. 참여 중인 세션 = 진행 중(ONGOING) 이벤트의 유효 주문 수
+        // 1. 참여 중인 이벤트 = 진행 중(ONGOING) 이벤트의 유효 주문 수
         long ongoingCount = orderRepositoryPort.countOngoingByUserId(userId);
 
-        // 2. 리뷰를 기다리는 세션 = 종료(ENDED) 이벤트의 유효 주문 수
-        //    (리뷰 테이블이 아직 없으므로, 종료된 이벤트 전체를 리뷰 대기로 간주)
-        long pendingReviewCount = orderRepositoryPort.countCompletedByUserId(userId);
+        // 2. 리뷰를 기다리는 이벤트 = 종료(ENDED) 이벤트 중 리뷰를 아직 작성하지 않은 이벤트 수
+        long pendingReviewCount = orderRepositoryPort.countCompletedWithoutReviewByUserId(userId);
 
-        // 3. 획득한 뱃지 = 아직 DB 테이블 없음, 0 반환
-        long earnedBadgeCount = 0L;
+        // 3. 획득한 뱃지 수
+        long earnedBadgeCount = badgeRepositoryPort.findByUserId(userId).size();
 
         log.debug("마이페이지 요약 조회: email={}, ongoing={}, pendingReview={}, badges={}",
                 email, ongoingCount, pendingReviewCount, earnedBadgeCount);

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Tabs, Pagination } from '@/components/ui';
@@ -16,7 +16,7 @@ const TAB_OPTIONS = [
 
 
 
-export default function MyPage() {
+function MyPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialTab = searchParams.get('tab') || undefined;
@@ -145,5 +145,13 @@ export default function MyPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function MyPage() {
+  return (
+    <Suspense fallback={<div style={{ padding: '40px', textAlign: 'center', color: '#6B7280' }}>로딩 중...</div>}>
+      <MyPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
 import { Card, CardGrid, Tabs, Pagination } from '@/components/ui';
 import { ReviewModal } from '@/components/modal';
@@ -18,6 +18,8 @@ const TAB_OPTIONS = [
 
 export default function MyPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialTab = searchParams.get('tab') || undefined;
   const [categoryMap, setCategoryMap] = useState<Record<number, string>>({});
 
   useEffect(() => {
@@ -52,7 +54,7 @@ export default function MyPage() {
     openReviewModal,
     closeReviewModal,
     handleReviewSuccess,
-  } = useEvents();
+  } = useEvents(initialTab);
 
   return (
     <div className="container-sidebar">

--- a/frontend/src/app/mypage/events/useEvents.ts
+++ b/frontend/src/app/mypage/events/useEvents.ts
@@ -16,8 +16,15 @@ export interface LectureItem {
 
 const ITEMS_PER_PAGE = 8; // 2열 × 4줄
 
-export function useEvents() {
-  const [activeTab, setActiveTab] = useState('upcoming');
+export function useEvents(initialTab?: string) {
+  const [activeTab, setActiveTab] = useState(initialTab || 'upcoming');
+  
+  useEffect(() => {
+    if (initialTab) {
+      setActiveTab(initialTab);
+    }
+  }, [initialTab]);
+
   const [currentPage, setCurrentPage] = useState(1);
 
   const [lectures, setLectures] = useState<LectureItem[]>([]);

--- a/frontend/src/app/mypage/page.module.css
+++ b/frontend/src/app/mypage/page.module.css
@@ -33,11 +33,11 @@
   border: 1px solid var(--color-text-gray-300);
   background-color: var(--color-bg);
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .summaryBox:hover {
-  border-color: var(--color-primary);
+  background-color: var(--color-surface-hover);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 

--- a/frontend/src/app/mypage/page.module.css
+++ b/frontend/src/app/mypage/page.module.css
@@ -32,6 +32,13 @@
   border-radius: var(--radius-md); /* 8px equivalent or exact var */
   border: 1px solid var(--color-text-gray-300);
   background-color: var(--color-bg);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summaryBox:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .summaryTitle {

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -59,15 +59,15 @@ export default function MyPageDashboard() {
           
           {/* 요약 박스 (3개 가로 배치) */}
           <div className={styles.summaryContainer}>
-            <div className={styles.summaryBox}>
+            <div className={styles.summaryBox} onClick={() => router.push('/mypage/events?tab=enrolled')}>
               <span className={styles.summaryTitle}>참여 중인 이벤트</span>
               <span className={styles.summaryContent}>{summaryData.ongoingCourseCount}개</span>
             </div>
-            <div className={styles.summaryBox}>
+            <div className={styles.summaryBox} onClick={() => router.push('/mypage/events?tab=completed')}>
               <span className={styles.summaryTitle}>리뷰를 기다리는 이벤트</span>
               <span className={styles.summaryContent}>{summaryData.pendingReviewCount}개</span>
             </div>
-            <div className={styles.summaryBox}>
+            <div className={styles.summaryBox} onClick={() => router.push('/mypage/badges')}>
               <span className={styles.summaryTitle}>획득한 배지</span>
               <span className={styles.summaryContent}>{summaryData.earnedBadgeCount}개</span>
             </div>


### PR DESCRIPTION
✔️ 관련 이슈
closes #VO-887

📝 PR 요약
사용자가 마이페이지 대시보드에서 참여 중인 이벤트, 리뷰 대기 중인 이벤트, 획득한 배지 개수를 정확하게 파악하고 해당 영역을 클릭했을 때 관련된 상세 페이지(또는 탭)로 바로 이동할 수 있도록 접근성과 통계 로직을 개선했습니다.

🛠️ 상세 변경 사항
🎨 Frontend
대시보드 요약 박스 UI 개선
사용자에게 클릭 가능함을 명시적으로 알리기 위해 요약 박스 컴포넌트에 cursor: pointer 및 hover 옵션(box-shadow, border-color) 추가
이동(Redirect) 및 파라미터 연동
요약 박스 3개에 클릭 시 router.push() 추가 (경로: /mypage/events?tab=enrolled, /mypage/events?tab=completed, /mypage/badges)
mypage/events/page.tsx 및 useEvents 훅에 URL 쿼리 파라미터(tab)를 파싱하여 초기 활성화 탭을 설정하는 커스텀 훅 로직 연동
⚙️ Backend
리뷰 대기 통계 로직 수정 (OrderJpaRepository, MyPageService)
기존 '종료된 모든 이벤트'를 리뷰 대기로 무조건 계산하던 로직에서 **'종료된 내 이벤트 중 미작성 이벤트'**로 정확히 집계되도록 countCompletedWithoutReviewByUserId JPQL 구현 및 연동
배지 통계 로직 연동
기본값으로 처리되던 배지 획득 카운트를 BadgeRepositoryPort.findByUserId(userId).size()로 가져오도록 변경

1