### PR TITLE
style: 마이페이지 및 커뮤니티 UI 컴포넌트 스타일 개선 #VO-889

### DIFF
--- a/frontend/src/app/_components/HeroSection/HeroSection.module.css
+++ b/frontend/src/app/_components/HeroSection/HeroSection.module.css
@@ -4,6 +4,8 @@
   padding: 60px 0 0 0; /* fixed 헤더(60px)가 위를 가리게 되므로 내용이 가려지지 않도록 패딩 추가 */
   display: flex;
   justify-content: center;
+  border-bottom-left-radius: 32px;
+  border-bottom-right-radius: 32px;
 }
 
 .heroInner {

--- a/frontend/src/app/community/_components/CommunityPostItem/CommunityPostItem.module.css
+++ b/frontend/src/app/community/_components/CommunityPostItem/CommunityPostItem.module.css
@@ -11,15 +11,20 @@
   width: 100%;
   box-sizing: border-box;
 
-  background: var(--color-text-gray-50);  /* #F9FAFB */
+  background: var(--color-bg);
   border-radius: var(--radius-md);        /* 8px */
   cursor: pointer;
   transition: background var(--transition), color var(--transition);
 }
 
+.item:hover {
+  background: var(--color-surface);
+}
+
 /* --------- 선택(selected) 상태 --------- */
 .selected {
-  background: var(--color-text-gray-900); /* #111827 */
+  background: var(--color-surface);
+  border: 1.2px solid var(--color-primary);
 }
 
 /* --------- 타이틀 래퍼 --------- */
@@ -70,7 +75,7 @@
 }
 
 .selected .postType {
-  color: #C7D2FE; /* 선택 시 더 밝은 보라색 */
+  color: var(--color-primary);
 }
 
 /* --------- 제목 --------- */
@@ -89,7 +94,7 @@
 }
 
 .selected .title {
-  color: var(--color-text-white);         /* #FFFFFF */
+  color: var(--color-primary);
 }
 
 /* --------- 하단 메타 행 (프로필 + 날짜) --------- */
@@ -111,5 +116,5 @@
 }
 
 .selected .date {
-  color: var(--color-text-gray-300);      /* #D1D5DB */
+  color: var(--color-text-gray-500); 
 }

--- a/frontend/src/app/mypage/events/page.tsx
+++ b/frontend/src/app/mypage/events/page.tsx
@@ -94,7 +94,7 @@ function MyPageContent() {
                   actionButtonText={
                     lecture.hasOnlineSessions 
                       ? '온라인 입장'
-                      : canWriteReview(lecture.eventId) 
+                      : activeTab === 'completed' && canWriteReview(lecture.eventId) 
                         ? '리뷰 작성하기' 
                         : activeTab === 'enrolled' 
                           ? '입장하기' 
@@ -103,15 +103,15 @@ function MyPageContent() {
                   onActionClick={() => {
                     if (lecture.hasOnlineSessions) {
                       router.push(`/mypage/orders/${lecture.orderId}`);
-                    } else if (canWriteReview(lecture.eventId)) {
+                    } else if (activeTab === 'completed' && canWriteReview(lecture.eventId)) {
                       openReviewModal(lecture.eventId, lecture.title);
                     } else {
                       router.push(`/events/${lecture.eventId}`);
                     }
                   }}
-                  secondaryActionText={activeTab === 'enrolled' ? '리뷰 작성하기' : undefined}
+                  secondaryActionText={activeTab === 'enrolled' && canWriteReview(lecture.eventId) ? '리뷰 작성하기' : undefined}
                   onSecondaryActionClick={() => {
-                    if (activeTab === 'enrolled') {
+                    if (activeTab === 'enrolled' && canWriteReview(lecture.eventId)) {
                       openReviewModal(lecture.eventId, lecture.title);
                     }
                   }}

--- a/frontend/src/app/mypage/events/useEvents.ts
+++ b/frontend/src/app/mypage/events/useEvents.ts
@@ -70,8 +70,8 @@ export function useEvents(initialTab?: string) {
         setLectures(mappedLectures);
         setTotalPages(data.totalPages || 1);
 
-        // 종료 탭일 때 각 이벤트의 리뷰 작성 여부 확인
-        if (tab === 'completed') {
+        // 종료 및 진행 중 탭일 때 각 이벤트의 리뷰 작성 여부 확인
+        if (tab === 'completed' || tab === 'enrolled') {
           const eventIds = [...new Set(mappedLectures.map(l => l.eventId))];
           const reviewed = new Set<number>();
           await Promise.all(
@@ -132,7 +132,7 @@ export function useEvents(initialTab?: string) {
 
   // 리뷰 작성 가능 여부 판단
   const canWriteReview = (eventId: number) => {
-    return activeTab === 'completed' && !reviewedSet.has(eventId);
+    return (activeTab === 'completed' || activeTab === 'enrolled') && !reviewedSet.has(eventId);
   };
 
   const openReviewModal = (eventId: number, title: string) => {

--- a/frontend/src/app/mypage/orders/[id]/page.module.css
+++ b/frontend/src/app/mypage/orders/[id]/page.module.css
@@ -5,7 +5,19 @@
   width: 100%;
 }
 
-.section {
+.sectionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.sectionTitle {
+  font: var(--text-h2-bold);
+  color: var(--color-text-gray-900);
+  margin: 0;
+}
+
+.sectionCard {
   display: flex;
   flex-direction: column;
   gap: var(--space-16);
@@ -13,14 +25,6 @@
   border-radius: var(--radius-md);
   padding: var(--space-24);
   background-color: var(--color-bg);
-}
-
-.sectionTitle {
-  font: var(--text-h2-bold);
-  color: var(--color-text-gray-900);
-  margin: 0 0 var(--space-8) 0;
-  border-bottom: 1px solid var(--color-gray-disabled-fill);
-  padding-bottom: var(--space-12);
 }
 
 .row {

--- a/frontend/src/app/mypage/orders/[id]/page.tsx
+++ b/frontend/src/app/mypage/orders/[id]/page.tsx
@@ -53,71 +53,79 @@ export default function OrderDetailPage() {
 
           <div className={styles.detailContainer}>
             {/* 1. 주문 정보 섹션 */}
-            <div className={styles.section}>
+            <div className={styles.sectionGroup}>
               <h2 className={styles.sectionTitle}>주문 정보</h2>
-              <div className={styles.row}>
-                <span className={styles.label}>주문 번호</span>
-                <span className={styles.value}>{order.orderId}</span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>주문 일시</span>
-                <span className={styles.value}>{formatDate(order.orderedAt)}</span>
+              <div className={styles.sectionCard}>
+                <div className={styles.row}>
+                  <span className={styles.label}>주문 번호</span>
+                  <span className={styles.value}>{order.orderId}</span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>주문 일시</span>
+                  <span className={styles.value}>{formatDate(order.orderedAt)}</span>
+                </div>
               </div>
             </div>
 
             {/* 2. 상품 정보 섹션 */}
-            <div className={styles.section}>
+            <div className={styles.sectionGroup}>
               <h2 className={styles.sectionTitle}>상품 정보</h2>
-              <div className={styles.row}>
-                <span className={styles.label}>행사명</span>
-                <span className={styles.value}>{order.eventTitle}</span>
-              </div>
-              {order.ticketName && (
+              <div className={styles.sectionCard}>
                 <div className={styles.row}>
-                  <span className={styles.label}>티켓</span>
-                  <span className={styles.value}>{order.ticketName}</span>
+                  <span className={styles.label}>행사명</span>
+                  <span className={styles.value}>{order.eventTitle}</span>
                 </div>
-              )}
-              <div className={styles.row}>
-                <span className={styles.label}>참가 인원(수량)</span>
-                <span className={styles.value}>{order.quantity}명</span>
+                {order.ticketName && (
+                  <div className={styles.row}>
+                    <span className={styles.label}>티켓</span>
+                    <span className={styles.value}>{order.ticketName}</span>
+                  </div>
+                )}
+                <div className={styles.row}>
+                  <span className={styles.label}>참가 인원(수량)</span>
+                  <span className={styles.value}>{order.quantity}명</span>
+                </div>
               </div>
             </div>
 
             {/* 3. 온라인 세션 정보 섹션 (조건부 노출) */}
             {order.onlineSessions && order.onlineSessions.length > 0 && (
-              <div className={styles.section}>
+              <div className={styles.sectionGroup}>
                 <h2 className={styles.sectionTitle}>온라인 세션 입장</h2>
-                {order.onlineSessions.map(session => (
-                  <OnlineSessionCard key={session.sessionId} session={session} />
-                ))}
+                <div className={styles.sectionCard}>
+                  {order.onlineSessions.map(session => (
+                    <OnlineSessionCard key={session.sessionId} session={session} />
+                  ))}
+                </div>
               </div>
             )}
 
             {/* 4. 결제 정보 섹션 */}
-            <div className={styles.section}>
+            <div className={styles.sectionGroup}>
               <h2 className={styles.sectionTitle}>결제 정보</h2>
-              <div className={styles.row}>
-                <span className={styles.label}>결제 수단</span>
-                <span className={styles.value}>{order.paymentMethod}</span>
-              </div>
-              <div className={styles.row}>
-                <span className={styles.label}>결제 일시</span>
-                <span className={styles.value}>{formatDate(order.paidAt || '')}</span>
-              </div>
-              <div className={`${styles.row} ${styles.totalRow}`}>
-                <span className={styles.label}>총 결제 금액</span>
-                <span className={styles.totalValue}>{formatCurrency(order.amount)}</span>
+              <div className={styles.sectionCard}>
+                <div className={styles.row}>
+                  <span className={styles.label}>결제 수단</span>
+                  <span className={styles.value}>{order.paymentMethod}</span>
+                </div>
+                <div className={styles.row}>
+                  <span className={styles.label}>결제 일시</span>
+                  <span className={styles.value}>{formatDate(order.paidAt || '')}</span>
+                </div>
+                <div className={`${styles.row} ${styles.totalRow}`}>
+                  <span className={styles.label}>총 결제 금액</span>
+                  <span className={styles.totalValue}>{formatCurrency(order.amount)}</span>
+                </div>
               </div>
             </div>
 
             {/* 액션 버튼 */}
             <div className={styles.actionArea}>
-              <Button variant="primary" onClick={() => router.push('/mypage/orders')}>
+              <Button size="large" variant="primary" onClick={() => router.push('/mypage/orders')} style={{ width: '120px' }}>
                 목록으로
               </Button>
               {canRefund && (
-                <Button variant="danger" onClick={() => setIsRefundModalOpen(true)}>
+                <Button size="large" variant="danger" onClick={() => setIsRefundModalOpen(true)} style={{ width: '120px' }}>
                   환불 신청
                 </Button>
               )}

--- a/frontend/src/app/mypage/page.module.css
+++ b/frontend/src/app/mypage/page.module.css
@@ -37,7 +37,7 @@
 }
 
 .summaryBox:hover {
-  background-color: var(--color-surface-hover);
+  background-color: var(--color-text-gray-50);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 

--- a/frontend/src/app/mypage/profile/page.module.css
+++ b/frontend/src/app/mypage/profile/page.module.css
@@ -125,39 +125,7 @@
   margin: 0;
 }
 
-.categoryPills {
-  display: flex;
-  flex-flow: row wrap;
-  gap: var(--space-12);
-}
 
-.categoryPill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-8) var(--space-16);
-  border-radius: var(--radius-full);
-  border: 1px solid var(--color-text-gray-300);
-  background: transparent;
-  color: var(--color-text-gray-700);
-  font: var(--text-body-medium);
-  cursor: pointer;
-  transition: all var(--transition);
-}
-
-.categoryPill:hover {
-  background: var(--color-surface);
-}
-
-.categoryPillActive {
-  background: var(--color-primary);
-  color: var(--color-text-white);
-  border-color: var(--color-primary);
-}
-
-.categoryPillActive:hover {
-  background: var(--color-primary-hover);
-}
 
 /* ── Mobile Responsive (Max 768px) ── */
 @media (max-width: 768px) {

--- a/frontend/src/app/mypage/profile/page.tsx
+++ b/frontend/src/app/mypage/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Sidebar from '@/components/layout/Sidebar';
-import { Button, InputField, UserProfile, Toggle } from '@/components/ui';
+import { Button, InputField, UserProfile, Toggle, Tabs } from '@/components/ui';
 import UploadModal from '@/components/modal/UploadModal';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import styles from './page.module.css';
@@ -90,18 +90,12 @@ export default function ProfileSettingsPage() {
               <h1 className={styles.pageTitle}>관심 카테고리 설정</h1>
               <p className={styles.subtitle}>관심있는 카테고리를 선택해주세요. 맞춤 이벤트를 추천해 드립니다.</p>
             </div>
-            <div className={styles.categoryPills}>
-              {availableCategories.map(cat => (
-                <button
-                  key={cat.id}
-                  type="button"
-                  className={`${styles.categoryPill} ${categories.includes(cat.name) ? styles.categoryPillActive : ''}`}
-                  onClick={() => toggleCategory(cat.name)}
-                >
-                  {cat.name}
-                </button>
-              ))}
-            </div>
+            <Tabs
+              variant="pill"
+              options={availableCategories.map(cat => ({ value: cat.name, label: cat.name }))}
+              activeValues={categories}
+              onChange={toggleCategory}
+            />
           </div>
 
           <div className={styles.rowSectionBlock}>

--- a/frontend/src/components/modal/ContactDetailModal.module.css
+++ b/frontend/src/components/modal/ContactDetailModal.module.css
@@ -95,7 +95,7 @@
   flex-direction: column;
   gap: var(--space-8);
   padding: var(--space-16);
-  background: var(--color-surface);
+  background: var(--color-text-gray-50);
   border-radius: var(--radius-md);
 }
 

--- a/frontend/src/components/ui/Tabs.module.css
+++ b/frontend/src/components/ui/Tabs.module.css
@@ -13,7 +13,7 @@
 }
 
 .variantPill {
-  gap: var(--space-8);
+  gap: var(--space-12);
   flex-wrap: wrap;
 }
 
@@ -52,18 +52,24 @@
 
 /* --------- Pill Variant --------- */
 .pillTab {
-  padding: var(--space-12) var(--space-24);
-  min-height: 48px;
-  background: var(--color-surface); /* #F3F4F6 (Gray/100) */
+  padding: var(--space-8) var(--space-16);
   border-radius: var(--radius-full);
-  /* Body/Medium */
+  border: 1px solid var(--color-text-gray-300);
+  background: transparent;
+  color: var(--color-text-gray-700);
   font: var(--text-body-medium);
-  /* 150% */
-  color: var(--color-text-gray-500); /* #6B7280 */
+}
+
+.pillTab:hover {
+  background: var(--color-surface);
 }
 
 .pillTabActive {
-  background: var(--color-secondary); /* #4B5563 (Brand/secondary) */
-  /* Body/Bold */
-  color: var(--color-text-white); /* #FFFFFF */
+  background: var(--color-primary);
+  color: var(--color-text-white);
+  border-color: var(--color-primary);
+}
+
+.pillTabActive:hover {
+  background: var(--color-primary-hover);
 }

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -13,8 +13,10 @@ export interface TabsProps {
   variant?: 'line' | 'pill';
   /** 출력할 탭 데이터 목록 */
   options: TabOption[];
-  /** 현재 선택된 탭의 value */
-  activeValue: string;
+  /** 현재 선택된 탭의 value (단일 선택 시) */
+  activeValue?: string;
+  /** 선택된 탭들의 value 배열 (다중 선택 시) */
+  activeValues?: string[];
   /** 탭 변경 시 호출될 콜백 함수 */
   onChange: (value: string) => void;
   className?: string;
@@ -24,6 +26,7 @@ export default function Tabs({
   variant = 'line',
   options,
   activeValue,
+  activeValues,
   onChange,
   className = ''
 }: TabsProps) {
@@ -32,7 +35,9 @@ export default function Tabs({
   return (
     <div className={`${styles.container} ${containerClass} ${className}`.trim()} role="tablist">
       {options.map((option) => {
-        const isActive = option.value === activeValue;
+        const isActive = activeValues 
+          ? activeValues.includes(option.value)
+          : option.value === activeValue;
         
         let tabClass = styles.tabButton;
         if (variant === 'line') {
@@ -47,7 +52,13 @@ export default function Tabs({
             role="tab"
             aria-selected={isActive}
             className={tabClass.trim()}
-            onClick={() => onChange(isActive ? '' : option.value)}
+            onClick={() => {
+              if (activeValues) {
+                onChange(option.value);
+              } else {
+                onChange(isActive ? '' : option.value);
+              }
+            }}
           >
             {option.label}
           </button>


### PR DESCRIPTION
closes  #VO-889

📝 PR 설명
마이페이지(프로필, 주문 내역 등)와 커뮤니티, 그리고 모달 디자인의 디테일한 스타일을 개선하여 사용자 경험(UX)과 UI 일관성을 높였습니다.

🛠️ 주요 변경 사항
1. 마이페이지 공통 레이아웃 및 디테일 개선

HeroSection: 하단에 부드러운 라운딩(border-radius: 32px) 디자인 적용
공통 탭 (Pill Tabs): 알약(pill) 형태의 탭 컴포넌트 재사용성 확보 및 스타일링
관심 카테고리 설정 (Profile): 기존 하드코딩된 자체 컴포넌트 방식을 공통 Pill Tabs를 사용하도록 통합 및 개선
2. 참여 내역 (Events) 로직 및 UI 개선

참여 내역의 '진행 중' 탭에서 리뷰 작성 여부를 체크하는 로직 추가
리뷰 작성 전에는 [리뷰 작성하기], [입장하기] 버튼이 모두 보이고, 리뷰 작성 후에는 [입장하기] 버튼만 노출되도록 반영
3. 주문 내역 상세 (Orders) 카드 UI 적용

타이틀 및 데이터가 단순 나열된 기존 구조를 시각적 구분이 쉬운 카드 형태로 감싸도록 개편
하단 Action 버튼 길이를 large button (120px) 규격으로 규격화하여 조화롭게 수정
4. 1:1 문의 (Contact) 상세 모달

관리자가 거절/답변 시 보이는 '관리자 코멘트 영역' 배경색을 일반 Surface 색상에서 gray-50 톤으로 변경해 상단 사용자 정보 패널과 어우러지게 조정
5. 커뮤니티 게시글 아이템 (PostItem) Hover / Selected 액션

기본(Unselected) 배경은 깔끔한 흰색(White)으로 설정하고 Hover 시 부드러운 Surface 컬러로 전환
선택(Selected)된 게시글은 Surface 배경과 함께 Primary 색상(보라색/Navy)의 테두리(stroke)를 두어 눈에 잘 띄게 강조